### PR TITLE
remove call to clone(meta) before calling custom formatter.

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -194,7 +194,7 @@ exports.log = function (options) {
   // Remark: this should really be a call to `util.format`.
   //
   if (typeof options.formatter == 'function') {
-    return String(options.formatter(exports.clone(options)));
+    return String(options.formatter(options));
   }
 
   output = timestamp ? timestamp + ' - ' : '';

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -72,7 +72,7 @@ exports.longestElement = function (xs) {
 //
 // ### function clone (obj)
 // #### @obj {Object} Object to clone.
-// Helper method for deep cloning JSON objects
+// Helper method for deep cloning objects
 //
 exports.clone = clone;
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -72,7 +72,7 @@ exports.longestElement = function (xs) {
 //
 // ### function clone (obj)
 // #### @obj {Object} Object to clone.
-// Helper method for deep cloning pure JSON objects
+// Helper method for deep cloning JSON objects
 //
 exports.clone = clone;
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -9,7 +9,6 @@
 var util = require('util'),
     crypto = require('crypto'),
     clone = require('clone'),
-    cycle = require('cycle'),
     fs = require('fs'),
     config = require('./config');
 
@@ -98,7 +97,7 @@ exports.log = function (options) {
       timestamp   = options.timestamp ? timestampFn() : null,
       showLevel   = options.showLevel === undefined ? true : options.showLevel,
       meta        = options.meta !== null && options.meta !== undefined && !(options.meta instanceof Error)
-        ? exports.clone(cycle.decycle(options.meta))
+        ? exports.clone(options.meta)
         : options.meta || null,
       output;
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -8,6 +8,7 @@
 
 var util = require('util'),
     crypto = require('crypto'),
+    clone = require('clone'),
     cycle = require('cycle'),
     fs = require('fs'),
     config = require('./config');
@@ -72,40 +73,8 @@ exports.longestElement = function (xs) {
 // ### function clone (obj)
 // #### @obj {Object} Object to clone.
 // Helper method for deep cloning pure JSON objects
-// i.e. JSON objects that are either literals or objects (no Arrays, etc)
 //
-exports.clone = function (obj) {
-  //
-  // We only need to clone reference types (Object)
-  //
-  if (obj instanceof Error) {
-    return obj;
-  }
-  else if (!(obj instanceof Object)) {
-    return obj;
-  }
-  else if (obj instanceof Date) {
-    return obj;
-  }
-
-  var copy = {};
-  for (var i in obj) {
-    if (Array.isArray(obj[i])) {
-      copy[i] = obj[i].slice(0);
-    }
-    else if (obj[i] instanceof Buffer) {
-        copy[i] = obj[i].slice(0);
-    }
-    else if (typeof obj[i] != 'function') {
-      copy[i] = obj[i] instanceof Object ? exports.clone(obj[i]) : obj[i];
-    }
-    else if (typeof obj[i] === 'function') {
-      copy[i] = obj[i];
-    }
-  }
-
-  return copy;
-};
+exports.clone = clone;
 
 //
 // ### function log (options)

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -163,7 +163,7 @@ exports.log = function (options) {
   // Remark: this should really be a call to `util.format`.
   //
   if (typeof options.formatter == 'function') {
-    return String(options.formatter(options));
+    return String(options.formatter(exports.clone(options)));
   }
 
   output = timestamp ? timestamp + ' - ' : '';

--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -10,7 +10,6 @@ var events = require('events'),
     http = require('http'),
     https = require('https'),
     util = require('util'),
-    cycle = require('cycle'),
     common = require('../common'),
     Transport = require('./transport').Transport;
 
@@ -70,7 +69,6 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
   }
 
   var self = this,
-      meta = cycle.decycle(meta),
       message = common.clone(meta),
       options,
       req;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "async": "0.9.x",
+    "clone": "^1.0.1",
     "colors": "1.0.x",
     "cycle": "1.0.x",
     "eyes": "0.1.x",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "async": "0.9.x",
     "clone": "^1.0.1",
     "colors": "1.0.x",
-    "cycle": "1.0.x",
     "eyes": "0.1.x",
     "isstream": "0.1.x",
     "pkginfo": "0.3.x",

--- a/test/custom-formatter-test.js
+++ b/test/custom-formatter-test.js
@@ -73,14 +73,14 @@ vows.describe('winston/transport/formatter').addBatch({
         }
       }),
       "and function value with custom format when a meta object has a circular reference": assertFileFormatter('customFormatterWithCircularReference', {
-        pattern: /^info:/,
+        pattern: /^I did not throw/,
         json: false,
         meta: objectWithCircularReference,
         timestamp: function() {
           return Date.now();
         },
         formatter: function(params) {
-          return 'info:' + params.message + params.meta;
+          return 'I did not throw' + params.message + params.meta;
         }
       }),
     }


### PR DESCRIPTION
Without this fix, passing in any object with a circular reference
as a meta parameter will cause the program to crash with a:

    RangeError: Maximum call stack size exceeded

as common.clone does not handle circular references.  This cloning
is done before the users custom formatter function is called, so
even if they define a format function that returns 'foo', the app
will crash before their function is called, making it difficult to
track down the issue.

I tried modifying the line to call cycle.detect() as happens earlier
in the function, but couldn't get that to work, so I just removed the
call to clone.  Meta is already cloned above in the function so I don't
think it is needed.

If you take out my fix and try to run the test, you'll see the file fails.  If you
comment out the `formatter: function() { ...` line, you'll see it passes again
as it only affects custom formatters.