### PR TITLE
Reversed the syslog levels to match the npm and cli ascending order

### DIFF
--- a/lib/winston/config/syslog-config.js
+++ b/lib/winston/config/syslog-config.js
@@ -9,14 +9,14 @@
 var syslogConfig = exports;
 
 syslogConfig.levels = {
-  emerg: 0,
-  alert: 1,
-  crit: 2,
-  error: 3,
-  warning: 4,
-  notice: 5,
-  info: 6,
-  debug: 7,
+  debug: 0,
+  info: 1,
+  notice: 2,
+  warning: 3,
+  error: 4,
+  crit: 5,
+  alert: 6,
+  emerg: 7,
 };
 
 syslogConfig.colors = {
@@ -29,3 +29,4 @@ syslogConfig.colors = {
   info: 'green',
   debug: 'blue',
 };
+


### PR DESCRIPTION
Would address issue: https://github.com/flatiron/winston/issues/249

Been running this in production for several weeks with winston-posix-syslog and all is well.
