### PR TITLE
Add an option addMeta for adding a meta to all logs

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -237,3 +237,23 @@ exports.serialize = function (obj, key) {
   
   return msg;
 };
+
+// ### function extend (obj, ...)
+// #### @obj {Object|literal} Object to be extended
+// Clones and extends a given object with all the properties in passed-in object(s).
+// example: extend({a : 1, b : 2}, {b : 3, c : 4}) --> {a : 1, b : 3, c : 4} 
+
+exports.extend = function(obj) {
+  obj = exports.clone(obj);
+
+  var arg;
+  
+  for (var i = 1, len = arguments.length; i < len; i++) { // i = 1, is not a logic error, we already know the first argument.
+    arg = arguments[i];
+    for (var prop in arg) {
+      obj[prop] = arg[prop];
+    }
+  }
+
+  return obj;
+};

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -26,7 +26,7 @@ var Console = exports.Console = function (options) {
   this.json      = options.json     || false;
   this.colorize  = options.colorize || false;
   this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
-  
+  this.addMeta   = options.addMeta || {};
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
       return JSON.stringify(obj, null, 2);
@@ -62,7 +62,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
     json:      this.json,
     level:     level,
     message:   msg,
-    meta:      meta,
+    meta:      common.extend(this.addMeta, meta),
     stringify: this.stringify,
     timestamp: this.timestamp
   });

--- a/lib/winston/transports/couchdb.js
+++ b/lib/winston/transports/couchdb.js
@@ -28,7 +28,8 @@ var Couchdb = exports.Couchdb = function (options) {
   this.pass   = options.pass;
   this.host   = options.host   || 'localhost';
   this.port   = options.port   || 5984;
-
+  this.addMeta   = options.addMeta || {};
+  
   if (options.auth) {
     //
     // TODO: add http basic auth options for outgoing HTTP requests
@@ -111,7 +112,7 @@ Couchdb.prototype.log = function (level, msg, meta, callback) {
       timestamp: new Date(), // RFC3339/ISO8601 format instead of common.timestamp()
       msg: msg, 
       level: level, 
-      meta: meta 
+      meta: common.extend(this.addMeta, meta) 
     } 
   }));
   

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -54,6 +54,7 @@ var File = exports.File = function (options) {
   this.maxsize   = options.maxsize   || null;
   this.maxFiles  = options.maxFiles  || null;
   this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.addMeta   = options.addMeta || {};
 
   //
   // Internal state variables representing the number
@@ -85,14 +86,15 @@ File.prototype.name = 'file';
 // Core logging method exposed to Winston. Metadata is optional.
 //
 File.prototype.log = function (level, msg, meta, callback) {
+  //console.log(level, msg, meta)
   if (this.silent) {
     return callback(null, true);
   }
-
+  
   var self = this, output = common.log({
     level:     level,
     message:   msg,
-    meta:      meta,
+    meta:      common.extend(this.addMeta, meta),
     json:      this.json,
     colorize:  this.colorize,
     timestamp: this.timestamp

--- a/lib/winston/transports/loggly.js
+++ b/lib/winston/transports/loggly.js
@@ -39,6 +39,7 @@ var Loggly = exports.Loggly = function (options) {
   
   this.name = 'loggly'; 
   this.logBuffer = [];
+  this.addMeta   = options.addMeta || {};
   
   this.client = loggly.createClient({
     subdomain: options.subdomain,
@@ -95,7 +96,7 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
   }
 
   var self = this,
-      message = common.clone(meta || {});
+      message = common.extend(this.addMeta, meta);
       
   message.level = level;
   message.message = msg;

--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -23,12 +23,13 @@ var events = require('events'),
 var Webhook = exports.Webhook = function (options) {
   Transport.call(this, options);
 
-  this.name   = 'webhook'; 
-  this.host   = options.host   || 'localhost';
-  this.port   = options.port   || 8080;
-  this.method = options.method || 'POST';
-  this.path   = options.path   || '/winston-log';
-
+  this.name    = 'webhook'; 
+  this.host    = options.host    || 'localhost';
+  this.port    = options.port    || 8080;
+  this.method  = options.method  || 'POST';
+  this.path    = options.path    || '/winston-log';
+  this.addMeta = options.addMeta || {};
+  
   if (options.auth) {
     this.auth = {};
     this.auth.username = options.auth.username || '';
@@ -125,7 +126,7 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
       timestamp: new Date(),
       msg: msg, 
       level: level, 
-      meta: meta 
+      meta: common.extend(this.addMeta, meta) 
     } 
   }));
   


### PR DESCRIPTION
`addMeta` property will get added to all meta logs. It is useful when all your processes are writing to one file and then you want to add another property in metas to identify them.

To make this possible I added an extend function in common.js inspired by underscore.js.
