### PR TITLE
Updated File Transport for new 'label' option; what's left?

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -63,7 +63,8 @@ var File = exports.File = function (options) {
   this.maxFiles    = options.maxFiles    || null;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
-  
+  this.label       = options.label       || null;
+
   if (this.json) {
     this.stringify = options.stringify;
   }
@@ -112,7 +113,8 @@ File.prototype.log = function (level, msg, meta, callback) {
     colorize:    this.colorize,
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,
-    stringify:   this.stringify
+    stringify:   this.stringify,
+    label:       this.label
   }) + '\n';
 
   this._size += output.length;


### PR DESCRIPTION
I adapted the File transport to accept and output the new label option.  I looked at the other Transports, but didn't see any other changes; did I miss anything?
