### PR TITLE
Update request to 2.40.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cycle": "1.0.x",
     "eyes": "0.1.x",
     "pkginfo": "0.3.x",
-    "request": "2.16.x",
+    "request": "2.40.x",
     "stack-trace": "0.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Versions < 2.40.0 of `request` contain a vulnerable `qs` dependency, see mikeal/request#992
