### PR TITLE
Fix logger.add() to properly handle if transport has handleExceptions on.

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -299,7 +299,7 @@ Logger.prototype.add = function (transport, options, created) {
   // If this transport has `handleExceptions` set to `true`
   // and we are not already handling exceptions, do so.
   //
-  if (transport.handleExceptions && !this.catchExceptions) {
+  if (instance.handleExceptions && !this.catchExceptions) {
     this.handleExceptions();
   }
 


### PR DESCRIPTION
Without this fix, the following doesn't work:

winston.add(winston.transports.File, { filename: 'handle-beta-requests.log', handleExceptions: true });
throw new Error('This should get logged!');
