### PR TITLE
Updating the syslog log level numerical codes to match the RFC 5424 spec...

### DIFF
--- a/lib/winston/config/syslog-config.js
+++ b/lib/winston/config/syslog-config.js
@@ -9,23 +9,23 @@
 var syslogConfig = exports;
 
 syslogConfig.levels = {
-  debug: 0, 
-  info: 1, 
-  notice: 2, 
-  warning: 3,
-  error: 4, 
-  crit: 5,
-  alert: 6,
-  emerg: 7
+  emerg: 0,
+  alert: 1,
+  crit: 2,
+  error: 3,
+  warning: 4,
+  notice: 5,
+  info: 6,
+  debug: 7
 };
 
 syslogConfig.colors = {
-  debug: 'blue',
-  info: 'green',
-  notice: 'yellow',
-  warning: 'red',
-  error: 'red', 
-  crit: 'red',
+  emerg: 'red',
   alert: 'yellow',
-  emerg: 'red'
+  crit: 'red',
+  error: 'red',
+  warning: 'red',
+  notice: 'yellow',
+  info: 'green',
+  debug: 'blue'
 };


### PR DESCRIPTION
... (http://tools.ietf.org/html/rfc5424)

I had a look at the code and I don't believe the numbers are used? Unless I missed something. But I figured it'd be nice if they matched the RFC 5424 spec.
