### PR TITLE
Syslog Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,25 @@ Setting the level for your logging message can be accomplished in one of two way
   winston.info("127.0.0.1 - there's no place like home");
 ```
 
-Winston allows you to set a `level` on each transport that specifies the level of messages this transport should log. For example, you could log only errors to the console, with the full logs in a file (note that the default level of a transport is `info`):
+Each `level` is given a specific integer priority.  The higher the priority, the more important the message is considered to be.  For example, `npm` logging levels are prioritized from 0 to 5:
+
+``` js
+{  silly: 0,  debug: 1,  verbose: 2,  info: 3,  warn: 4,  error: 5  };
+```
+
+Similarly, `syslog` levels are prioritized from 0 to 7:
+
+``` js
+{  debug: 0,  info: 1,  notice: 2,  warning: 3,  error: 4,  crit: 5,  alert: 6,  emerg: 7  };
+```
+
+If you do not explicitly define the levels that Winston should use (more on how to do that can be found below), then Winston will use a default set of priorities (named `cli`) that roughly combine the two:
+
+``` js
+{  silly: 0,  input: 1,  verbose: 2,  prompt: 3,  debug: 4,  info: 5,  data: 6,  help: 7,  warn: 8,  error: 9 };
+```
+
+Winston allows you to define a `level` property on each transport which specifies the *minimum* level of messages that a transport should log. For example, you could log only errors (and above) to the console:
 
 ``` js
   var logger = new (winston.Logger)({
@@ -318,6 +336,10 @@ Winston allows you to set a `level` on each transport that specifies the level o
     ]
   });
 ```
+
+In the example above, and depending on your levels configuration, errors and any level higher would be output to the console.  Anything lower than an `error` would skip the console.
+
+Also, since a level was not specified for the `File` transport, it would default to `info`, which is the default level for transports. 
 
 You may also dynamically change the log level of a transport:
 

--- a/lib/winston/config/syslog-config.js
+++ b/lib/winston/config/syslog-config.js
@@ -9,23 +9,23 @@
 var syslogConfig = exports;
 
 syslogConfig.levels = {
-  emerg: 0,
-  alert: 1,
-  crit: 2,
-  error: 3,
-  warning: 4,
-  notice: 5,
-  info: 6,
-  debug: 7,
+  debug: 0,
+  info: 1,
+  notice: 2,
+  warning: 3,
+  error: 4,
+  crit: 5,
+  alert: 6,
+  emerg: 7
 };
 
 syslogConfig.colors = {
-  emerg: 'red',
-  alert: 'yellow',
-  crit: 'red',
-  error: 'red',
-  warning: 'red',
-  notice: 'yellow',
-  info: 'green',
   debug: 'blue',
+  info: 'green',
+  notice: 'yellow',
+  warning: 'red',
+  error: 'red',
+  crit: 'red',
+  alert: 'yellow',
+  emerg: 'red'
 };


### PR DESCRIPTION
In all other configs the numerical order is from lowest to highest (e.g. 'npm' has silly=0,error=5). However, the syslog levels were from highest to lowest (debug=7,emerg=0).  The CLI config also had a similar order as the NPM config.

I've corrected this file to follow the same pattern.  Its so obvious and fundamental that I know I am probably breaking something that has been the source of long debates or something, but I cannot think of why it is the way it is.

The main reason this change is needed is because of the behavior of the 'level' param when adding transports.  Before this change, if I set the level of my console transport to 'notice', then it would listen for:  debug, info, and notice.  Thus, the setting would imply "Listen for this level and all levels of lower priority" (i.e. MaxLevel)

Limiting by 'Maximum Level' is counter-intuitive.  More often than otherwise I would want to prevent lesser priorities from being logged.. not higher priorities.  In fact, this setup would make it impossible to disable debug logging.  Instead, level should refer to 'Minimum Level', enabling this setup:

```
    - Debug > Console
    - Info, Notice, Warning, Error, Crit, Alert, Emerg > Log File
    - Notice, Warning, Error, Crit, Alert, Emerg > Logging System
    - Crit, Alert, Emerg > Cell Phone
```

--

I also added some additional docs for levels.