### PR TITLE
File-Transport should be using the operating systems end of line, not the Unix one, by default.

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -15,7 +15,8 @@ var events = require('events'),
     common = require('../common'),
     Transport = require('./transport').Transport,
     isWritable = require('isstream').isWritable,
-    Stream = require('stream').Stream;
+    Stream = require('stream').Stream,
+    osEOL = require('os').EOL;
 
 //
 // ### function File (options)
@@ -76,7 +77,7 @@ var File = exports.File = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.label       = options.label       || null;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
-  this.eol         = options.eol || '\n';
+  this.eol         = options.eol || osEOL;
   this.tailable    = options.tailable    || false;
   this.depth       = options.depth       || null;
   this.showLevel   = options.showLevel === undefined ? true : options.showLevel;


### PR DESCRIPTION
I don't see any advantages, if the file-transport logs with '\n' by default. It would make more sense, if it uses the OS EOLs if none is explicitly specified.