### PR TITLE
[minor] Use regular timestamp in webhook transport

### DIFF
--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -122,7 +122,7 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
   req.write(JSON.stringify({ 
     method: 'log', 
     params: { 
-      timestamp: common.timestamp(), 
+      timestamp: new Date(),
       msg: msg, 
       level: level, 
       meta: meta 


### PR DESCRIPTION
As per our IRC conversation.
