### PR TITLE
Added ability to pass string like objects to the File transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -104,9 +104,13 @@ File.prototype.log = function (level, msg, meta, callback) {
 
   var self = this;
 
+  if (msg && (typeof msg.toString === 'function')) {
+    msg = msg.toString();
+  }
+
   var output = common.log({
     level:       level,
-    message:     msg.toString(),
+    message:     msg,
     meta:        meta,
     json:        this.json,
     colorize:    this.colorize,


### PR DESCRIPTION
Right now when doing:

```
logger.error(new Error('some text...'));
```

The file transport will log an empty message. This commit calls the .toString() method on all messages in case they are not strings.
