### PR TITLE
Unable to Change the  Default Logger Level

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -114,10 +114,27 @@ winston.setLevels = function (target) {
 };
 
 //
+// Define getter / setter for the default logger level
+// which need to be exposed by winston.
+//
+Object.defineProperty(winston, 'level', {
+  get: function () {
+    return defaultLogger.level;
+  },
+  set: function (val) {
+    defaultLogger.level = val;
+
+    Object.keys(defaultLogger.transports).forEach(function(key) {
+      defaultLogger.transports[key].level = val;
+    });
+  }
+});
+
+//
 // Define getters / setters for appropriate properties of the 
 // default logger which need to be exposed by winston.
 //
-['emitErrs', 'exitOnError', 'padLevels', 'level', 'levelLength', 'stripColors'].forEach(function (prop) {
+['emitErrs', 'exitOnError', 'padLevels', levelLength', 'stripColors'].forEach(function (prop) {
   Object.defineProperty(winston, prop, {
     get: function () {
       return defaultLogger[prop];


### PR DESCRIPTION
I have been trying to change the default console logger level and it doesn't seem to be affecting the output (keeps showing `info` level even when set to `warn`).

Here is a simple example:

https://gist.github.com/2003250
