### PR TITLE
Issue #362 - Added the option for showing the file name along with the logs

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -127,6 +127,7 @@ exports.log = function (options) {
     output         = exports.clone(meta) || {};
     output.level   = options.level;
     output.message = options.message.stripColors;
+    output.fileName = options.fileName;
     return JSON.stringify(output);
   }
 
@@ -141,11 +142,12 @@ exports.log = function (options) {
     output         = exports.clone(meta) || {};
     output.level   = options.level;
     output.message = options.message;
+    output.fileName = options.fileName;
 
     if (timestamp) {
       output.timestamp = timestamp;
     }
-    
+
     if (options.logstash === true) {
       // use logstash format
       var logstashOutput = {};
@@ -177,6 +179,7 @@ exports.log = function (options) {
   output = timestamp ? timestamp + ' - ' : '';
   output += options.colorize ? config.colorize(options.level) : options.level;
   output += ': ';
+  output += options.fileName ? ('[' + options.fileName + '] ') : '';
   output += options.label ? ('[' + options.label + '] ') : '';
   output += options.message;
 
@@ -307,7 +310,7 @@ exports.tailFile = function tail(options, callback) {
   if (options.start === -1) {
     delete options.start;
   }
-  
+
   stream.on('data', function (data) {
     var data = (buff + data).split(/\n+/),
         l = data.length - 1,

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -50,6 +50,7 @@ var Logger = exports.Logger = function (options) {
   this.exitOnError = typeof options.exitOnError !== 'undefined'
     ? options.exitOnError
     : true;
+  this.showFileName = options.showFileName || false;
 
   //
   // Setup other intelligent default settings.
@@ -176,7 +177,9 @@ Logger.prototype.log = function (level) {
     var transport = self.transports[name];
     if ((transport.level && self.levels[transport.level] <= self.levels[level])
       || (!transport.level && self.levels[self.level] <= self.levels[level])) {
-      transport.log(level, msg, meta, function (err) {
+      transport.log(level, msg, meta, (self.showFileName)
+        ? self._getCallerFile()
+        : '' , function (err) {
         if (err) {
           err.transport = transport;
           cb(err);
@@ -663,3 +666,22 @@ Logger.prototype._onError = function (transport, err) {
     this.emit('error', err, transport);
   }
 };
+
+//
+// ### @private function _getCallerFile ()
+// Uses the error stack trace to find the caller file.
+// Ignores the calls from node_module folder and native calls.
+//
+Logger.prototype._getCallerFile = function() {
+    try {
+        var err = new Error(),callerfile,currentfile;
+        Error.prepareStackTrace = function (err, stack) {return stack;};
+        while (err.stack.length) {
+            callerfile = err.stack.shift().getFileName();
+            if(currentfile!==callerfile && callerfile.indexOf('node_module') < 0 && callerfile.split(' ')[0] !== 'native') {
+              return callerfile;
+            }
+        }
+    } catch (err) {}
+    return undefined;
+}

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -50,10 +50,11 @@ Console.prototype.name = 'console';
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
 // #### @meta {Object} **Optional** Additional metadata to attach
+// #### @fileName {string} **Optional** Aditional file name to log
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Console.prototype.log = function (level, msg, meta, callback) {
+Console.prototype.log = function (level, msg, meta, fileName, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -71,7 +72,8 @@ Console.prototype.log = function (level, msg, meta, callback) {
     timestamp:   this.timestamp,
     prettyPrint: this.prettyPrint,
     raw:         this.raw,
-    label:       this.label
+    label:       this.label,
+    'fileName': fileName
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -72,7 +72,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
-  
+
   if (this.json) {
     this.stringify = options.stringify;
   }
@@ -136,10 +136,11 @@ DailyRotateFile.prototype.name = 'dailyRotateFile';
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
 // #### @meta {Object} **Optional** Additional metadata to attach
+// #### @fileName {string} **Optional** Aditional file name to log
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
+DailyRotateFile.prototype.log = function (level, msg, meta, fileName, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -154,7 +155,8 @@ DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
     colorize:    this.colorize,
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,
-    stringify:   this.stringify
+    stringify:   this.stringify,
+    'fileName': fileName
   }) + '\n';
 
   this._size += output.length;
@@ -320,11 +322,11 @@ DailyRotateFile.prototype.stream = function (options) {
   };
 
   stream.destroy = common.tailFile(tail, function (err, line) {
-    
+
     if(err){
       return stream.emit('error',err);
     }
-    
+
     try {
       stream.emit('data', line);
       line = JSON.parse(line);
@@ -333,7 +335,7 @@ DailyRotateFile.prototype.stream = function (options) {
       stream.emit('error', e);
     }
   });
-  
+
   if(stream.resume){
     stream.resume();
   }

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -103,10 +103,11 @@ File.prototype.name = 'file';
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
 // #### @meta {Object} **Optional** Additional metadata to attach
+// #### @fileName {string} **Optional** Aditional file name to log
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-File.prototype.log = function (level, msg, meta, callback) {
+File.prototype.log = function (level, msg, meta, fileName callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -126,7 +127,8 @@ File.prototype.log = function (level, msg, meta, callback) {
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,
     stringify:   this.stringify,
-    label:       this.label
+    label:       this.label,
+    fileName:    fileName
   }) + '\n';
 
   this._size += output.length;
@@ -291,11 +293,11 @@ File.prototype.stream = function (options) {
   };
 
   stream.destroy = common.tailFile(tail, function (err, line) {
-    
+
     if(err){
       return stream.emit('error',err);
     }
-    
+
     try {
       stream.emit('data', line);
       line = JSON.parse(line);

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -68,10 +68,11 @@ Http.prototype._request = function (options, callback) {
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
 // #### @meta {Object} **Optional** Additional metadata to attach
+// #### @fileName {string} **Optional** Aditional file name to log
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Http.prototype.log = function (level, msg, meta, callback) {
+Http.prototype.log = function (level, msg, meta, fileName, callback) {
   var self = this;
 
   if (typeof meta === 'function') {
@@ -88,6 +89,11 @@ Http.prototype.log = function (level, msg, meta, callback) {
     }
   };
 
+  // adding the filename to the parameters
+  if (fileName) {
+    options.params['fileName'] = fileName;
+  }
+
   if (meta) {
     if (meta.path) {
       options.path = meta.path;
@@ -99,7 +105,7 @@ Http.prototype.log = function (level, msg, meta, callback) {
       delete meta.auth;
     }
   }
-  
+
   this._request(options, function (err, res, body) {
     if (res && res.statusCode !== 200) {
       err = new Error('HTTP Status Code: ' + res.statusCode);

--- a/lib/winston/transports/memory.js
+++ b/lib/winston/transports/memory.js
@@ -45,10 +45,11 @@ Memory.prototype.name = 'memory';
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
 // #### @meta {Object} **Optional** Additional metadata to attach
+// #### @fileName {string} **Optional** Aditional file name to log
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Memory.prototype.log = function (level, msg, meta, callback) {
+Memory.prototype.log = function (level, msg, meta, fileName, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -67,6 +68,7 @@ Memory.prototype.log = function (level, msg, meta, callback) {
     prettyPrint: this.prettyPrint,
     raw:         this.raw,
     label:       this.label
+    'fileName':    fileName
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -61,10 +61,11 @@ Webhook.prototype.name = 'webhook';
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
 // #### @meta {Object} **Optional** Additional metadata to attach
+// #### @fileName {string} **Optional** Aditional file name to log
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Webhook.prototype.log = function (level, msg, meta, callback) {
+Webhook.prototype.log = function (level, msg, meta, fileName, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -136,6 +137,11 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
   params.timestamp = new Date();
   params.message = msg;
   params.level = level;
+
+  // adding the filename to the parameter
+  if (fileName) {
+    params.filename = fileName;
+  }
 
   req.write(JSON.stringify({
     method: 'log',


### PR DESCRIPTION
Hi.
With this tweak, one will be able to print the file name along with the logs with the option 'showFileName' set to true.

``` javascript
new (winston.Logger)({
    exitOnError: false,
    transports: DEFAULT_TRANSPORTS,
    'showFileName': true
});
```

This is how the logs would look-

``` properties
2014-04-29T07:14:57.720Z - debug: [/home/user/project/trunk/someFolder/server/app.js] Logging module 'Winston' has been successfully integrated.
```

In order to achieve this I have modified the following files:
# modified:   lib/winston/common.js
# modified:   lib/winston/logger.js
# modified:   lib/winston/transports/console.js
# modified:   lib/winston/transports/daily-rotate-file.js
# modified:   lib/winston/transports/file.js
# modified:   lib/winston/transports/http.js
# modified:   lib/winston/transports/memory.js
# modified:   lib/winston/transports/webhook.js

Please let me know, if this pull can be approved.

Thanks,
Gaurav
