### PR TITLE
add close method for file transport so that logger calls it when removing a transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -157,7 +157,25 @@ File.prototype.open = function (callback) {
   // Otherwise we have a valid (and ready) stream.
   //
   callback();
+
 };
+
+
+File.prototype.close = function() {
+    var self = this;
+
+    if (self.stream) {
+        self.stream.end();
+        self.stream.destroySoon();
+    }
+
+    self.stream.once('drain', function () {
+        self.emit('flush');
+        self.emit('closed');
+    });
+};
+
+
 
 //
 // ### function flush ()


### PR DESCRIPTION
I noticed the logger object calls a transport's close method when you call `log.remove(transport, options)`.   I added a simple `close` method to the file transport to close the stream. 

My motivation is that I'm doing timed-based file rotation and couldn't figure out a clean way to do what I wanted, so I decided to add and remove file transports on a timeout.  This, however, seems to leave streams open that I don't want.  

I would actually prefer to use the maxsize option on the file transport, but it currently doesn't allow for a lot of flexibility in filenames, which is a feature that I would love to see.  
