### PR TITLE
File: revert f2466178

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -118,10 +118,13 @@ File.prototype.log = function (level, msg, meta, callback) {
     //
     this._stream.write(output);
     this._lazyDrain();
+
+    callback(null, true);
   }
   else {
     this.open(function (err) {
       if (err) {
+        callback(null, true);
         //
         // If there was an error enqueue the message
         //
@@ -130,10 +133,10 @@ File.prototype.log = function (level, msg, meta, callback) {
 
       self._stream.write(output);
       self._lazyDrain();
+
+      callback(null, true);
     });
   }
-
-  callback(null, true);
 };
 
 //


### PR DESCRIPTION
f246617870831003e02edadb8fb4e4a9a918ec96 added different callback handling for File.prototype.log. I'm beginning to think it was a mistake. It originally added the ability for File to take different kinds of streams without making the assumption that the stream would _always_ emit `drain` no matter what (like fs.WriteStream does). The way it was implemented involved executing callbacks stored in a queue and binding to `.once('drain'` over and over, potentially adding a lot of listeners to one EE. People seemed to get along fine without this before. I feel better removing it for now.
