### PR TITLE
[fix] Fix the message loss at file open stage

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -501,6 +501,14 @@ File.prototype._createStream = function () {
       self.once('flush', function () {
         self.opening = false;
         self.emit('open', fullname);
+
+        //
+        // If there are messages buffered between flush() and once('flush')
+        // flush them.
+        //
+        if (self._buffer.length > 0) {
+          self.flush();
+        }
       });
 
       //


### PR DESCRIPTION
I had a doubt that there was a bug to cause the loss of message buffered between file.flush() and once('flush'). And I made a fix but I am not sure that this is a correct one. Please check this out.
