### PR TITLE
levels filter added for query on file transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -271,6 +271,12 @@ File.prototype.query = function (options, callback) {
       return;
     }
 
+    if(options.levels && 
+      typeof(options.levels) === "object" && 
+      options.levels.indexOf(log.level) === -1){
+        return;
+    }
+    
     return true;
   }
 };


### PR DESCRIPTION
query on file transport by levels

eg:

``` Javascript
var winston = require('winston');
var logger = new (winston.Logger)({
    transports: [
      new (winston.transports.File)({ filename: 'logfile.log' })
    ]
});

logger.query({
  levels : ['info', 'warn']
},function (err, results) {
  if (err) {
    throw err;
  }
  console.log(results);
});

```
