### PR TITLE
Null Object Reference error in HTTP Transport.

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -86,16 +86,18 @@ Http.prototype.log = function (level, msg, meta, callback) {
     }
   };
 
-  if (meta.path) {
-    options.path = meta.path;
-    delete meta.path;
-  }
+  if (meta) {
+    if (meta.path) {
+      options.path = meta.path;
+      delete meta.path;
+    }
 
-  if (meta.auth) {
-    options.auth = meta.auth;
-    delete meta.auth;
+    if (meta.auth) {
+      options.auth = meta.auth;
+      delete meta.auth;
+    }
   }
-
+  
   this._request(options, function (err, res, body) {
     if (res && res.statusCode !== 200) {
       err = new Error('HTTP Status Code: ' + res.statusCode);


### PR DESCRIPTION
Meta is an optional param, however if it omitted then we had a null
object reference error. Fixed by doing a null object check before hand.
