### PR TITLE
addResults should only callback once

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -12,7 +12,8 @@ var events = require('events'),
     config = require('./config'),
     common = require('./common'),
     exception = require('./exception'),
-    Stream = require('stream').Stream;
+    Stream = require('stream').Stream,
+    once = require('once');
 
 //
 // Time constants
@@ -251,6 +252,7 @@ Logger.prototype.query = function (options, callback) {
   // `queryTransport` into the `results`.
   //
   function addResults (transport, next) {
+    next = once(next);
     queryTransport(transport, function (err, result) {
       result = err || result;
       if (result) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eyes": "0.1.x",
     "pkginfo": "0.3.x",
     "request": "2.16.x",
-    "stack-trace": "0.0.x"
+    "stack-trace": "0.0.x",
+    "once": "~1.3.0"
   },
   "devDependencies": {
     "vows": "0.7.x"


### PR DESCRIPTION
This will cause Node to crash because async throws an error [as shown
here](https://github.com/caolan/async/blob/master/lib/async.js#L22). Fix
is to use isaac's once module to make sure we only call `next` one time.
