### PR TITLE
String interpolation for helper methods

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -38,29 +38,9 @@ exports.setLevels = function (target, past, current, isDefault) {
   //
   Object.keys(target.levels).forEach(function (level) {
     target[level] = function (msg) {
-      var args = Array.prototype.slice.call(arguments, 1),
-          callback = args.pop(),
-          ltype = typeof callback,
-          meta = args.length ? args : null;
-
-      if (ltype !== 'function') {
-        if (meta && ltype !== 'undefined') {
-          meta.push(callback);
-        }
-
-        callback = null;
-      }
-
-      if (meta) {
-        meta = (meta.length <= 1 && meta.shift()) || meta;
-        return callback
-          ? target.log(level, msg, meta, callback)
-          : target.log(level, msg, meta)
-      }
-
-      return callback
-        ? target.log(level, msg, callback)
-        : target.log(level, msg)
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(level);
+      return target.log.apply(target, args);
     };
   });
 

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -25,6 +25,7 @@ var Console = exports.Console = function (options) {
   this.json        = options.json        || false;
   this.colorize    = options.colorize    || false;
   this.prettyPrint = options.prettyPrint || false;
+  this.meta        = options.meta        || false;
   this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
   this.label       = options.label       || null;
 
@@ -66,7 +67,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
     json:        this.json,
     level:       level,
     message:     msg,
-    meta:        meta,
+    meta:        this.meta ? meta : null,
     stringify:   this.stringify,
     timestamp:   this.timestamp,
     prettyPrint: this.prettyPrint,


### PR DESCRIPTION
This hack allows using string interpolation with helper methods, i.e.

>logger.info('Hello, %s!', name);

instead of

>logger.log('info', 'Hello, %s!', name);