### PR TITLE
Logger.log meta parameter mutation issue

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -11,6 +11,7 @@ var events = require('events'),
     async = require('async'),
     config = require('./config'),
     common = require('./common'),
+    cycle = require('cycle'),
     exception = require('./exception'),
     Stream = require('stream').Stream;
 
@@ -129,7 +130,7 @@ Logger.prototype.log = function (level) {
   }
 
   var callback = typeof args[args.length - 1] === 'function' ? args.pop() : null,
-      meta     = typeof args[args.length - 1] === 'object' ? common.clone(args.pop()) : {},
+      meta     = typeof args[args.length - 1] === 'object' ? common.clone(cycle.decycle(args.pop())) : {},
       msg      = util.format.apply(null, args);
 
   // If we should pad for levels, do so


### PR DESCRIPTION
Without cloning it, configured rewriters will end up synchronously rewriting the original object passed in. 
I do not think it is the intention for logging to mutate its parameters.

Steps to reproduce:
var winston = require('winston');
function addTime(level, msg, meta) {
  meta.time = new Date();
  return meta;
}

var logger = new winston.Logger({
  level: 'info',
  rewriters: [addTime],
  transports: [new winston.transports.Console]
});
var message = 'logging with meta';
var response = {status:"ok"};
logger.info(message, response); // info: logging with meta status=ok, time=Tue Sep 16 2014 16:14:23 GMT+0300 (EEST)
console.log(response); // { status: 'ok', time: Tue Sep 16 2014 16:11:34 GMT+0300 (EEST) }
