### PR TITLE
Write log messages to stderr only

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -74,11 +74,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
     label:       this.label
   });
 
-  if (level === 'error' || level === 'debug') {
-    process.stderr.write(output + '\n');
-  } else {
-    process.stdout.write(output + '\n');
-  }
+  process.stderr.write(output + '\n');
 
   //
   // Emit the `logged` event immediately because the event loop


### PR DESCRIPTION
I'm writing a command line app, and evaluated Winston for logging for its breadth of out-of-the-box transports.

I saw in the console transport that some log messages are written to stdout.

I'm writing program output (ie: the final results of my command line app) to stdout. This is pretty common Unix-ish stuff.

The output of my program can be piped into the input of another program (more Unix-ish stuff), or used as an argument to another program (if it doesn't handle stdin).

I can't use the output of my program (stdout) if stdout is also being used for diagnostic (ie: logging) output.

Ideally, diagnostic info like logging (as well as errors) should be confined to stderr so that stdout can be used for program output.
