### PR TITLE
Allow multiple File transports for a logger

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -498,9 +498,14 @@ Logger.prototype.clear = function () {
 Logger.prototype.remove = function (transport) {
   var name = transport.name || transport.prototype.name;
 
+  if (name === 'file') {
+      name = name + transport.filename;
+  }
+
   if (!this.transports[name]) {
     throw new Error('Transport ' + name + ' not attached to this instance');
   }
+
 
   var instance = this.transports[name];
   delete this.transports[name];


### PR DESCRIPTION
Makes it possible to use several File transports for one logger:

```
var logger = new (winston.Logger)({
    transports: [
        new (winston.transports.File) ({ 
            level: 'info',
            filename: 'log/access.log',
            json: true
        }),
        new (winston.transports.File) ({ 
            level: 'error',
            filename: 'log/error.log',
            json: true
        })
    ]
});
```
