### PR TITLE
new *Transport({level: <level value>}): <level value> can be null to inh...

### DIFF
--- a/lib/winston/transports/transport.js
+++ b/lib/winston/transports/transport.js
@@ -19,7 +19,7 @@ var Transport = exports.Transport = function (options) {
   events.EventEmitter.call(this);
 
   options               = options        || {};
-  this.level            = options.level  || 'info';
+  this.level            = options.level === undefined ? 'info' : options.level;
   this.silent           = options.silent || false;
   this.raw              = options.raw    || false;
   this.name             = options.name   || this.name;


### PR DESCRIPTION
Setting a default via `||` ignores falsey but valid values like `null`. (I currently have to create the Transport and then set transport.level on the next line.) Check for `undefined` explicitly instead.
