### PR TITLE
Emit a 'logged' event after successfully logging to all transports.

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -208,6 +208,9 @@ Logger.prototype.log = function (level) {
       callback(null, level, msg, meta);
     }
     callback = null;
+    if (!err) {
+        self.emit('logged', level, msg, meta);
+    }
   }
 
   async.forEach(this._names, emit, cb);

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -55,13 +55,25 @@ vows.describe('winton/logger').addBatch({
         assert.throws(function () { logger.add(winston.transports.Console) }, Error);
       },
       "the log() method": {
-        topic: function (logger) {
-          logger.once('logging', this.callback);
-          logger.log('info', 'test message');
+        "when listening for the 'logging' event": {
+            topic: function (logger) {
+              logger.once('logging', this.callback);
+              logger.log('info', 'test message');
+            },
+            "should emit the 'log' event with the appropriate transport": function (transport, ign) {
+              helpers.assertConsole(transport);
+            }
         },
-        "should emit the 'log' event with the appropriate transport": function (transport, ign) {
-          helpers.assertConsole(transport);
-        }
+        "when listening for the 'logged' event": {
+            topic: function (logger) {
+              logger.once('logging', this.callback);
+              logger.log('info', 'test message');
+            },
+            "should emit the 'logged' event": function (level, msg, meta) {
+              assert.equal(level, 'info');
+              assert.equal(msg, 'test message');
+            }
+        },
       },
       "the profile() method": {
         "when passed a callback": {


### PR DESCRIPTION
This should emit a single 'logged' event after all transports have successfully logged.
