### PR TITLE
Fixed HTTP Transport inheritance

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -1,7 +1,8 @@
 var util = require('util'),
     winston = require('../../winston'),
     request = require('request'),
-    Stream = require('stream').Stream;
+    Stream = require('stream').Stream,
+    Transport = require('./transport').Transport;
 
 //
 // ### function Http (options)
@@ -10,6 +11,7 @@ var util = require('util'),
 // for persisting log messages and metadata to a terminal or TTY.
 //
 var Http = exports.Http = function (options) {
+  Transport.call(this, options);
   options = options || {};
 
   this.name = 'http';


### PR DESCRIPTION
Added call to transport constructor to correctly set up default values. This is equivalent to what happens in the File transport which behaves correctly in regards to pre-sets.
