### PR TITLE
Flush buffer again after first "flush" event

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -434,6 +434,11 @@ File.prototype._createStream = function () {
       // and thus can emit the `open` event.
       //
       self.once('flush', function () {
+        // Because "flush" event is based on native stream "drain" event,
+        // logs could be written inbetween "self.flush()" and here
+        // Therefore, we need to flush again to make sure everything is flushed
+        self.flush();
+
         self.opening = false;
         self.emit('open', fullname);
       });


### PR DESCRIPTION
In file transport, before the `FileStream` is opened, logs are buffered to `_buffer`.

Once the `FileStream` is opened, file transport will flush `_buffer` to disk and wait for the first `drain` event from the stream. After the `drain` event is received, `_buffer` will be decommissioned and subsequent write will direct to the `FileStream` itself.

There are race condition when the logs are written inbetween the `flush` call and the `drain` event. Logs written inbetween them will still be stored in `_buffer` (because `self.opening` is still `true`). Because we did not flush the `_buffer` again after `drain`, some logs could be orphaned there forever.

The fix is to flush the `_buffer` again after the `drain` event is received.
