### PR TITLE
Multiple loggers of same type

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -22,7 +22,6 @@ var Console = exports.Console = function (options) {
   Transport.call(this, options);
   options = options || {};
 
-  this.name        = 'console';
   this.json        = options.json        || false;
   this.colorize    = options.colorize    || false;
   this.prettyPrint = options.prettyPrint || false;

--- a/lib/winston/transports/transport.js
+++ b/lib/winston/transports/transport.js
@@ -22,6 +22,7 @@ var Transport = exports.Transport = function (options) {
   this.level            = options.level  || 'info';
   this.silent           = options.silent || false;
   this.raw              = options.raw    || false;
+  this.name             = options.name   || this.name;
 
   this.handleExceptions = options.handleExceptions || false;
 };


### PR DESCRIPTION
Allows for using multiple loggers of the same type, example;

var logger = new winston.Logger({
    transports: [
        new winston.transports.File({ filename: './logs/error.log', name: 'file.error', level: 'error' }),
        new winston.transports.File({ filename: './logs/info.log', name: 'file.info', level: 'info' }),
        new winston.transports.File({ filename: './logs/debug.log', name: 'file.debug', level: 'debug' })
    ]
});

Should close the following issues;

https://github.com/flatiron/winston/issues/167
https://github.com/flatiron/winston/issues/101
