### PR TITLE
logger level methods like logger.info(...) behave the same as logger.log('info, ...)

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -38,29 +38,9 @@ exports.setLevels = function (target, past, current, isDefault) {
   //
   Object.keys(target.levels).forEach(function (level) {
     target[level] = function (msg) {
-      var args = Array.prototype.slice.call(arguments, 1),
-          callback = args.pop(),
-          ltype = typeof callback,
-          meta = args.length ? args : null;
-
-      if (ltype !== 'function') {
-        if (meta && ltype !== 'undefined') {
-          meta.push(callback);
-        }
-
-        callback = null;
-      }
-
-      if (meta) {
-        meta = (meta.length <= 1 && meta.shift()) || meta;
-        return callback
-          ? target.log(level, msg, meta, callback)
-          : target.log(level, msg, meta)
-      }
-
-      return callback
-        ? target.log(level, msg, callback)
-        : target.log(level, msg)
+      // build argument list (level, msg, ... [string interpolate], [{metadata}], [callback])
+      var args = [level].concat(Array.prototype.slice.call(arguments));
+      target.log.apply(target, args);
     };
   });
 

--- a/test/logger-levels-test.js
+++ b/test/logger-levels-test.js
@@ -1,0 +1,116 @@
+/*
+ * log-rewriter-test.js: Tests for rewriting metadata in winston.
+ *
+ * (C) 2010 Charlie Robbins
+ * MIT LICENSE
+ *
+ */
+
+var assert = require('assert'),
+    vows = require('vows'),
+    winston = require('../lib/winston'),
+    util = require('util'),
+    helpers = require('./helpers');
+
+vows.describe('winston/logger/levels').addBatch({
+  "The winston logger": {
+    topic: new (winston.Logger)({
+      transports: [
+        new (winston.transports.Console)()
+      ]
+    }),
+    "the info() method": {
+      "when passed metadata": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.info('test message', {foo: 'bar'});
+        },
+        "should have metadata object": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message');
+          assert.deepEqual(meta, {foo: 'bar'});
+        }
+         }
+        },
+      "when passed a string placeholder": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.info('test message %s', 'my string');
+        },
+        "should interpolate": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message my string');
+        },
+      },
+      "when passed a number placeholder": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.info('test message %d', 123);
+        },
+        "should interpolate": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message 123');
+        },
+      },
+      "when passed a json placholder and an empty object": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.info('test message %j', {number: 123}, {});
+        },
+        "should interpolate": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message {"number":123}');
+        },
+      },
+      "when passed a escaped percent sign": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.info('test message %%', {number: 123});
+        },
+        "should not interpolate": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, util.format('test message %%'));
+          assert.deepEqual(meta, {number: 123});          
+        },
+      },
+      "when passed interpolation strings and a meta object": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.info('test message %s, %s', 'first', 'second' ,{number: 123});
+        },
+        "should interpolate and have a meta object": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message first, second');
+          assert.deepEqual(meta, {number: 123});
+        },
+      },
+      "when passed multiple strings and a meta object": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.info('test message', 'first', 'second' , {number: 123});
+        },
+        "should join and have a meta object": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message first second');
+          assert.deepEqual(meta, {number: 123});
+        },
+      },
+      "when passed interpolations strings, meta object and a callback": {
+        topic: function (logger) {
+          var that = this;
+          logger.info('test message %s, %s', 'first', 'second' , {number: 123}, function(transport, level, msg, meta){
+            that.callback(transport, level, msg, meta)
+          });
+        },
+        "should interpolate and have a meta object": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message first, second');
+          assert.deepEqual(meta, {number: 123});
+        },
+      },
+      "when passed multiple strings, a meta object and a callback": {
+        topic: function (logger) {
+          var that = this;
+          logger.info('test message', 'first', 'second' , {number: 123}, function(transport, level, msg, meta){
+            that.callback(transport, level, msg, meta)
+          });
+        },
+        "should join and have a meta object": function (transport, level, msg, meta) {
+          assert.strictEqual(msg, 'test message first second');
+          assert.deepEqual(meta, {number: 123});
+        }    
+      }
+    }
+}).export(module);


### PR DESCRIPTION
Logger level methods like logger.info now support:
- passing metadata

```
logger.info('test message', {foo: 'bar'});
```
- interpolating string args 

```
logger.info('test message %d', 123);
```
- should simply behave as a shortcut for calling logger.log(level, ...)

It appeared that logger level helper methods like logger.info() weren't behaving the same as if I made the underlying logger.log('info', msg, metadata, callback) style call. 

I simplified the common.js setLevels to simply proxy the call to target.log, it was previously attempting to parse out callback and metadata and I first noticed that metadata was not being passed through correctly.

This pull request was initiated based on my question on StackOverflow: http://stackoverflow.com/questions/16349288/winston-js-info-method-not-passing-metadata
