### PR TITLE
Adding doc about `timestamp` and `json` options for File Transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The Console transport takes two simple options:
 * __level:__ Level of messages that this transport should log (default 'debug').
 * __silent:__ Boolean flag indicating whether to suppress output (default false).
 * __colorize:__ Boolean flag indicating if we should colorize output (default false).
-* __timestamp:__ Boolean flag indicating if we should prepend output with timestamps (default false).
+* __timestamp:__ Boolean flag indicating if we should prepend output with timestamps (default false). If function is specified, its return value will be used instead of timestamps.
 
 *Metadata:* Logged via util.inspect(meta);
 
@@ -469,7 +469,7 @@ The File transport should really be the 'Stream' transport since it will accept 
 * __level:__ Level of messages that this transport should log.
 * __silent:__ Boolean flag indicating whether to suppress output.
 * __colorize:__ Boolean flag indicating if we should colorize output.
-* __timestamp:__ Boolean flag indicating if we should prepend output with timestamps (default false).
+* __timestamp:__ Boolean flag indicating if we should prepend output with timestamps (default false). If function is specified, its return value will be used instead of timestamps.
 * __filename:__ The filename of the logfile to write output to.
 * __maxsize:__ Max size in bytes of the logfile, if the size is exceeded then a new file is created.
 * __maxFiles:__ Limit the number of files created when the size of the logfile is exceeded.


### PR DESCRIPTION
This might be helpful to someone.
