### PR TITLE
Add stringify support to the file transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -50,6 +50,13 @@ var File = exports.File = function (options) {
   }
     
   this.json      = options.json !== false;
+
+  if (this.json) {
+    this.stringify = options.stringify || function (obj) {
+            return JSON.stringify(obj, null, 2);
+        };
+  }
+
   this.colorize  = options.colorize  || false;
   this.maxsize   = options.maxsize   || null;
   this.maxFiles  = options.maxFiles  || null;
@@ -95,7 +102,8 @@ File.prototype.log = function (level, msg, meta, callback) {
     meta:      meta,
     json:      this.json,
     colorize:  this.colorize,
-    timestamp: this.timestamp
+    timestamp: this.timestamp,
+    stringify: this.stringify
   }) + '\n';
   
   this._size += output.length;


### PR DESCRIPTION
Allow a customised stringify implementation to be provided to the file transport.
- Allows tuning of what JSON data is logged to file (e.g. removing  / renaming fields if present)
- Can transform the JSON to a non-JSON representation in the logfile if necessary.
