### PR TITLE
fix show levels property for console transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Often in larger, more complex applications it is necessary to have multiple logg
   winston.loggers.add('category1', {
     console: {
       level: 'silly',
-      colorize: 'true',
+      colorize: true,
       label: 'category one'
     },
     file: {
@@ -517,7 +517,7 @@ If you prefer to manage the `Container` yourself you can simply instantiate one:
   container.add('category1', {
     console: {
       level: 'silly',
-      colorize: 'true'
+      colorize: true
     },
     file: {
       filename: '/path/to/some/file'

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -76,7 +76,7 @@ exports.longestElement = function (xs) {
 //
 exports.clone = function (obj) {
   //
-  // We only need to clone refrence types (Object)
+  // We only need to clone reference types (Object)
   //
   if (obj instanceof Error) {
     return obj;

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -73,6 +73,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
     meta:        meta,
     stringify:   this.stringify,
     timestamp:   this.timestamp,
+    showLevel:   this.showLevel,
     prettyPrint: this.prettyPrint,
     raw:         this.raw,
     label:       this.label,

--- a/test/transports/console-test.js
+++ b/test/transports/console-test.js
@@ -32,7 +32,7 @@ vows.describe('winston/transports/console').addBatch({
         assert.equal(line, 'info: \n');
       }
     },
-    "with showLevel on": {
+    "with showLevel off": {
       topic : function() {
         npmTransport.showLevel = false;
         stdMocks.use();
@@ -43,7 +43,7 @@ vows.describe('winston/transports/console').addBatch({
         var output = stdMocks.flush(),
             line   = output.stdout[0];
 
-        assert.equal(line, '\n');
+        assert.equal(line, undefined);
       }
     },
     "with npm levels": {

--- a/test/transports/console-test.js
+++ b/test/transports/console-test.js
@@ -10,13 +10,42 @@ var path = require('path'),
     vows = require('vows'),
     assert = require('assert'),
     winston = require('../../lib/winston'),
-    helpers = require('../helpers');
+    helpers = require('../helpers'),
+    stdMocks = require('std-mocks');
 
 var npmTransport = new (winston.transports.Console)(),
     syslogTransport = new (winston.transports.Console)({ levels: winston.config.syslog.levels });
 
 vows.describe('winston/transports/console').addBatch({
   "An instance of the Console Transport": {
+    "with showLevel on": {
+      topic : function() {
+        npmTransport.showLevel = true;
+        stdMocks.use();
+        npmTransport.log('info', '');
+      },
+      "should have level prepended": function () {
+        stdMocks.restore();
+        var output = stdMocks.flush(),
+            line   = output.stdout[0];
+
+        assert.equal(line, 'info: \n');
+      }
+    },
+    "with showLevel on": {
+      topic : function() {
+        npmTransport.showLevel = false;
+        stdMocks.use();
+        npmTransport.log('info', '');
+      },
+      "should not have level prepended": function () {
+        stdMocks.restore();
+        var output = stdMocks.flush(),
+            line   = output.stdout[0];
+
+        assert.equal(line, '\n');
+      }
+    },
     "with npm levels": {
       "should have the proper methods defined": function () {
         helpers.assertConsole(npmTransport);


### PR DESCRIPTION
looks like this was added in 0.9.0, but doesn't work 