### PR TITLE
Fixing uncaught exception handler on Windows.

### DIFF
--- a/lib/winston/exception.js
+++ b/lib/winston/exception.js
@@ -23,8 +23,8 @@ exception.getAllInfo = function (err) {
 exception.getProcessInfo = function () {
   return {
     pid:         process.pid,
-    uid:         process.getuid(),
-    gid:         process.getgid(),
+    uid:         process.getuid ? process.getuid() : null,
+    gid:         process.getgid ? process.getgid() : null,
     cwd:         process.cwd(),
     execPath:    process.execPath,
     version:     process.version,


### PR DESCRIPTION
The lack of `process.getuid` and `process.getgid` cause it to throw an exception. An exception in the uncaught exception handler is... not good.
