### PR TITLE
Allow debug messages to be sent to stdout

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -27,7 +27,7 @@ var Console = exports.Console = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
   this.label       = options.label       || null;
-  this.debugStderr = options.debugStderr || true
+  this.debugStdout = options.debugStdout || false;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -75,7 +75,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
     label:       this.label
   });
 
-  if (level === 'error' || (level === 'debug' && options.debugStderr) ) {
+  if (level === 'error' || (level === 'debug' && ! this.debugStdout) ) {
     process.stderr.write(output + '\n');
   } else {
     process.stdout.write(output + '\n');


### PR DESCRIPTION
Currently debug messages for console transport always go to stderr.

This change introduces a new option called "debugStdout" which defaults to false (so console is backward compatible). If set to true, debug messages will go to stdout instead of stderr.

Just curious - but why are debug messages going to stderr by default?
