### PR TITLE
Issue #566 maxFiles doesn't seem to behave as expected

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -555,7 +555,7 @@ File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
   }
 
   oldest = this._created - this.maxFiles;
-  target = path.join(this.dirname, basename + (oldest === 0 ? oldest : '') + ext);
+  target = path.join(this.dirname, basename + (oldest !== 0 ? oldest : '') + ext);
   fs.unlink(target, callback);
 };
 

--- a/test/transports/file-maxfiles-test.js
+++ b/test/transports/file-maxfiles-test.js
@@ -23,7 +23,7 @@ var maxfilesTransport = new winston.transports.File({
   maxsize: 4096,
   maxFiles: 3
 });
-    
+
 vows.describe('winston/transports/file/maxfiles').addBatch({
   "An instance of the File Transport": {
     "when passed a valid filename": {
@@ -43,48 +43,48 @@ vows.describe('winston/transports/file/maxfiles').addBatch({
         topic: function () {
           var that = this,
               created = 0;
-              
+
           function data(ch) {
             return new Array(1018).join(String.fromCharCode(65 + ch));
           };
-      
+
           function logKbytes(kbytes, txt) {
             //
             // With no timestamp and at the info level,
-            // winston adds exactly 7 characters: 
+            // winston adds exactly 7 characters:
             // [info](4)[ :](2)[\n](1)
             //
             for (var i = 0; i < kbytes; i++) {
               maxfilesTransport.log('info', data(txt), null, function () { });
             }
           }
-          
+
           maxfilesTransport.on('logged', function () {
             if (++created === 6) {
               return that.callback();
             }
-            
+
             logKbytes(4, created);
           });
-         
+
           logKbytes(4, created);
         },
         "should be only 3 files called 5.log, 4.log and 3.log": function () {
           for (var num = 0; num < 6; num++) {
             var file = !num ? 'testmaxfiles.log' : 'testmaxfiles' + num + '.log',
                 fullpath = path.join(__dirname, '..', 'fixtures', 'logs', file);
-            
+
             // There should be no files with that name
             if (num >= 0 && num < 3) {
-              return assert.throws(function () {
-                fs.statSync(file);
+              assert.throws(function () {
+                fs.statSync(fullpath);
               }, Error);
-            } 
-
-            // The other files should be exist
-            assert.doesNotThrow(function () {
-              fs.statSync(file);
-            }, Error);
+            } else {
+              // The other files should be exist
+              assert.doesNotThrow(function () {
+                  fs.statSync(fullpath);
+              }, Error);
+            }
           }
         },
         "should have the correct content": function () {

--- a/test/transports/file-maxfiles-test.js
+++ b/test/transports/file-maxfiles-test.js
@@ -82,7 +82,7 @@ vows.describe('winston/transports/file/maxfiles').addBatch({
             } else {
               // The other files should be exist
               assert.doesNotThrow(function () {
-                  fs.statSync(fullpath);
+                fs.statSync(fullpath);
               }, Error);
             }
           }


### PR DESCRIPTION
Issue #566, when using maxFiles (with tailsble = false) deleting the oldest file (in _checkMaxFilesIncrementing) is not behaving as expected.
Calculating the target to delete, the log number should be (oldest !== 0 ? oldest : '') .