### PR TITLE
apply label and prettyPrint to JSON output if applicable

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -126,7 +126,7 @@ exports.log = function (options) {
     }
     output         = exports.clone(meta) || {};
     output.level   = options.level;
-    output.label   = options.label;
+    if(options.label) output.label = options.label;
     output.message = options.message.stripColors;
     return JSON.stringify(output);
   }
@@ -141,7 +141,7 @@ exports.log = function (options) {
 
     output         = exports.clone(meta) || {};
     output.level   = options.level;
-    output.label   = options.label;
+    if(options.label) output.label = options.label;
     output.message = options.message;
 
     if (timestamp) {


### PR DESCRIPTION
Hello, couple of simple changes
- `label` wasn't being included in JSON output. perhaps it should be? Seems to make sense to me.
- if `prettyPrint` is set to `true`, pretty print the JSON output.

All test pass.
