### PR TITLE
Padding in function of the maximum level length at the Transport level.

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -145,7 +145,7 @@ exports.log = function (options) {
     if (timestamp) {
       output.timestamp = timestamp;
     }
-    
+
     if (options.logstash === true) {
       // use logstash format
       var logstashOutput = {};
@@ -177,6 +177,9 @@ exports.log = function (options) {
   output = timestamp ? timestamp + ' - ' : '';
   output += options.colorize ? config.colorize(options.level) : options.level;
   output += ': ';
+  output += options.levelPadLength
+    ? new Array(options.levelPadLength - options.level.length + 1).join(' ')
+    : '';
   output += options.label ? ('[' + options.label + '] ') : '';
   output += options.message;
 
@@ -307,7 +310,7 @@ exports.tailFile = function tail(options, callback) {
   if (options.start === -1) {
     delete options.start;
   }
-  
+
   stream.on('data', function (data) {
     var data = (buff + data).split(/\n+/),
         l = data.length - 1,

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -132,11 +132,6 @@ Logger.prototype.log = function (level) {
       meta     = typeof args[args.length - 1] === 'object' ? args.pop() : {},
       msg      = util.format.apply(null, args);
 
-  // If we should pad for levels, do so
-  if (this.padLevels) {
-    msg = new Array(this.levelLength - level.length + 1).join(' ') + msg;
-  }
-
   function onError (err) {
     if (callback) {
       callback(err);
@@ -428,6 +423,11 @@ Logger.prototype.unhandleExceptions = function () {
 //
 Logger.prototype.add = function (transport, options, created) {
   var instance = created ? transport : (new (transport)(options));
+
+  // If we should pad for levels, inform the transport.
+  if (this.padLevels) {
+    instance.levelPadLength = this.levelLength;
+  }
 
   if (!instance.name && !instance.log) {
     throw new Error('Unknown transport with no log() method');

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -62,16 +62,17 @@ Console.prototype.log = function (level, msg, meta, callback) {
       output;
 
   output = common.log({
-    colorize:    this.colorize,
-    json:        this.json,
-    level:       level,
-    message:     msg,
-    meta:        meta,
-    stringify:   this.stringify,
-    timestamp:   this.timestamp,
-    prettyPrint: this.prettyPrint,
-    raw:         this.raw,
-    label:       this.label
+    colorize:       this.colorize,
+    json:           this.json,
+    level:          level,
+    levelPadLength: this.levelPadLength,
+    message:        msg,
+    meta:           meta,
+    stringify:      this.stringify,
+    timestamp:      this.timestamp,
+    prettyPrint:    this.prettyPrint,
+    raw:            this.raw,
+    label:          this.label
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -72,7 +72,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
-  
+
   if (this.json) {
     this.stringify = options.stringify;
   }
@@ -147,14 +147,15 @@ DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
   var self = this;
 
   var output = common.log({
-    level:       level,
-    message:     msg,
-    meta:        meta,
-    json:        this.json,
-    colorize:    this.colorize,
-    prettyPrint: this.prettyPrint,
-    timestamp:   this.timestamp,
-    stringify:   this.stringify
+    level:          level,
+    message:        msg,
+    meta:           meta,
+    levelPadLength: this.levelPadLength,
+    json:           this.json,
+    colorize:       this.colorize,
+    prettyPrint:    this.prettyPrint,
+    timestamp:      this.timestamp,
+    stringify:      this.stringify
   }) + '\n';
 
   this._size += output.length;
@@ -320,11 +321,11 @@ DailyRotateFile.prototype.stream = function (options) {
   };
 
   stream.destroy = common.tailFile(tail, function (err, line) {
-    
+
     if(err){
       return stream.emit('error',err);
     }
-    
+
     try {
       stream.emit('data', line);
       line = JSON.parse(line);
@@ -333,7 +334,7 @@ DailyRotateFile.prototype.stream = function (options) {
       stream.emit('error', e);
     }
   });
-  
+
   if(stream.resume){
     stream.resume();
   }

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -118,15 +118,16 @@ File.prototype.log = function (level, msg, meta, callback) {
   }
 
   var output = common.log({
-    level:       level,
-    message:     msg,
-    meta:        meta,
-    json:        this.json,
-    colorize:    this.colorize,
-    prettyPrint: this.prettyPrint,
-    timestamp:   this.timestamp,
-    stringify:   this.stringify,
-    label:       this.label
+    level:          level,
+    message:        msg,
+    meta:           meta,
+    levelPadLength: this.levelPadLength,
+    json:           this.json,
+    colorize:       this.colorize,
+    prettyPrint:    this.prettyPrint,
+    timestamp:      this.timestamp,
+    stringify:      this.stringify,
+    label:          this.label
   }) + '\n';
 
   this._size += output.length;
@@ -291,11 +292,11 @@ File.prototype.stream = function (options) {
   };
 
   stream.destroy = common.tailFile(tail, function (err, line) {
-    
+
     if(err){
       return stream.emit('error',err);
     }
-    
+
     try {
       stream.emit('data', line);
       line = JSON.parse(line);

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -84,7 +84,8 @@ Http.prototype.log = function (level, msg, meta, callback) {
     params: {
       level: level,
       message: msg,
-      meta: meta
+      meta: meta,
+      levelPadLength: this.levelPadLength,
     }
   };
 
@@ -99,7 +100,7 @@ Http.prototype.log = function (level, msg, meta, callback) {
       delete meta.auth;
     }
   }
-  
+
   this._request(options, function (err, res, body) {
     if (res && res.statusCode !== 200) {
       err = new Error('HTTP Status Code: ' + res.statusCode);

--- a/lib/winston/transports/memory.js
+++ b/lib/winston/transports/memory.js
@@ -57,16 +57,17 @@ Memory.prototype.log = function (level, msg, meta, callback) {
       output;
 
   output = common.log({
-    colorize:    this.colorize,
-    json:        this.json,
-    level:       level,
-    message:     msg,
-    meta:        meta,
-    stringify:   this.stringify,
-    timestamp:   this.timestamp,
-    prettyPrint: this.prettyPrint,
-    raw:         this.raw,
-    label:       this.label
+    colorize:       this.colorize,
+    json:           this.json,
+    level:          level,
+    levelPadLength: this.levelPadLength,
+    message:        msg,
+    meta:           meta,
+    stringify:      this.stringify,
+    timestamp:      this.timestamp,
+    prettyPrint:    this.prettyPrint,
+    raw:            this.raw,
+    label:          this.label
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -136,6 +136,7 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
   params.timestamp = new Date();
   params.message = msg;
   params.level = level;
+  params.levelPadLength = this.levelPadLength;
 
   req.write(JSON.stringify({
     method: 'log',


### PR DESCRIPTION
This is an attempt to address #352.
- `Transport.levelPadLength` is set directly on the `Transport` instance, if you would rather I make a setter (`Transport.prototype.setLevelPadLength`) I have no problem with that, but I didn't see any setters so I didn't create one.
- I updated the provided `Transport`s to use this, and it is somewhat backwards compatible with third-party `Transport`s in the sense that they won't break or crash, but will act as if `Logger.options.padLevels` was ignored.
- It seems that the tests do not strictly validate the raw output of the log calls, but are rather provided a mean to validate the message content. Hence, I did not write any test.

Let me know if there is anything to modify or if you want to discuss the approach!

Thank you
