### PR TITLE
[fix] catch exceptions for file transport unlinkSync

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -553,11 +553,15 @@ File.prototype._getFile = function (inc) {
     // Check for maxFiles option and delete file
     if (this.maxFiles && (this._created >= (this.maxFiles - 1))) {
       remaining = this._created - (this.maxFiles - 1);
-      if (remaining === 0) {
-        fs.unlinkSync(path.join(this.dirname, basename + ext));
-      }
-      else {
-        fs.unlinkSync(path.join(this.dirname, basename + remaining + ext));
+      try {
+        if (remaining === 0) {
+          fs.unlinkSync(path.join(this.dirname, basename + ext));
+        }
+        else {
+          fs.unlinkSync(path.join(this.dirname, basename + remaining + ext));
+        }
+      } catch (e) {
+        // If the file was already removed
       }
     }
 


### PR DESCRIPTION
Using cluster, I sometimes run more than one winston logger on a
single instance. Occasionally they both detect that they should
remove the log file, and one will unlink before the other. This
adds a try...catch to make sure that the unlinkSync call doesn't
throw.

I'd be happy to modify the PR to provide some way of notifying the
developer that the unlink failed. I didn't see a good one off the bat,
ordinarily I'd use something like debug().
