### PR TITLE
Added ability to use multiple color levels

### DIFF
--- a/lib/winston/config.js
+++ b/lib/winston/config.js
@@ -16,7 +16,21 @@ config.addColors = function (colors) {
 };
 
 config.colorize = function (level) {
-  return level[allColors[level]];
+  var colorized = level;
+  if (allColors[level] instanceof Array) {
+    for (var i = 0, l = allColors[level].length; i < l; ++i) {
+      colorized = colorized[allColors[level][i]];
+    }
+  } else if (allColors[level].match(/\s/)) {
+    var colorArr = allColors[level].split(/\s+/);
+    for (var i = 0; i < colorArr.length; ++i) {
+      colorized = colorized[colorArr[i]];
+    }
+    allColors[level] = colorArr;
+  } else {
+    colorized = colorized[allColors[level]];
+  }
+  return colorized;
 };
 
 //


### PR DESCRIPTION
Changed the colorize method to allow for multiple color levels.

Colors allows for bold, inverse, italic, etc; you can mix and match them.

You can now do the following:

``` javascript
var colors = {
  "debug": "blue",
  "error": "red",
  "wereAllGonnaDie!!!!!11!!1one!!": "bold inverse red"
}

// give your colors to winston ...
```
