### PR TITLE
Fixing showLevel support in the File transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -138,6 +138,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     stringify:   this.stringify,
     label:       this.label,
     depth:       this.depth,
+    showLevel:   this.showLevel,
     formatter:   this.formatter,
     humanReadableUnhandledException: this.humanReadableUnhandledException
   }) + this.eol;


### PR DESCRIPTION
The [Winston documentation](https://github.com/winstonjs/winston?PHPSESSID=02b65463441ebb6580ba41bde8f03247#file-transport) claims that the File transport accepts a `showLevel` parameter that is a

> Boolean flag indicating if we should prepend output with level (default true).

However, this isn't currently true. This parameter is accepted by the File transport, but **not** forwarded to the `common.log` function. This PR is a one-line change that fixes that.