### PR TITLE
Fix ReferenceError in Logger.unhandleExceptions

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -406,6 +406,7 @@ Logger.prototype.unhandleExceptions = function () {
 
   if (this.catchExceptions) {
     Object.keys(this.exceptionHandlers).forEach(function (name) {
+      var handler = self.exceptionHandlers[name];
       if (handler.close) {
         handler.close();
       }

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -197,4 +197,20 @@ vows.describe('winton/logger').addBatch({
       }
     }
   }
+}).addBatch({
+  "The winston logger": {
+    topic: new (winston.Logger)({
+      exceptionHandlers: [
+        new (winston.transports.Console)(),
+        new (winston.transports.File)({ filename: path.join(__dirname, 'fixtures', 'logs', 'filelog.log' )})
+      ]
+    }),
+    "the unhandleExceptions() method": {
+      "should remove all transports": function (logger) {
+        assert.equal(helpers.size(logger.exceptionHandlers), 2);
+        logger.unhandleExceptions();
+        assert.equal(helpers.size(logger.exceptionHandlers), 0);
+      }
+    }
+  }
 }).export(module);


### PR DESCRIPTION
There was a bug in Logger.unhandleExceptions.  The handler variable used in line 407 was not defined causing winston to throw a ReferenceError.  I added a simple fix and a test case that covers the code in question.  Please review and merge if possible.  Thanks!

ReferenceError: handler is not defined 
      at Logger.unhandleExceptions.exceptionHandlers (/github/winston/lib/winston/logger.js:409:11) 
      at Array.forEach (native) 
      at Logger.unhandleExceptions (/github/winston/lib/winston/logger.js:408:41) 
      at Object.vows.describe.addBatch.addBatch.addBatch.addBatch.addBatch.The winston logger.the unhandleExceptions() method.should remove all transports (/github/winston/test/logger-test.js:211:16) 
      at runTest (/github/winston/node_modules/vows/lib/vows.js:132:26) 
      at EventEmitter.<anonymous> (/github/winston/node_modules/vows/lib/vows.js:78:9) 
      at EventEmitter.emit (events.js:115:20) 
      at EventEmitter.vows.describe.options.Emitter.emit (/github/winston/node_modules/vows/lib/vows.js:237:24) 
      at Suite.runBatch.topic (/github/winston/node_modules/vows/lib/vows/suite.js:168:45) 
      at process.startup.processNextTick.process._tickCallback (node.js:244:9)
