### PR TITLE
Filter metadata along with messages

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -159,8 +159,8 @@ Logger.prototype.log = function (level) {
     if (typeof filtered === 'string')
       msg = filtered;
     else {
-      msg = filtered[0];
-      meta = filtered[1];
+      msg = filtered.msg;
+      meta = filtered.meta;
     }
   });
 
@@ -487,9 +487,9 @@ Logger.prototype.addRewriter = function (rewriter) {
 // ### function addFilter (filter)
 // #### @filter {function} Filter function, called with the message and
 // optional metadata as the two arguments.
-// Expected to return either the filtered message or a list with the filtered
-// message as the first element and the filtered metadata as the second
-// argument.
+// Expected to return either the filtered message or an object with properties:
+//   - msg = the filtered message string
+//   - meta = the filtered metadata object
 //
 Logger.prototype.addFilter = function (filter) {
   this.filters.push(filter);

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -155,7 +155,13 @@ Logger.prototype.log = function (level) {
   });
 
   this.filters.forEach(function(filter) {
-    msg = filter(msg);
+    var filtered = filter(msg, meta);
+    if (typeof filtered === 'string')
+      msg = filtered;
+    else {
+      msg = filtered[0];
+      meta = filtered[1];
+    }
   });
 
   //
@@ -479,8 +485,11 @@ Logger.prototype.addRewriter = function (rewriter) {
 
 //
 // ### function addFilter (filter)
-// #### @filter {function} Filter function, called with the message as single
-// argument, expected to return the filtered message.
+// #### @filter {function} Filter function, called with the message and
+// optional metadata as the two arguments.
+// Expected to return either the filtered message or a list with the filtered
+// message as the first element and the filtered metadata as the second
+// argument.
 //
 Logger.prototype.addFilter = function (filter) {
   this.filters.push(filter);

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -155,7 +155,7 @@ Logger.prototype.log = function (level) {
   });
 
   this.filters.forEach(function(filter) {
-    var filtered = filter(msg, meta);
+    var filtered = filter(msg, meta, level);
     if (typeof filtered === 'string')
       msg = filtered;
     else {

--- a/test/log-filter-test.js
+++ b/test/log-filter-test.js
@@ -44,7 +44,7 @@ vows.describe('winston/logger/filter').addBatch({
     topic: new (winston.Logger)({transports: [
       new (winston.transports.Console)({ level: 'info' })
     ]}),
-    "the addFilter() method filtering only a message": {
+    "the addFilter() method, adding a filter only for the message": {
       topic: function (logger) {
         logger.addFilter(function (msg) {
           return maskCardNumbers(msg);
@@ -54,7 +54,7 @@ vows.describe('winston/logger/filter').addBatch({
       "should add the filter": function (logger) {
         assert.equal(helpers.size(logger.filters), 1);
       },
-      "the log() method": {
+      "the log() method with a filtered message": {
         topic: function (logger) {
           logger.once('logging', this.callback);
           logger.log('info', 'card number 123456789012345 for testing');
@@ -70,14 +70,14 @@ vows.describe('winston/logger/filter').addBatch({
     topic: new (winston.Logger)({transports: [
       new (winston.transports.Console)({ level: 'info' })
     ]}),
-    "the addFilter() method filtering a message and metadata": {
+    "the addFilter() method adding a filter for the message and metadata": {
       topic: function (logger) {
         logger.addFilter(function (msg, meta) {
           return maskSecrets(msg, meta);
         });
         return logger;
       },
-      "the log() method": {
+      "the log() method with a filtered message and filtered metadata": {
         topic: function (logger) {
           logger.once('logging', this.callback);
           logger.log('info',

--- a/test/log-filter-test.js
+++ b/test/log-filter-test.js
@@ -36,7 +36,10 @@ function maskSecrets(msg, meta) {
     return maskedMeta;
   }, {});
 
-  return [msg, meta];
+  return {
+      msg: msg,
+      meta: meta
+  };
 }
 
 vows.describe('winston/logger/filter').addBatch({


### PR DESCRIPTION
I added support for filtering metadata along with messages. You can still add filter functions that only accept the message and return the filtered message, but now you can also add filters that will accept the metadata and return a list of `[filtered_msg, filtered_meta]`.

Also added a unit test for the new filter method.