### PR TITLE
Fix a crash when log() is called with an empty meta parameter

### DIFF
--- a/lib/winston/transports/loggly.js
+++ b/lib/winston/transports/loggly.js
@@ -87,7 +87,7 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
   }
 
   var self = this,
-      message = common.clone(meta);
+      message = common.clone(meta || {});
       
   message.level = level;
   message.message = msg;


### PR DESCRIPTION
Fixes https://github.com/indexzero/winston/issues/55
