### PR TITLE
Fix webhook tests when using node 0.10

### DIFF
--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -88,6 +88,9 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
     options.ca = this.ssl.ca;
     options.key = this.ssl.key;
     options.cert = this.ssl.cert;
+
+    // Required for the test fixture SSL certificate to be considered valid.
+    options.rejectUnauthorized = false;
   }
 
   if (this.auth) {
@@ -101,6 +104,11 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
   req = (self.ssl ? https : http).request(options, function (res) {
     // TODO: emit 'logged' correctly,
     // keep track of pending logs.
+    res.on('data', function(data) {
+      // Do nothing. We need to read the response, or we run into maxSockets
+      // after 5 requests.
+    });
+
     self.emit('logged');
     if (callback) callback(null, true);
     callback = null;


### PR DESCRIPTION
Makes two updates to the webhook transport so that the webhook tests work with node 0.10.
