### PR TITLE
Added color for pre-defined cli set.

### DIFF
--- a/lib/winston/config.js
+++ b/lib/winston/config.js
@@ -43,6 +43,7 @@ config.syslog = require('./config/syslog-config');
 //
 // Add colors for pre-defined config sets
 //
+config.addColors(config.cli.colors);
 config.addColors(config.npm.colors);
 config.addColors(config.syslog.colors);
 


### PR DESCRIPTION
Otherwise it raises an error when using the CLI pre-defined level with the colorize option for the transporter.
