### PR TITLE
Readme: add example "winston.level = 'debug'"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ The default logger is accessible through the winston module directly. Any method
 
   winston.log('info', 'Hello distributed log files!');
   winston.info('Hello again distributed logs');
+
+  winston.level = 'debug';
+  winston.log('debug', 'Now my debug messages are written to console!');
 ```
 
 By default, only the Console transport is set on the default logger. You can add or remove transports via the add() and remove() methods:


### PR DESCRIPTION
I spent about 30 minutes on this and I have seen a one other stack overflow posts where people were asking the same question: how do I set the log level when I am using winston in it's most basic form. So I updated the docs and made a new Stack overflow post for street cred ;)

My post:
http://stackoverflow.com/questions/28620577/npm-winston-set-log-level-for-basic-logging-instance/28620578#28620578

Another post (see the second answer):
http://stackoverflow.com/questions/15535937/how-to-setup-log-level-in-winston-node-js 