### PR TITLE
Change console transport to write directly to stdout & stderr

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -74,9 +74,9 @@ Console.prototype.log = function (level, msg, meta, callback) {
   });
 
   if (level === 'error' || level === 'debug') {
-    console.error(output);
+    process.stderr.write(output + '\n');
   } else {
-    console.log(output);
+    process.stdout.write(output + '\n');
   }
 
   //


### PR DESCRIPTION
Changed console transport to log directly to stdout & stderr. This allows for overriding console.log|error etc without causing an infinite recursive loop.

Fixes #162
