### PR TITLE
FileTransport compatibility patch (Node 0.10).

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -40,7 +40,7 @@ var File = exports.File = function (options) {
     throwIf('filename or dirname', 'stream');
     this._basename = this.filename = path.basename(options.filename) || 'winston.log';
     this.dirname   = options.dirname || path.dirname(options.filename);
-    this.options   = options.options || { flags: 'a' };
+    this.options   = options.options || { flags: 'a' , highWaterMark: 24}; // "24 bytes" is maybe a good value for logging lines.
   }
   else if (options.stream) {
     throwIf('stream', 'filename', 'maxsize');


### PR DESCRIPTION
Added 'highWaterMark' property to the options of the WritableStream in order to be compatible with the new streams2 API in Node 0.10.\* (Issue #227).
