### PR TITLE
Handle logging of Buffer meta data

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -56,7 +56,7 @@ exports.setLevels = function (target, past, current, isDefault) {
 exports.longestElement = function (xs) {
   return Math.max.apply(
     null,
-    xs.map(function (x) { return x.length })
+    xs.map(function (x) { return x.length; })
   );
 };
 
@@ -80,7 +80,10 @@ exports.clone = function (obj) {
     if (Array.isArray(obj[i])) {
       copy[i] = obj[i].slice(0);
     }
-    else {
+    else if (obj[i] instanceof Buffer) {
+        copy[i] = obj[i].slice(0);
+    }
+    else if (typeof obj[i] != 'function') {
       copy[i] = obj[i] instanceof Object ? exports.clone(obj[i]) : obj[i];
     }
   }
@@ -116,10 +119,15 @@ exports.log = function (options) {
     if (timestamp) {
       output.timestamp = timestamp;
     }
-    
+
     return typeof options.stringify === 'function' 
       ? options.stringify(output)
-      : JSON.stringify(output);
+      : JSON.stringify(output, function(key, value) {
+    	  if (value instanceof Buffer) {
+	        return value.toString('base64');
+	    }
+	    return value;
+      });
   }
 
   output = timestamp ? timestamp + ' - ' : '';
@@ -205,14 +213,18 @@ exports.serialize = function (obj, key) {
   if (typeof obj !== 'object') {
     return key ? key + '=' + obj : obj;
   }
-  
+
+  if (obj instanceof Buffer) {
+    return key ? key + '=' + obj.toString('base64') : obj.toString('base64');
+  }
+
   var msg = '',
       keys = Object.keys(obj),
       length = keys.length;
   
   for (var i = 0; i < length; i++) {
     if (Array.isArray(obj[keys[i]])) {
-      msg += keys[i] + '=['
+      msg += keys[i] + '=[';
       
       for (var j = 0, l = obj[keys[i]].length; j < l; j++) {
         msg += exports.serialize(obj[keys[i]][j]);


### PR DESCRIPTION
Buffer objects were previously stringified in an extremely space consuming format ( they looked like {"0":"124", "1":"0", "2":"36", …, "readUInt32BE": {}, ...}).

This commit serializes buffers as base64 strings.
It also ensures that objects that are serialized do not have their functions serialized as empty objects.
