### PR TITLE
[minor] Set `Content-Type: application/json` header in webhook transport

### DIFF
--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -77,7 +77,8 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
     host: this.host,
     port: this.port,
     path: this.path,
-    method: this.method
+    method: this.method,
+    headers: { 'Content-Type': 'application/json' }
   };
   
   // Perform HTTP logging request


### PR DESCRIPTION
NT.
