### PR TITLE
fix Logger#transports length check upon Logger#log

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -146,7 +146,8 @@ Logger.prototype.log = function (level) {
     }
   }
 
-  if (this.transports.length === 0) {
+  
+  if (Object.keys(this.transports).length === 0) {
     return onError(new Error('Cannot log with no transports.'));
   }
   else if (typeof self.levels[level] === 'undefined') {


### PR DESCRIPTION
`Logger#transports` seems to be an object so there's no `length` property to test if transports were defined.
Used `Object.keys(Logger#transports).length` instead.
