### PR TITLE
fix(lib): File Transports Not Emitting Errors On Stream Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ The File transport should really be the 'Stream' transport since it will accept 
 * __showLevel:__ Boolean flag indicating if we should prepend output with level (default true).
 * __formatter:__ If function is specified and `json` is set to `false`, its return value will be used instead of default output. (default undefined)
 * __tailable:__ If true, log files will be rolled based on maxsize and maxfiles, but in ascending order. The __filename__ will always have the most recent log lines. The larger the appended number, the older the log file.
+* __maxRetries:__ The number of stream creation retry attempts before entering a failed state. In a failed state the transport stays active but performs a NOOP on it's log function. (default 2)
 
 *Metadata:* Logged via util.inspect(meta);
 

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -152,6 +152,15 @@ DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
     return callback(null, true);
   }
 
+  //
+  // If failures exceeds maxRetries then we can't access the
+  // stream. In this case we need to perform a noop and return
+  // an error.
+  //
+  if (this._failures >= this.maxRetries) {
+    return callback(new Error('Transport is in a failed state.'));
+  }
+
   var self = this;
 
   var output = common.log({

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -78,6 +78,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
   this.depth       = options.depth       || null;
+  this.maxRetries  = options.maxRetries || 2;
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -92,6 +93,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this._created  = 0;
   this._buffer   = [];
   this._draining = false;
+  this._failures = 0;
 
   var now = new Date();
   this._year   = now.getFullYear();
@@ -467,7 +469,13 @@ DailyRotateFile.prototype._createStream = function () {
       self.filename = target;
       self._stream = fs.createWriteStream(fullname, self.options);
       self._stream.on('error', function(error){
-        self.emit('error', error);
+        if (self._failures < self.maxRetries) {
+          self._createStream();
+          self._failures++;
+        }
+        else {
+          self.emit('error', error);
+        }
       });
 
       //

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -53,6 +53,9 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   else if (options.stream) {
     throwIf('stream', 'filename', 'maxsize');
     this._stream = options.stream;
+    this._stream.on('error', function(error){
+      self.emit('error', error);
+    });
 
     //
     // We need to listen for drain events when
@@ -463,6 +466,9 @@ DailyRotateFile.prototype._createStream = function () {
       self._size = size;
       self.filename = target;
       self._stream = fs.createWriteStream(fullname, self.options);
+      self._stream.on('error', function(error){
+        self.emit('error', error);
+      });
 
       //
       // We need to listen for drain events when

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -125,6 +125,15 @@ File.prototype.log = function (level, msg, meta, callback) {
     return callback(null, true);
   }
 
+  //
+  // If failures exceeds maxRetries then we can't access the
+  // stream. In this case we need to perform a noop and return
+  // an error.
+  //
+  if (this._failures >= this.maxRetries) {
+    return callback(new Error('Transport is in a failed state.'));
+  }
+
   var self = this;
 
   if (typeof msg !== 'string') {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -56,6 +56,9 @@ var File = exports.File = function (options) {
     throwIf('stream', 'filename', 'maxsize');
     this._stream = options.stream;
     this._isStreams2 = isWritable(this._stream);
+    this._stream.on('error', function(error){
+      self.emit('error', error);
+    });
     //
     // We need to listen for drain events when
     // write() returns false. This can make node
@@ -452,6 +455,9 @@ File.prototype._createStream = function () {
       self.filename = target;
       self._stream = fs.createWriteStream(fullname, self.options);
       self._isStreams2 = isWritable(self._stream);
+      self._stream.on('error', function(error){
+        self.emit('error', error);
+      });
       //
       // We need to listen for drain events when
       // write() returns false. This can make node

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -83,6 +83,7 @@ var File = exports.File = function (options) {
   this.tailable    = options.tailable    || false;
   this.depth       = options.depth       || null;
   this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
+  this.maxRetries  = options.maxRetries || 2;
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -98,6 +99,7 @@ var File = exports.File = function (options) {
   this._buffer   = [];
   this._draining = false;
   this._opening  = false;
+  this._failures = 0;
 };
 
 //
@@ -456,7 +458,13 @@ File.prototype._createStream = function () {
       self._stream = fs.createWriteStream(fullname, self.options);
       self._isStreams2 = isWritable(self._stream);
       self._stream.on('error', function(error){
-        self.emit('error', error);
+        if (self._failures < self.maxRetries) {
+          self._createStream();
+          self._failures++;
+        }
+        else {
+          self.emit('error', error);
+        }
       });
       //
       // We need to listen for drain events when

--- a/test/transports/daily-rotate-file-test.js
+++ b/test/transports/daily-rotate-file-test.js
@@ -22,6 +22,9 @@ var stream = fs.createWriteStream(
       filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfilename.log'),
       datePattern: '.yyyy-MM-dd'
     }),
+    failedDailyRotateFileTransport = new (winston.transports.DailyRotateFile)({
+      filename: path.join(__dirname, '..', 'fixtures', 'logs', 'dir404', 'testfile.log')
+    }),
     streamTransport = new (winston.transports.DailyRotateFile)({ stream: stream });
 
 vows.describe('winston/transports/daily-rotate-file').addBatch({
@@ -34,6 +37,14 @@ vows.describe('winston/transports/daily-rotate-file').addBatch({
         assert.isNull(err);
         assert.isTrue(logged);
       })
+    },
+    "when passed an invalid filename": {
+      "should have proper methods defined": function () {
+        helpers.assertDailyRotateFile(failedDailyRotateFileTransport);
+      },
+      "should enter noop failed state": function () {
+        helpers.assertFailedTransport(failedDailyRotateFileTransport);
+      }
     },
     "when passed a valid file stream": {
       "should have the proper methods defined": function () {

--- a/test/transports/file-test.js
+++ b/test/transports/file-test.js
@@ -22,6 +22,9 @@ var stream = fs.createWriteStream(
     fileTransport = new (winston.transports.File)({
       filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfilename.log')
     }),
+    failedFileTransport = new (winston.transports.File)({
+      filename: path.join(__dirname, '..', 'fixtures', 'logs', 'dir404', 'testfile.log')
+    }),
     streamTransport = new (winston.transports.File)({ stream: stream });
 
 vows.describe('winston/transports/file').addBatch({
@@ -34,6 +37,14 @@ vows.describe('winston/transports/file').addBatch({
         assert.isNull(err);
         assert.isTrue(logged);
       })
+    },
+    "when passed an invalid filename": {
+      "should have proper methods defined": function () {
+        helpers.assertFile(failedFileTransport);
+      },
+      "should enter noop failed state": function () {
+        helpers.assertFailedTransport(failedFileTransport);
+      }
     },
     "when passed a valid file stream": {
       "should have the proper methods defined": function () {


### PR DESCRIPTION
In this commit file & daily-rotate-file add an 'error' event listener on
their stream so that we can emit those errors from the transport.

fixes #511