### PR TITLE
Order of processing options in common.log

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -123,6 +123,15 @@ exports.clone = function (obj) {
 //    }
 //
 exports.log = function (options) {
+  //
+  // Formatter function that operates on `options`. Overrides all other
+  // formatting options. Its return value will be used instead of default
+  // output.
+  //
+  if (typeof options.formatter == 'function') {
+    return String(options.formatter(exports.clone(options)));
+  }
+
   var timestampFn = typeof options.timestamp === 'function'
         ? options.timestamp
         : exports.timestamp,
@@ -188,13 +197,6 @@ exports.log = function (options) {
         ? value.toString('base64')
         : value;
     });
-  }
-
-  //
-  // Remark: this should really be a call to `util.format`.
-  //
-  if (typeof options.formatter == 'function') {
-    return String(options.formatter(exports.clone(options)));
   }
 
   output = timestamp ? timestamp + ' - ' : '';


### PR DESCRIPTION
In common.log, options.formatter takes precedence over other formatting options.