### PR TITLE
Filter by logging level of logger first and then by transport

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -174,8 +174,10 @@ Logger.prototype.log = function (level) {
   //
   function emit(name, next) {
     var transport = self.transports[name];
-    if ((transport.level && self.levels[transport.level] <= self.levels[level])
-      || (!transport.level && self.levels[self.level] <= self.levels[level])) {
+    // 1. check against logger logging level
+    // 2. check against transport logging level
+    if ((self.levels[level] >= self.levels[self.level])
+      && (!transport.level || self.levels[level] >= self.levels[transport.level])) {
       transport.log(level, msg, meta, function (err) {
         if (err) {
           err.transport = transport;

--- a/test/logger-levels-test.js
+++ b/test/logger-levels-test.js
@@ -65,7 +65,7 @@ vows.describe('winston/logger/levels').addBatch({
         },
         "should not interpolate": function (transport, level, msg, meta) {
           assert.strictEqual(msg, util.format('test message %%'));
-          assert.deepEqual(meta, {number: 123});          
+          assert.deepEqual(meta, {number: 123});
         },
       },
       "when passed interpolation strings and a meta object": {
@@ -110,7 +110,52 @@ vows.describe('winston/logger/levels').addBatch({
         "should join and have a meta object": function (transport, level, msg, meta) {
           assert.strictEqual(msg, 'test message first second');
           assert.deepEqual(meta, {number: 123});
-        }    
+        }
       }
     }
+}).addBatch({
+  "An instance of winston.Logger": {
+    topic: function () {
+      return new (winston.Logger)({ transports: [ new (winston.transports.Memory)() ] });
+    },
+
+    "with logging level higher": {
+      topic: function (logger) {
+        logger.level = 'info';
+        return logger;
+      },
+
+      "than logging level of incoming message": {
+        topic: function (logger) {
+          var that = this;
+          logger.debug('hello world', function () {
+            that.callback(null, logger.transports.memory);
+          });
+        },
+
+        "should not log such message": function (memory) {
+          assert.equal(memory.writeOutput.length, 0);
+        }
+      }
+    },
+
+    "with transport with logging level higher": {
+      topic: function (logger) {
+        logger.transports.memory.level = 'info';
+        return logger;
+      },
+
+      "than logging level of incoming message": {
+        topic: function (logger) {
+          var that = this;
+          logger.debug('hello world', function () {
+            that.callback(null, logger.transports.memory);
+          });
+        },
+        "should not log such message": function (memory) {
+          assert.equal(memory.writeOutput.length, 0);
+        }
+      }
+    }
+  }
 }).export(module);


### PR DESCRIPTION
It's very common to filter messages by logger's logging level first before filtering by transport's logging level. The reason behind it is that there should be an easy way to disable `debug` level (as an example)) entirely w/o updating configuration for each transport.
