### PR TITLE
Allow using logstash option with the File transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ The File transport should really be the 'Stream' transport since it will accept 
 * __maxFiles:__ Limit the number of files created when the size of the logfile is exceeded.
 * __stream:__ The WriteableStream to write output to.
 * __json:__ If true, messages will be logged as JSON (default true).
+* __logstash:__ If true, messages will be logged as JSON and formatted for logstash (default false).
 
 *Metadata:* Logged via util.inspect(meta);
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -132,7 +132,7 @@ exports.log = function (options) {
   //
   // json mode is intended for pretty printing multi-line json to the terminal
   //
-  if (options.json) {
+  if (options.json || true === options.logstash) {
     if (typeof meta !== 'object' && meta != null) {
       meta = { meta: meta };
     }

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -66,6 +66,7 @@ var File = exports.File = function (options) {
   }
 
   this.json        = options.json !== false;
+  this.logstash    = options.logstash    || false;
   this.colorize    = options.colorize    || false;
   this.maxsize     = options.maxsize     || null;
   this.maxFiles    = options.maxFiles    || null;
@@ -122,6 +123,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     message:     msg,
     meta:        meta,
     json:        this.json,
+    logstash:    this.logstash,
     colorize:    this.colorize,
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,


### PR DESCRIPTION
Hello,

I noticed a nice logstash format option by browsing your code, and after reading some PRs I saw you're only using it with another library.
Logging in a file using the logstash format is useful if you use a centralized logstash installation, as we do.

This PR only allows people to add a logstash parameter to format the output, and take advantage of the already written code.

I'm not sure it's useful for the other transports though, so I only added that for the File transport.
