### PR TITLE
Feature: lodash template formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,9 +938,11 @@ Adding a custom transport (say for one of the datastore on the Roadmap) is actua
 ```
 
 ### Custom Log Format
-To specify custom log format you should set formatter function for transport. Currently supported transports are: Console, File, Memory.
-Options object will be passed to the format function. It's general properties are: timestamp, level, message, meta. Depending on the transport type may be additional properties.
+To specify custom log format you can set a formatter function or a string
+containing a [lodash template](https://lodash.com/docs#template) for the
+transport. Currently supported transports are: Console, File, Memory. An options object will be passed to the format function. It's general properties are: timestamp, level, message, meta. Depending on the transport type may be additional properties.
 
+#### Formatter Function
 ``` js
 var logger = new (winston.Logger)({
   transports: [
@@ -953,6 +955,18 @@ var logger = new (winston.Logger)({
         return options.timestamp() +' '+ options.level.toUpperCase() +' '+ (undefined !== options.message ? options.message : '') +
           (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
       }
+    })
+  ]
+});
+logger.info('Data to log.');
+```
+
+#### Formatter [Lodash Template](https://lodash.com/docs#template)
+``` js
+var logger = new (winston.Logger)({
+  transports: [
+    new (winston.transports.Console)({
+      formatter: "<%-new Date().getTime()%> <%-level.toUpperCase()%> <%-_.isString(message)?message+' ':''%><%-!_.isEmpty(meta)?'\\n'+JSON.stringify(meta):''%>"
     })
   ]
 });

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -11,8 +11,7 @@ var util = require('util'),
     cycle = require('cycle'),
     fs = require('fs'),
     config = require('./config'),
-    _ = require('lodash'),
-    S = require('string');
+    _ = require('lodash');
 
 //
 // ### function setLevels (target, past, current)

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -10,7 +10,9 @@ var util = require('util'),
     crypto = require('crypto'),
     cycle = require('cycle'),
     fs = require('fs'),
-    config = require('./config');
+    config = require('./config'),
+    _ = require('lodash'),
+    S = require('string');
 
 //
 // ### function setLevels (target, past, current)
@@ -193,8 +195,20 @@ exports.log = function (options) {
   //
   // Remark: this should really be a call to `util.format`.
   //
-  if (typeof options.formatter == 'function') {
+  if (_.isFunction(options.formatter)) {
     return String(options.formatter(exports.clone(options)));
+  }
+  else if (_.isString(options.formatter) && (
+    options.formatter.match(_.templateSettings.interpolate) ||
+    options.formatter.match(_.templateSettings.escape) ||
+    options.formatter.match(_.templateSettings.evaluate) )) {
+    return (_.template(options.formatter, {
+      'imports': {
+        // We might expand this later support passing in imports.
+        // Some things are accessible by default like Date, Number, String
+        // and lodash
+      }
+    }))(exports.clone(options));
   }
 
   output = timestamp ? timestamp + ' - ' : '';

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cycle": "1.0.x",
     "eyes": "0.1.x",
     "isstream": "0.1.x",
+    "lodash": "3.3.x",
     "pkginfo": "0.3.x",
     "stack-trace": "0.0.x"
   },

--- a/test/custom-formatter-test.js
+++ b/test/custom-formatter-test.js
@@ -57,6 +57,16 @@ vows.describe('winston/transport/formatter').addBatch({
         json: false,
         formatter: {}
       }),
+      "with value set to string lodash template": assertFileFormatter('customFormatterStringTemplate', {
+        pattern: /^\d{13,} INFO What does the fox say\?/,
+        json: false,
+        formatter: "<%-new Date().getTime()%> <%-level.toUpperCase()%> <%-_.isString(message)?message+' ':''%><%-_.isObject(meta)?'\\n'+JSON.stringify(params.meta):''%>"
+      }),
+      "with value set to string": assertFileFormatter('customFormatterStringPlain', {
+        pattern: /info\:/,
+        json: false,
+        formatter: "My boring string should be ignored"
+      }),
       "and function value with custom format": assertFileFormatter('customFormatter', {
         pattern: /^\d{13,} INFO What does the fox say\?/,
         json: false,


### PR DESCRIPTION
This PR adds the ability to set formatters on Console/File/FileRotation transports as strings that contain a lodash template. I think adding this feature opens up to some very useful opportunities that the entire community would enjoy.

I see a at least few advantages:
1. Formatter code doesn't need to be hard coded - it can be stored as a string in a JSON config file (That's what I've done) 
2. Access to system objects in your template string like Date (ex. Instead of forcing 'timestamp' function/boolean just call `new Date` inside your template string)
3. Access to lodash in your template (ex. _.padRight(meta.tags.logger, 30) )

Here's an full example of a formatter I am using in an API project I'm working on:
```js
{
    "formatter":"<%-new Date().toISOString()%> <%-level.toUpperCase()%>\t<%-_.padRight(meta.tags.logger, 30)%><%=message%>"
}
```

About the changes:
1. added lodash
2. common.log()->checks if the formatters is a string && contains template regex then runs _.template
3. added two unit tests: test that the formatter works and test that the formatter ignores regular strings

Let me know what y'all think!

ps. I have another PR I'll be submitting within the next couple of days too....it's a bit larger :)