### PR TITLE
fixed padding for lines with longest log level name

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -140,7 +140,7 @@ Logger.prototype.log = function (level, msg) {
 
   // If we should pad for levels, do so
   if (this.padLevels) {
-    msg = new Array(this.levelLength - level.length).join(' ') + msg;
+    msg = new Array(this.levelLength - level.length + 1).join(' ') + msg;
   }
 
   function onError (err) {


### PR DESCRIPTION
Padding for lines with longest log level name was jumping out of the indention so extra padding space is required.
