### PR TITLE
Adding rotationFormat prop to file.js

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -68,6 +68,7 @@ var File = exports.File = function (options) {
   this.json        = options.json !== false;
   this.colorize    = options.colorize    || false;
   this.maxsize     = options.maxsize     || null;
+  this.rotationFormat = options.rotationFormat || false;
   this.maxFiles    = options.maxFiles    || null;
   this.prettyPrint = options.prettyPrint || false;
   this.label       = options.label       || null;
@@ -565,7 +566,7 @@ File.prototype._getFile = function (inc) {
   }
 
   return this._created
-    ? basename + this._created + ext
+    ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
     : basename + ext;
 };
 


### PR DESCRIPTION
The goal of the rotation format property is to allow the user to pass a pointer to a function that will determine the format of the file name in case of a rotating logger (a logger with maxsize that generated files). 

sample usage:
this will make the files created under "log" to be named:
run<yyyyMMddhhmmss>.log

so these would be files created today:

`run20130629190056.log`
`run20130629190057.log`
and so forth...

sample code:

``` js
winston.add(winston.transports.File, { 
  filename: 'log/run.log',   
  maxsize: 150,
  rotationFormat: function() {
    return getFormattedDate();
    function getFormattedDate() {
    var temp = new Date();
    return dateStr = padStr(temp.getFullYear()) +
                  padStr(1 + temp.getMonth()) +
                  padStr(temp.getDate()) +
                  padStr(temp.getHours()) +
                  padStr(temp.getMinutes()) +
                  padStr(temp.getSeconds());    
    }
    function padStr(i) {
        return (i < 10) ? "0" + i : "" + i;
    }
  }
});
```
