### PR TITLE
Add prettyPrint option for files and console which uses util.inspect

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -161,7 +161,7 @@ exports.log = function (options) {
       output += ' ' + meta;
     }
     else if (Object.keys(meta).length > 0) {
-      output += ' ' + exports.serialize(meta);
+      output += ' ' + (options.prettyPrint ? ('\n' + util.inspect(meta, false, null, options.colorize)) : exports.serialize(meta));
     }
   }
 

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -22,10 +22,11 @@ var Console = exports.Console = function (options) {
   Transport.call(this, options);
   options = options || {};
 
-  this.name      = 'console';
-  this.json      = options.json     || false;
-  this.colorize  = options.colorize || false;
-  this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.name        = 'console';
+  this.json        = options.json        || false;
+  this.colorize    = options.colorize    || false;
+  this.prettyPrint = options.prettyPrint || false;
+  this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -56,19 +57,21 @@ Console.prototype.log = function (level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
+<<<<<<< HEAD
 
   var self = this,
       output;
 
   output = common.log({
-    colorize:  this.colorize,
-    json:      this.json,
-    level:     level,
-    message:   msg,
-    meta:      meta,
-    stringify: this.stringify,
-    timestamp: this.timestamp,
-    raw:       this.raw
+    colorize:    this.colorize,
+    json:        this.json,
+    level:       level,
+    message:     msg,
+    meta:        meta,
+    stringify:   this.stringify,
+    timestamp:   this.timestamp,
+    prettyPrint: this.prettyPrint
+    raw:         this.raw
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -57,11 +57,12 @@ var File = exports.File = function (options) {
     throw new Error('Cannot log to file without filename or stream.');
   }
 
-  this.json      = options.json !== false;
-  this.colorize  = options.colorize  || false;
-  this.maxsize   = options.maxsize   || null;
-  this.maxFiles  = options.maxFiles  || null;
-  this.timestamp = options.timestamp != null ? options.timestamp : true;
+  this.json        = options.json !== false;
+  this.colorize    = options.colorize    || false;
+  this.maxsize     = options.maxsize     || null;
+  this.maxFiles    = options.maxFiles    || null;
+  this.prettyPrint = options.prettyPrint || false;
+  this.timestamp   = options.timestamp != null ? options.timestamp : true;
 
   //
   // Internal state variables representing the number
@@ -100,12 +101,13 @@ File.prototype.log = function (level, msg, meta, callback) {
   var self = this;
 
   var output = common.log({
-    level:     level,
-    message:   msg,
-    meta:      meta,
-    json:      this.json,
-    colorize:  this.colorize,
-    timestamp: this.timestamp
+    level:       level,
+    message:     msg,
+    meta:        meta,
+    json:        this.json,
+    colorize:    this.colorize,
+    prettyPrint: this.prettyPrint
+    timestamp:   this.timestamp
   }) + '\n';
 
   this._size += output.length;


### PR DESCRIPTION
When in options, json is set to false, the format that the meta is printed on, is not perfectly easy to read. So I added prettyPrint option. If it is set to true, it will use util.inspect to produce the output, which is human readable and can be colorized. But this will only work if json is set to false.

We can also add another option, like format which accepts a string that can be `json` or `loggly` or `prittyPrinted`. But that will break the existing API.
