### PR TITLE
Revert "conform with RFC 5424"

### DIFF
--- a/lib/winston/config/syslog-config.js
+++ b/lib/winston/config/syslog-config.js
@@ -9,23 +9,23 @@
 var syslogConfig = exports;
 
 syslogConfig.levels = {
-  emerg: 0,
-  alert: 1,
-  crit: 2,
-  error: 3,
-  warning: 4,
-  notice: 5,
-  info: 6,
-  debug: 7,
+  debug: 0,
+  info: 1,
+  notice: 2,
+  warning: 3,
+  error: 4,
+  crit: 5,
+  alert: 6,
+  emerg: 7
 };
 
 syslogConfig.colors = {
-  emerg: 'red',
-  alert: 'yellow',
-  crit: 'red',
-  error: 'red',
-  warning: 'red',
-  notice: 'yellow',
-  info: 'green',
   debug: 'blue',
+  info: 'green',
+  notice: 'yellow',
+  warning: 'red',
+  error: 'red',
+  crit: 'red',
+  alert: 'yellow',
+  emerg: 'red'
 };


### PR DESCRIPTION
This reverts commit 651b13e1952cbfc312bd72d26684c7ad552af00f.

This is to fix the fact that this commit broke the way levels are handled with winston.  This restores the levels to a working order.
