### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ The File transport should really be the 'Stream' transport since it will accept 
 * __depth__ Numeric indicating how many times to recurse while formatting the object with `util.inspect` (only used with `prettyPrint: true`) (default null, unlimited)
 * __logstash:__ If true, messages will be logged as JSON and formatted for logstash (default false).
 * __showLevel:__ Boolean flag indicating if we should prepend output with level (default true).
-* __formatter:__ If function is specified, its return value will be used instead of default output. (default undefined)
+* __formatter:__ If function is specified and `json` is set to `false`, its return value will be used instead of default output. (default undefined)
 * __tailable:__ If true, log files will be rolled based on maxsize and maxfiles, but in ascending order. The __filename__ will always have the most recent log lines. The larger the appended number, the older the log file.
 
 *Metadata:* Logged via util.inspect(meta);


### PR DESCRIPTION
Indicate the the `formatter` option in the file transport has no effect unless the `json` option is set to false.  Took me a while to figure out why it wasn't working, till I saw this stack overflow question: http://stackoverflow.com/questions/18712680/how-can-i-change-the-winston-log-format