### PR TITLE
Daily file appender improvements: reading already written logs at startu...

### DIFF
--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -69,6 +69,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.colorize    = options.colorize    || false;
   this.maxsize     = options.maxsize     || null;
   this.maxFiles    = options.maxFiles    || null;
+  this.maxDays     = options.maxDays     || null;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
@@ -76,7 +77,9 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   if (this.json) {
     this.stringify = options.stringify;
   }
-
+  
+  this._filesDataStructure = new FilesDataHandler(this.dirname, this._basename, this.datePattern, this.maxFiles, this.maxDays);
+  
   //
   // Internal state variables representing the number
   // of files this instance has created and the current
@@ -109,11 +112,11 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
       M:    this._month + 1,
       MM:   pad(this._month + 1),
       d:    this._date,
-      dd:   pad(this._date),
-      H:    this._hour,
+      dd:   pad(this._date)
+      /*H:    this._hour,
       HH:   pad(this._hour),
       m:    this._minute,
-      mm:   pad(this._minute)
+      mm:   pad(this._minute)*/
     };
     return this.datePattern.replace(token, function ($0) {
       return $0 in flags ? flags[$0] : $0.slice(1, $0.length - 1);
@@ -419,7 +422,7 @@ DailyRotateFile.prototype.open = function (callback) {
     return callback(true);
   }
   else if (!this._stream || (this.maxsize && this._size >= this.maxsize) ||
-      (this._year < now.getFullYear() || this._month < now.getMonth() || this._date < now.getDate() || this._hour < now.getHours() || this._minute < now.getMinutes())) {
+      (this._year < now.getFullYear() || this._month < now.getMonth() || this._date < now.getDate())) {// || this._hour < now.getHours() || this._minute < now.getMinutes())) {
     //
     // If we dont have a stream or have exceeded our size, then create
     // the next stream and respond with a value indicating that
@@ -541,6 +544,9 @@ DailyRotateFile.prototype._createStream = function () {
       // than one second.
       //
       self.flush();
+      
+      // signaling the new file creation
+      self._filesDataStructure.addFilename(target);
     }
 
     fs.stat(fullname, function (err, stats) {
@@ -551,17 +557,19 @@ DailyRotateFile.prototype._createStream = function () {
 
         return createAndFlush(0);
       }
-
+      
+      // rotation remaining in the same day
       if (!stats || (self.maxsize && stats.size >= self.maxsize)) {
         //
         // If `stats.size` is greater than the `maxsize` for
         // this instance then try again
         //
-        return checkFile(self._getFile(true));
+        return checkFile(self._getFile());
       }
-
+      
+      // day-based rotation: check if the day has changed
       var now = new Date();
-      if (self._year < now.getFullYear() || self._month < now.getMonth() || self._date < now.getDate() || self._hour < now.getHours() || self._minute < now.getMinutes()) {
+      if (self._year < now.getFullYear() || self._month < now.getMonth() || self._date < now.getDate()) {
         self._year   = now.getFullYear();
         self._month  = now.getMonth();
         self._date   = now.getDate();
@@ -573,41 +581,16 @@ DailyRotateFile.prototype._createStream = function () {
 
       createAndFlush(stats.size);
     });
-  })(this._getFile());
+  })(this._filesDataStructure.getCurrentFile()); // rotating on day-base at startup
 };
 
 //
 // ### @private function _getFile ()
-// Gets the next filename to use for this instance
-// in the case that log filesizes are being capped.
+// Gets the next filename to use for this instance (day-based rotation and
+// rotation of days).
 //
-DailyRotateFile.prototype._getFile = function (inc) {
-  var self = this,
-      filename = this._basename + this.getFormattedDate(),
-      remaining;
-
-  if (inc) {
-    //
-    // Increment the number of files created or
-    // checked by this instance.
-    //
-    // Check for maxFiles option and delete file
-    if (this.maxFiles && (this._created >= (this.maxFiles - 1))) {
-      remaining = this._created - (this.maxFiles - 1);
-      if (remaining === 0) {
-        fs.unlinkSync(path.join(this.dirname, filename));
-      }
-      else {
-        fs.unlinkSync(path.join(this.dirname, filename + '.' + remaining));
-      }
-    }
-
-    this._created += 1;
-  }
-
-  return this._created
-    ? filename + '.' + this._created
-    : filename;
+DailyRotateFile.prototype._getFile = function (/*boolean*/incrementDayFiles, /*boolean*/rotateDay) {
+  return this._filesDataStructure.getNextFilenameToUse();
 };
 
 //
@@ -628,3 +611,381 @@ DailyRotateFile.prototype._lazyDrain = function () {
     });
   }
 };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//
