### PR TITLE
fix for 'showLevel' value not being used in Console transport (#557) and description of debugStdout usage for Console Transport (#556)

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ The Console transport takes a few simple options:
 * __depth__ Numeric indicating how many times to recurse while formatting the object with `util.inspect` (only used with `prettyPrint: true`) (default null, unlimited)
 * __showLevel:__ Boolean flag indicating if we should prepend output with level (default true).
 * __formatter:__ If function is specified, its return value will be used instead of default output. (default undefined)
+* __debugStdout:__ Boolean flag indicating if 'debug'-level output should be redirected to stdout instead of to stderr. (default false)
 
 *Metadata:* Logged via util.inspect(meta);
 

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -80,7 +80,8 @@ Console.prototype.log = function (level, msg, meta, callback) {
     logstash:    this.logstash,
     depth:       this.depth,
     formatter:   this.formatter,
-    humanReadableUnhandledException: this.humanReadableUnhandledException
+    humanReadableUnhandledException: this.humanReadableUnhandledException,
+    showLevel: this.showLevel
   });
 
   if (level === 'error' || (level === 'debug' && !this.debugStdout) ) {


### PR DESCRIPTION
Although test cases cover the scenario and the tests pass:
```
$ npm test test/transports/console-test.js

> winston@0.9.0 test e:\Work\workspace_private\winston
> vows --spec test/transports/console-test.js


  ♢ winston/transports/console

  An instance of the Console Transport with showLevel on
    ✓ should have level prepended
  An instance of the Console Transport with showLevel off
    ✓ should not have level prepended
```
the [open issue](https://github.com/winstonjs/winston/issues/557) shows that this scenario fails in a "real world" test. Hence this fix.