### PR TITLE
Should be possible to pass Error object to logger and have it passed (as an Error) to the transport

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -125,7 +125,13 @@ Logger.prototype.log = function (level) {
       args = Array.prototype.slice.call(arguments, 1),
       callback = typeof args[args.length - 1] === 'function' ? args.pop() : null,
       meta     = typeof args[args.length - 1] === 'object' ? args.pop() : {},
+      error    = args[args.length - 1] instanceof Error ? args.pop() : meta instanceof Error ? meta : null,
       msg      = util.format.apply(null, args);
+
+  // If msg is empty but we have the original Error object, use error.message
+  if ((typeof msg === 'undefined' || msg === null || msg == '') && error) {
+    msg = error.message;
+  }
 
   // If we should pad for levels, do so
   if (this.padLevels) {
@@ -177,9 +183,9 @@ Logger.prototype.log = function (level) {
           cb(err);
           return next();
         }
-        self.emit('logging', transport, level, msg, meta);
+        self.emit('logging', transport, level, msg, meta, error);
         next();
-      });
+      }, error);
     } else {
       next();
     }

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -318,6 +318,59 @@ vows.describe('winton/logger').addBatch({
           assert.strictEqual(msg, 'test message first second');
           assert.deepEqual(meta, {number: 123});
         },
+      },
+      "when passed only Error object": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.error(new Error("this is an error"))
+        },
+        "should have an error object, and msg should be error.message": function (transport, level, msg, meta, error) {
+          assert.strictEqual(msg, "this is an error");
+          assert.equal(error instanceof Error, true);
+        },
+      },
+      "when passed message and an Error object": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.error("this is a test message", new Error("this is an error"))
+        },
+        "should have an error object, and msg should be as given": function (transport, level, msg, meta, error) {
+          assert.strictEqual(msg, "this is a test message");
+          assert.equal(error instanceof Error, true);
+        },
+      },
+      "when passed message, Error object, and meta": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.error("this is a test message", new Error("this is an error"), {foo: "bar"})
+        },
+        "should have an error object, msg and meta object as given": function (transport, level, msg, meta, error) {
+          assert.strictEqual(msg, "this is a test message");
+          assert.deepEqual(meta, {foo: "bar"});
+          assert.equal(error instanceof Error, true);
+        },
+      },
+      "when passed Error object and meta": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.error(new Error("this is an error"), {foo: "bar"})
+        },
+        "should have an error object, msg should be error.message, and meta object as given": function (transport, level, msg, meta, error) {
+          assert.strictEqual(msg, "this is an error");
+          assert.deepEqual(meta, {foo: "bar"});
+          assert.equal(error instanceof Error, true);
+        },
+      },
+      "when passed interpolation strings, Error object and meta": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.error('test message %s, %s', 'first', 'second' , new Error("this is an error"), {foo: "bar"});
+        },
+        "shoud interpolate, have Error object and meta": function (transport, level, msg, meta, error) {
+          assert.strictEqual(msg, "test message first, second");
+          assert.deepEqual(meta, {foo: "bar"});
+          assert.equal(error instanceof Error, true);
+        },
       }
     }
   }


### PR DESCRIPTION
Today when passing an Error object to the logger, the Error (with the stack trace etc.) is "stringified" and not passed to the transport layer. In case meta data is not passed, the Error object will get passed as meta (but this seems to be more by accident than on deliberate).

My suggestion is to support the passing of Error objects to the logger and underlying transports, without breaking the current interface at all.

The use case I'm aiming at are transport that should be "aware" of Errors and not only strings. For example, the Sentry transport, should be able to send to Sentry an Error object, mainly because it allows the Sentry client to extract the relevant code frames and send them through.
