### PR TITLE
Exclude functions from cloned meta objects

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -66,7 +66,7 @@ exports.longestElement = function (xs) {
 // Helper method for deep cloning pure JSON objects
 // i.e. JSON objects that are either literals or objects (no Arrays, etc)
 //
-exports.clone = function (obj) {
+exports.clone = function (obj, skipFunctions) {
   // we only need to clone refrence types (Object)
   if (!(obj instanceof Object)) {
     return obj;
@@ -86,7 +86,7 @@ exports.clone = function (obj) {
     else if (typeof obj[i] != 'function') {
       copy[i] = obj[i] instanceof Object ? exports.clone(obj[i]) : obj[i];
     }
-    else if (typeof obj[i] === 'function') {
+    else if (typeof obj[i] === 'function' && !skipFunctions) {
       copy[i] = obj[i];
     }
   }
@@ -114,7 +114,7 @@ exports.log = function (options) {
                   ? options.timestamp
                   : exports.timestamp,
       timestamp   = options.timestamp ? timestampFn() : null,
-      meta        = options.meta !== undefined || options.meta !== null ? exports.clone(cycle.decycle(options.meta)) : null,
+      meta        = options.meta !== undefined || options.meta !== null ? exports.clone(cycle.decycle(options.meta), true) : null,
       output;
 
   //


### PR DESCRIPTION
When we add some custom function to Object.prototype, winston logs that code as well since clone function copies everything from meta object. E.g. cloned {} meta will have Object.prototype functions which is quite useless in meta I believe.

Resolves #420 

Issue:

Defining new Object function:

``` javascript
Object.prototype.hasOwnValue = function(val) {
    for(var prop in this)
    {
        if(this.hasOwnProperty(prop) && this[prop] === val)
        {
            return true;   
        }
    }

    return false;
};
```

Writing some text to log without meta:

``` javascript
logger.log("warn", "Logger initialized");`
```

And the result:
![image](https://cloud.githubusercontent.com/assets/3230176/4178043/17d39bf8-3673-11e4-9850-e298957264b5.png)
