### PR TITLE
Hack for issue #84

### DIFF
--- a/lib/winston/exception.js
+++ b/lib/winston/exception.js
@@ -16,8 +16,8 @@ exception.getAllInfo = function (err) {
     date:    new Date().toString(),
     process: exception.getProcessInfo(),
     os:      exception.getOsInfo(),
-    trace:   exception.getTrace(err),
-    stack:   err.stack && err.stack.split('\n')
+    //trace:   exception.getTrace(err),
+    stack:   err.stack //&& err.stack.split('\n')
   };
 };
 


### PR DESCRIPTION
Simple hack I use to solve the problem described in 84.  I remove 'trace' completely from the meta info (seems to be it's duplicated in err.stack.  I also remove the split('\n') from err.stack, which causes the one line problem.
