### PR TITLE
Custom EOL option for FileTransport

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -66,6 +66,7 @@ The File transport should really be the 'Stream' transport since it will accept 
 * __maxFiles:__ Limit the number of files created when the size of the logfile is exceeded.
 * __stream:__ The WriteableStream to write output to.
 * __json:__ If true, messages will be logged as JSON (default true).
+* __eol:__ string indicating the end-of-live characters to use (default to `\n`).
 
 *Metadata:* Logged via util.inspect(meta);
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -74,6 +74,7 @@ var File = exports.File = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.label       = options.label       || null;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
+  this.eol         = options.eol || '\n';
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -130,7 +131,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     timestamp:   this.timestamp,
     stringify:   this.stringify,
     label:       this.label
-  }) + '\n';
+  }) + this.eol;
 
   this._size += output.length;
 


### PR DESCRIPTION
I've some users on Windows, and when I ask them to open the logs, they usually double click (launching notepad.exe) which doesn't handle very well the `\n` thing.

I am planning to use with this:

```
winston.add(winston.transports.File, {
  //...options
  eol: require('os').EOL
});
```

Thanks
