### PR TITLE
Fix for max listeners warning in file transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -219,6 +219,7 @@ File.prototype._createStream = function () {
       self._size = size;
       self.filename = target;
       self.stream = fs.createWriteStream(fullname, self.options);
+      self.stream.setMaxListeners(0);
       
       //
       // When the current stream has finished flushing 


### PR DESCRIPTION
In a noisy environment line 124, and others, can quickly run into the default max listener cap.  It seems to also be uselessly spammy on the logged events, but this at least disables the warning that's not helpful in this case.