+//Handler object for log files data structure: reads and parses log file names
+//in logs directory at startup, exposes the next filename to use and rotates
+//logs.
+//
+//* logsDir: directory in which to find logs, e.g. "./logs" or "logs"
+//* filename: base filename of single log file, like "app-logs.log"
+//* datePattern: daily transport date pattern, like ".yyyy-MM-dd"
+//* maxFilesPerDay: in-day rotation limit
+//* maxDays: daily rotation limit
+//
+//* (C) 2013 Nicola Baisero
+//* MIT LICENCE
+//
+function FilesDataHandler(/*string*/logsDir, filename, datePattern, maxFilesPerDay, maxDays) {
+  this._dataStructure = [];
+  this._filename = filename; // with extension
+  this._datePattern = datePattern; // with letters, like y, M, m
+  this._logsDir = logsDir;
+  this._maxPerDay = maxFilesPerDay;
+  this._maxDays = maxDays;
+  
+  this._log('params: ' + util.inspect(arguments, {depth : 4}));
+  
+  // initializing data structure
+  this._initDataStructure(logsDir);
+  
+  this._log('data structure');
+  this._log(util.inspect(this._dataStructure, {depth: 5}));
+}
+(function() {
+FilesDataHandler.prototype = {
+  constructor : FilesDataHandler,
+  
+  //*** init stuff
+  // Reads the logs directory and setups the data structure accordingly
+  _initDataStructure : function(/*string*/logsDir) {
+    var allFiles = fs.readdirSync(logsDir);
+    
+    for (var i = 0; i < allFiles.length; i++) {
+      var curr = allFiles[i];
+      
+      if (curr.indexOf(this._filename) != -1) {
+        // updating data structure
+        this._insertInDataStructure(curr);
+      }
+    }
+    
+    // sorting data structure
+    this._sortDays();
+    this._sortIndexesInDays();
+  },
+  
+  
+  //*** removing elements stuff (also from file system)
+  // removes the oldest log file name for today (in-day rotation)
+  removeOldestFilenameLastDay : function() {
+    if (!this._dataStructure.length) return;
+    
+    // getting file to delete
+    var newestDay = this._dataStructure[this._dataStructure.length - 1];
+    var files = newestDay.files;
+    var fileToDelete = files.shift();
+    
+    // deleting file
+    this._deleteFileSilent(fileToDelete.filename);
+    
+    // if that was the latest filename, removing entire day from data structure
+    if (!files.length) this._dataStructure.pop();
+  },
+  // removes the oldest day (days rotation)
+  removeOldestDay : function() {
+    if (!this._dataStructure.length) return;
+    
+    // getting first day from data structure
+    var latestElement = this._dataStructure.shift();
+    var files = latestElement.files;
+    
+    // cycling over files for deletion
+    for (var i = 0; i < files.length; i++) {
+      this._deleteFileSilent(files[i].filename);
+    }
+    
+    this._log('struct after deletion: ');
+    this._log(util.inspect(this._dataStructure, {depth: 5}));
+  },
+  // adds the given filename to the data structure and rotates if necessary
+  addFilename : function(filename) {
+    this._log('adding filename: ' + filename);
+    
+    if (this._alreadyInserted(filename)) return;
+    
+    this._insertInDataStructure(filename);
+    
+    this._log('data struct after adding filename: ' + util.inspect(this._dataStructure, {depth: 5}));
+    
+    // rotating
+    this._inDayRotateSafe();
+    this._dailyRotateSafe();
+    
+    this._log('data struct after adding filename, after rotation: ' + util.inspect(this._dataStructure, {depth: 5}));
+  },
+  // assesses the next filename to use: doesn't check for file size, simply
+  // creates the next name. If the related file gets created successfully,
+  // addFilename must be then called for updating everything and for rotating.
+  getNextFilenameToUse : function() {
+    var now = new Date();
+    
+    // if there are logs for today, they are in the last position
+    var lastDay = this._dataStructure[this._dataStructure.length - 1];
+    
+    // the day exists, and also a log file
+    if (!lastDay || this._datesEqualYearMonthDay(lastDay.date, now)) {
+      var latestLogFileInDay = lastDay.files[lastDay.files.length - 1];
+      
+      this._log('*********** nuovo file: ' + this._filename + this._formatDate(now) + "." + (latestLogFileInDay.index + 1));
+      
+      return this._filename + this._formatDate(now) + "." + (latestLogFileInDay.index + 1);
+    }
+    // the day doesn't exist
+    else {
+      this._log('*********** nuovo file n: ' + this._filename + this._formatDate(now));
+      
+      return this._filename + this._formatDate(now);
+    }
+  },
+  // returns the latest log file of the day if that day exists, otherwise
+  // returns a new name file, for today. This filename doesn't get added
+  // to the structure: the addition occurs with "addFilename"
+  getCurrentFile : function() {
+    var now = new Date();
+    
+    var lastDay = this._dataStructure[this._dataStructure.length - 1];
+    
+    if (lastDay && this._datesEqualYearMonthDay(lastDay.date, now)) {
+      var lastDayFiles = lastDay.files;
+      
+      return lastDayFiles[lastDayFiles.length - 1].filename;
+    } else {
+      return this._filename + this._formatDate(now);
+    }
+  },
+  
+  
+  
+  
+  //******  internal business
+  //*** filenames parsing
+  // retrieve given filename's index, defaulting to 0
+  _getFileIndex : function(filename) {
+    var regEx = new RegExp('^.*' + this._getDatePatternRegex() + '\.(.*)$');
+    var matchResult = filename.match(regEx);
+    var rawIndex = (matchResult && matchResult[1] ? matchResult[1] : null);
+    var index = parseInt(rawIndex); // it's null safe
+    
+    return (isNaN(index) ? 0 : index);
+  },
+  // retrieve and parse given filename's date
+  /*returns Date*/ _getFileDate : function(filename) {
+    var datePatternRegex = this._getDatePatternRegex();
+    var dateRegex = new RegExp('^' + this._filename + '(' + datePatternRegex + ')');
+    var matchResult = filename.match(dateRegex);
+    var rawDate = matchResult[1]; // like .2017-05-12
+    
+    // getting string values
+    var year = '';
+    var month = '';
+    var day = '';
+    var yearDigits = 0;
+    for (var i = 0; i < this._datePattern.length; i++) {
+      var curr = this._datePattern[i];
+      var stringDateVal = rawDate[i];
+      
+      if (curr == 'y') {
+        yearDigits++;
+        year += stringDateVal;
+      } else if (curr == 'M') {
+        month += stringDateVal;
+      } else if (curr == 'd') {
+        day += stringDateVal;
+      }
+    }
+    month -= 1; // they start from 0...
+    
+    return new Date(year, month, day);
+  },
+  // transforms date pattern from 
+  _getDatePatternRegex : function() {
+    return this._datePattern.replace(/[yMdHm]/g, '\\d');
+  },
+  
+  
+  //*** Data structure handling
+  _insertInDataStructure : function(filename, /*boolean*/checkAlreadyInserted) {
+    // parsing filename's stuff
+    var index = this._getFileIndex(filename);
+    var date = this._getFileDate(filename);
+    
+    this._log('***********');
+    this._log('filename: ' + filename);
+    this._log('index: ' + index);
+    this._log('date: ' + date);
+    this._log('***********');
+    
+    // get the insertion index
+    var insertionIndex = -1;
+    var newInsert = true;
+    for (var i = 0; i < this._dataStructure.length; i++) {
+      var currEl = this._dataStructure[i];
+      
+      // date found, inserting index
+      if (this._datesEqualYearMonthDay(currEl.date, date)) {
+        insertionIndex = i;
+        newInsert = false;
+        break;
+      }
+      // need to seek ahead
+      if (currEl.date < date) continue;
+      // previous index was the right one
+      if (currEl.date > date) {
+        insertionIndex = i - 1;
+        break;
+      }
+    }
+    
+    // inserting element in the given index
+    // last
+    if (insertionIndex < 0) {
+      this._dataStructure.push(this._getNewElement(date, index, filename));
+    }
+    // inserting element at given index, it's brand new
+    else if (newInsert) {
+      this._dataStructure.splice(insertionIndex, 0, this._getNewElement(date, index, filename));
+    }
+    // updating element at given index
+    else {
+      this._updateElementForIndex(insertionIndex, index, filename);
+    }
+  },
+  _updateElementForIndex : function(arrayIndex, dayCounter, filename) {
+    var dayFiles = this._dataStructure[arrayIndex].files; // as returned by _getNewElement
+    
+    // finding position in which to insert the filename
+    var insertionIndex = -1;
+    for (var i = 0; i < dayFiles.length; i++) {
+      var currentElement = dayFiles[i];
+      
+      if (currentElement.index < dayCounter) continue;
+      if (currentElement.index > dayCounter) {
+        insertionIndex = i - 1;
+      }
+    }
+    
+    // inserting filename
+    // last
+    if (insertionIndex < 0) {
+      dayFiles.push(this._getNewFileElement(dayCounter, filename));
+    } else {
+      dayFiles.splice(insertionIndex, 0, this._getNewFileElement(dayCounter, filename));
+    }
+  },
+  _getNewElement : function(date, index, filename) {
+    return {
+      date : date,
+      files : [this._getNewFileElement(index, filename)]
+    };
+  },
+  _getNewFileElement : function(index, filename) {
+    return {
+      index : index,
+      filename : filename
+    };
+  },
+  // says if the given filename has been already inserted in the structure
+  _alreadyInserted : function(filename) {
+    for (var i = 0; i < this._dataStructure.length; i++) {
+      var currEl = this._dataStructure[i];
+      for (var j = 0; j < currEl.files.length; j++) {
+        if (currEl.files[j].filename == filename) return true;
+      }
+    }
+    
+    return false;
+  },
+  // sorting functions, useful only on startup
+  _sortDays : function() {
+    this._dataStructure.sort(function(a, b) {
+      return a.date - b.date;
+    });
+  },
+  _sortIndexesInDays : function() {
+    for (var i = 0; i < this._dataStructure.length; i++) {
+      this._dataStructure[i].files.sort(function(a, b) {
+        return a.index - b.index;
+      });
+    }
+  },
+  
+  //*** rotation
+  // checks if day rotation is needed and eventually performs it
+  _dailyRotateSafe : function() {
+    // checks
+    if (this._dataStructure.length <= this._maxDays) return;
+    
+    // rotating
+    while (this._dataStructure.length > this._maxDays) this.removeOldestDay();
+  },
+  // checks if in-day rotation is needed and eventually performs it
+  _inDayRotateSafe : function() {
+    var lastDay = this._dataStructure[this._dataStructure.length - 1];
+    
+    if (lastDay.files.length > this._maxPerDay) this.removeOldestFilenameLastDay();
+  },
+  
+  
+  //*** misc
+  // useful for turning off logging when necessary
+  _log : function(message) {
+    //console.log(message);
+  },
+  _datesEqualYearMonthDay : function(dateA, dateB) {
+    return dateA.getFullYear() == dateB.getFullYear() &&
+      dateA.getMonth() == dateB.getMonth() &&
+      dateA.getDate() == dateB.getDate();
+  },
+  _deleteFileSilent : function(filename) {
+    this._log('deleting log ' + filename);
+    
+    var filePath = path.resolve('.', path.join(this._logsDir, filename));
+    
+    try {
+      fs.unlinkSync(filePath);
+    } catch(error) {
+      console.log('Error while deleting file ' + filePath + ': ' + util.inspect(error, {depth : 4}));
+    }
+  },
+  // XXX copied from above...
+  _formatDate : function(dateInstance) {
+    var year = dateInstance.getFullYear();
+    var month = dateInstance.getMonth();
+    var date = dateInstance.getDate();
+    
+    var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhM])\1?/g,
+      pad = function (val, len) {
+        val = String(val);
+        len = len || 2;
+        while (val.length < len) val = "0" + val;
+        return val;
+      };
+      
+    var flags = {
+      yy:   String(year).slice(2),
+      yyyy: year,
+      M:    month + 1,
+      MM:   pad(month + 1),
+      d:    date,
+      dd:   pad(date)
+      };
+      return this._datePattern.replace(token, function ($0) {
+        return $0 in flags ? flags[$0] : $0.slice(1, $0.length - 1);
+      });
+  }
+};
+})();


### PR DESCRIPTION
Daily file appender improvements:
-  on startup: read of already created log files for keeping to write on the latest available log file (it was buggy if rotation inside a day occurred);
-  added rotation over days;
-  removed hours/minutes accounting for rotating (it's a daily transport).

Notes on stability and test:
-  date patterns: tested _only_ against default date pattern (that is enough for me), should work well anyway with other patterns supported by the classic version;
-  in-day and over-days rotations tested manually (it could be great to add some unit tests...);
-  tested in node v0.10.1.
