### PR TITLE
Support exclusive custom logging levels using negative numbers.

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -169,8 +169,10 @@ Logger.prototype.log = function (level) {
   //
   function emit(name, next) {
     var transport = self.transports[name];
-    if ((transport.level && self.levels[transport.level] <= self.levels[level])
-      || (!transport.level && self.levels[self.level] <= self.levels[level])) {
+      if ((transport.level && ((self.levels[transport.level] >= 0 &&
+          self.levels[transport.level] < self.levels[level])
+          || (self.levels[transport.level] == self.levels[level])))
+          || (!transport.level && self.levels[self.level] <= self.levels[level]) && self.levels[self.level] >= 0) {
       transport.log(level, msg, meta, function (err) {
         if (err) {
           err.transport = transport;


### PR DESCRIPTION
Would like to set up exclusive custom levels so messages are only written to matching transports.  Any other transport with a level < log level are ignored.

```
 //set my custom log levels    
 logger.setLevels({error_only:-3,warn_only:-2,info_only:-1});

 //log only to custom warnings transport, not any other levels <
 logger.log('warn_only','Only write this message to transport configured with     level:warn_only');
```

Basically if a custom level is set with a negative number, the transport level needs to equal the logging level, instead of <= logging level.  Can be mixed with levels >= 0.
