### PR TITLE
Prevent objects from being interpreted as metadata

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -124,7 +124,7 @@ Logger.prototype.log = function (level) {
   var self = this,
       args = Array.prototype.slice.call(arguments, 1),
       callback = typeof args[args.length - 1] === 'function' ? args.pop() : null,
-      meta     = typeof args[args.length - 1] === 'object' ? args.pop() : {},
+      meta     = typeof args[args.length - 1] === 'object' && args.length > 1 ? args.pop() : {},
       msg      = util.format.apply(null, args);
 
   // If we should pad for levels, do so


### PR DESCRIPTION
This will prevent logmessages from being interpreted as metadata.
If a user of winston accidentally inputs a variable pointing to an object as the logmessage,
winston will think the variable is metadata.
ie:
var logMessage = { foo: 'bar' }
log.info(logMessage); // The object of logMessage will be interpreted as metadata and the logmessage will be blank
Console output:
info:  foo=bar

After the patch logMessage will be intepreted as the message
Console output:
info: { foo: 'bar' }
Metadata can still be passed as usual.
