### PR TITLE
Use log callback instead of event listeners. This prevents log handlers ...

### DIFF
--- a/lib/winston/transports/transport.js
+++ b/lib/winston/transports/transport.js
@@ -103,19 +103,5 @@ Transport.prototype.formatResults = function (results, options) {
 // all logging has completed.
 //
 Transport.prototype.logException = function (msg, meta, callback) {
-  var self = this;
-
-  function onLogged () {
-    self.removeListener('error', onError);
-    callback();
-  }
-
-  function onError () {
-    self.removeListener('logged', onLogged);
-    callback();
-  }
-
-  this.once('logged', onLogged);
-  this.once('error', onError);
-  this.log('error', msg, meta, function () { });
+  this.log('error', msg, meta, function () { callback(); });
 };


### PR DESCRIPTION
...from being leaked when transport is silent.