### PR TITLE
dirname given, but not filename: _basename->"undefined"

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -38,7 +38,7 @@ var File = exports.File = function (options) {
 
   if (options.filename || options.dirname) {
     throwIf('filename or dirname', 'stream');
-    this._basename = this.filename = path.basename(options.filename) || 'winston.log';
+    this._basename = this.filename = (options.filename ? path.basename(options.filename) : 'winston.log');
     this.dirname   = options.dirname || path.dirname(options.filename);
     this.options   = options.options || { flags: 'a' };
   }


### PR DESCRIPTION
When using the file transport and providing a `dirname`, but no `filename`, winston will log into a file named `undefined`.

This patch makes the filename default to "winston.log", as intended.
