### PR TITLE
Fixes #306: Can't set customlevels to my loggers

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -42,12 +42,8 @@ exports.setLevels = function (target, past, current, isDefault) {
 
     // TODO Refactor logging methods into a different object to avoid name clashes
     if (level === 'log') {
-      throw new Error('There cannot be a log level named "log" as it will clash with the method "log"');
-    }
-
-    // TODO Discuss the right approach here
-    if (target[level]) {
-      console.warn('Logging method "' + level + '" overrides an existing property. Consider level renaming.');
+      console.warn('Log level named "log" will clash with the method "log". Consider using a different name.');
+      return;
     }
 
     target[level] = function (msg) {

--- a/test/logger-levels-test.js
+++ b/test/logger-levels-test.js
@@ -137,29 +137,6 @@ vows.describe('winston/logger/levels').addBatch({
           } catch (e)  {
             assert.ifError(e);
           }
-        },
-        "should warn if logging level overrides a method": function (logger) {
-          var that = this;
-
-          // Logging levels
-          var customLevels = {
-            levels: {
-              none: 0,
-              extend: 1,
-            }
-          };
-
-          // TODO Find a better way to do this
-          var oldWarn = console.warn;
-          console.warn = function (x) {
-            assert.equal('Logging method "extend" overrides ' +
-                         'an existing property. Consider level renaming.', x);
-            console.warn = oldWarn;
-          };
-
-          var logger = winston.loggers.add('hello243', { });
-          logger.setLevels(customLevels.levels);
-
         }
       }
     }


### PR DESCRIPTION
(aka `RangeError: Maximum call stack size exceeded` when setting custom levels)

I've tracked the issue and found that `log` method was overriden by one of the levels named `log`. My approach to fix this was creating a check and throwing an exception when a name collision is found. Also, I've added a `console.warn` when a level is overriding an logger object property (such as extend). 

@indexzero @jcrugzz we can discuss on Tuesday:
- [x] If this is the right fix or if we should fix it in another way.
- [x] I'm not 100% convinced that doing `console.warn` when methods are overriden by levels is the right choice. We have to discuss what to do in those cases.
