### PR TITLE
Adding the raw error to the `logException` call.

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -457,7 +457,7 @@ Logger.prototype._uncaughtException = function (err) {
     : this.exitOnError;
   
   function logAndWait(transport, next) {
-    transport.logException('uncaughtException', info, next);
+    transport.logException('uncaughtException', info, next, err);
   }
   
   function gracefulExit() {


### PR DESCRIPTION
Trying to write a custom transport that has separate functionality for logging exceptions but needs the original error.

Adding to the `logException` unless there is a better way to handle this?
