### PR TITLE
Stop global variable leak in ProfileHandler.done

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -316,6 +316,7 @@ var ProfileHandler = function(logger){
   this.start = Date.now();
 
   this.done = function(msg){
+    var args, callback, meta;
     args     = Array.prototype.slice.call(arguments);
     callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
     meta     = typeof args[args.length - 1] === 'object' ? args.pop() : {};


### PR DESCRIPTION
I was trying to use logger.startTimer() and timer.done() but was getting an error when testing my app with mocha that there were global leaks detected and it was failing the test.

I just added the missing variable declarations in this.done for ProfileHandler.
