### PR TITLE
sets the correct ssl default port (443) for webhook transports

### DIFF
--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -41,6 +41,7 @@ var Webhook = exports.Webhook = function (options) {
     this.ssl.key  = options.ssl.key  || null;
     this.ssl.cert = options.ssl.cert || null;
     this.ssl.ca   = options.ssl.ca;
+    this.port     = options.port     || 443;
   }
 };
 


### PR DESCRIPTION
an attempt to use the default port set by the webhook transport construtor with the ssl option on, the port will be defaulted to 8080 instead of 443.
