### PR TITLE
Allow for formatting message via string or function

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -154,20 +154,69 @@ exports.log = function (options) {
     });
   }
 
-  output = timestamp ? timestamp + ' - ' : '';
-  output += options.colorize ? config.colorize(options.level) : options.level;
-  output += (': ' + options.message);
+  if (! options.format) {
+      options.format = '';
+      
+      if (options.timestamp) {
+          options.format += '%t - ';
+      }
+      
+      options.format += options.colorize ? config.colorize(options.level) : options.level;
+      
+      options.format += options.prettyPrint ? ': %m %MP' : ': %m %M';
+  }
+  
+  switch (typeof options.format) {              
+      case 'function':
+        output = options.format({
+          meta: meta,
+          timestamp: timestamp || timestampFn(),
+          level: options.level,
+          message: options.message
+        });
+        break;
+              
+      case 'string':
+        output = '';
 
-  if (meta) {
-    if (typeof meta !== 'object') {
-      output += ' ' + meta;
-    }
-    else if (Object.keys(meta).length > 0) {
-      output += ' ' + (options.prettyPrint ? ('\n' + util.inspect(meta, false, null, options.colorize)) : exports.serialize(meta));
-    }
+        options.format.split(' ').forEach(function(flag) {
+            switch (flag) {
+                case '%t':
+                    output += timestamp || timestampFn();
+                    break;
+                    
+                case '%T':
+                    output += options.level;
+                    break;
+                    
+                case '%TC':
+                    output += config.colorize(options.level);
+                    break;
+                    
+                case '%m':
+                    output += options.message;
+                    break;
+                    
+                case '%M':
+                    output += meta ? exports.serialize(meta) : '';
+                    break;
+                    
+                case '%MP':
+                    output += meta ? ('\n' + util.inspect(meta, false, null, options.colorize)) : '';
+                    break;
+                    
+                default:
+                    output += flag;
+            }
+            
+            output += ' ';
+        });  
+        
+        output = output.trim();
+        break;                            
   }
 
-  return output;
+  return output; 
 };
 
 exports.capitalize = function (str) {

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -27,6 +27,7 @@ var Console = exports.Console = function (options) {
   this.colorize    = options.colorize    || false;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.format      = options.format;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -70,7 +71,8 @@ Console.prototype.log = function (level, msg, meta, callback) {
     stringify:   this.stringify,
     timestamp:   this.timestamp,
     prettyPrint: this.prettyPrint,
-    raw:         this.raw
+    raw:         this.raw,
+    format:      this.format
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -63,6 +63,7 @@ var File = exports.File = function (options) {
   this.maxFiles    = options.maxFiles    || null;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
+  this.format      = options.format;
   
   if (this.json) {
     this.stringify = options.stringify;
@@ -112,7 +113,8 @@ File.prototype.log = function (level, msg, meta, callback) {
     colorize:    this.colorize,
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,
-    stringify:   this.stringify
+    stringify:   this.stringify,
+    format:      this.format
   }) + '\n';
 
   this._size += output.length;


### PR DESCRIPTION
Allows you to specify a format string with the following options;

%t timestamp
%T level
%TC level colorized
%m message
%M meta (serialized)
%MP meta (pretty}

Alternatively one could provide a function as the format options and it
will receive an object containing the meta, timestamp, level and message
for the log item.

This should close ticket https://github.com/flatiron/winston/issues/178
