### PR TITLE
Add labels for multiple loggers who share the same transport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,8 @@ Often in larger, more complex applications it is necessary to have multiple logg
   winston.loggers.add('category1', {
     console: {
       level: 'silly',
-      colorize: 'true'
+      colorize: 'true',
+      label: 'category one'
     },
     file: {
       filename: '/path/to/some/file'

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -114,6 +114,7 @@ exports.clone = function (obj) {
 //      meta:      'additional logging metadata to serialize',
 //      colorize:  false, // Colorizes output (only if `.json` is false)
 //      timestamp: true   // Adds a timestamp to the serialized message
+//      label:     'label to prepend the message'
 //    }
 //
 exports.log = function (options) {
@@ -166,7 +167,9 @@ exports.log = function (options) {
 
   output = timestamp ? timestamp + ' - ' : '';
   output += options.colorize ? config.colorize(options.level) : options.level;
-  output += (': ' + options.message);
+  output += ': ';
+  output += options.label ? ('[' + options.label + '] ') : '';
+  output += options.message;
 
   if (meta !== null && meta !== undefined) {
     if (typeof meta !== 'object') {

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -26,6 +26,7 @@ var Console = exports.Console = function (options) {
   this.colorize    = options.colorize    || false;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.label       = options.label       || null;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -69,7 +70,8 @@ Console.prototype.log = function (level, msg, meta, callback) {
     stringify:   this.stringify,
     timestamp:   this.timestamp,
     prettyPrint: this.prettyPrint,
-    raw:         this.raw
+    raw:         this.raw,
+    label:       this.label
   });
 
   if (level === 'error' || level === 'debug') {


### PR DESCRIPTION
I have a library where each sub-module creates its own id'd logger... this allows a consumer to configure logging levels and transports for each sub-module individually just from config.

What I'd like to add is the ability to label each message from a logger so the output is something like:

```
12:12:12 [submodule one] debug: awesome logged message
12:12:12 [submodule two] info: awesome logged message
```

by configuring the logger as follows:

```
winston.loggers.add('category1', {
  console: {
    level: 'silly',
    colorize: 'true',
    label: 'category one'
  }
);
```

This pull request enables the ability to label each logger's output.
