### PR TITLE
Removing the deprecated `util.puts` and `util.error`

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -72,10 +72,9 @@ Console.prototype.log = function (level, msg, meta, callback) {
   });
 
   if (level === 'error' || level === 'debug') {
-    util.error(output);
-  }
-  else {
-    util.puts(output);
+    console.error(output);
+  } else {
+    console.log(output);
   }
 
   //


### PR DESCRIPTION
The `util.error` and `util.puts` are deprecated. Updated to use the `console.error` and `console.log` instead.

Also see https://github.com/joyent/node/pull/2361
