### PR TITLE
Module isStream should be isstream

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -13,7 +13,7 @@ var events = require('events'),
     colors = require('colors'),
     common = require('../common'),
     Transport = require('./transport').Transport,
-    isWritable = require('isStream').isWritable,
+    isWritable = require('isstream').isWritable,
     Stream = require('stream').Stream;
 
 //


### PR DESCRIPTION
```
Error: Cannot find module 'isStream'
```

Incorrect case for including isstream modules.
