### PR TITLE
Fix log level ordering for syslog-config.js

### DIFF
--- a/lib/winston/config/syslog-config.js
+++ b/lib/winston/config/syslog-config.js
@@ -9,14 +9,14 @@
 var syslogConfig = exports;
 
 syslogConfig.levels = {
-  emerg: 0,
-  alert: 1,
-  crit: 2,
-  error: 3,
-  warning: 4,
-  notice: 5,
-  info: 6,
-  debug: 7,
+  emerg: 7,
+  alert: 6,
+  crit: 5,
+  error: 4,
+  warning: 3,
+  notice: 2,
+  info: 1,
+  debug: 0,
 };
 
 syslogConfig.colors = {


### PR DESCRIPTION
The logLevel priorities were in reverse.
