### PR TITLE
DailyRotateFile transport: availability to prepend formatted date to log name

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,9 +706,10 @@ The File transport should really be the 'Stream' transport since it will accept 
 
 The Daily Rotate File transport lets you rotate log files based on time.
 
-In addition to the options accepted by the File transport, the Daily Rotate File Transport also accepts the following option.
+In addition to the options accepted by the File transport, the Daily Rotate File Transport also accepts the following options:
 
-* __datePattern:__ Defines rolling time of a log file and suffix appended to the file. Following meta characters can be used: `yy`, `yyyy`, `M`, `MM`, `d`, `dd`, `H`, `HH`, `m`, `mm`. The default pattern is `'.yyyy-MM-dd'`. Rotation time of the log file will be equal to the smallest given time token timespan, so `'.yyyy-MM-ddTHH'` will rotate logfile every hour. You can not rotate files more frequent then every minute.
+* __datePattern:__ Defines rolling time of a log file and suffix appended/prepended to the file. Following meta characters can be used: `yy`, `yyyy`, `M`, `MM`, `d`, `dd`, `H`, `HH`, `m`, `mm`. The default pattern is `'.yyyy-MM-dd'`. Rotation time of the log file will be equal to the smallest given time token timespan, so `'.yyyy-MM-ddTHH'` will rotate logfile every hour. You can not rotate files more frequent then every minute.
+* __prepend:__ Defines if the rolling time of the log file should be prepended at the begging of the filename (default `false`)
 
 ### Loggly Transport
 ``` js

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -75,7 +75,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
   this.depth       = options.depth       || null;
-	this.prepend     = options.prepend     || false;
+  this.prepend     = options.prepend     || false;
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -563,13 +563,13 @@ DailyRotateFile.prototype._getFile = function (inc) {
 // Returns the log filename depending on `this.prepend` option value
 //
 DailyRotateFile.prototype._getFilename = function () {
-	var formattedDate = this.getFormattedDate();
-
-	if (this.prepend) {
-		return formattedDate + this._basename;
-	}
-
-	return this._basename + formattedDate;
+  var formattedDate = this.getFormattedDate();
+  
+  if (this.prepend) {
+    return formattedDate + this._basename;
+  }
+  
+  return this._basename + formattedDate;
 };
 
 //

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -75,6 +75,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
   this.depth       = options.depth       || null;
+	this.prepend     = options.prepend     || false;
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -224,7 +225,7 @@ DailyRotateFile.prototype.query = function (options, callback) {
   }
 
   // TODO when maxfilesize rotate occurs
-  var file = path.join(this.dirname, this._basename + this.getFormattedDate()),
+  var file = path.join(this.dirname, this._getFilename()),
       options = this.normalizeQuery(options),
       buff = '',
       results = [],
@@ -318,7 +319,7 @@ DailyRotateFile.prototype.query = function (options, callback) {
 // Returns a log stream for this transport. Options object is optional.
 //
 DailyRotateFile.prototype.stream = function (options) {
-  var file = path.join(this.dirname, this._basename + this.getFormattedDate()),
+  var file = path.join(this.dirname, this._getFilename()),
       options = options || {},
       stream = new Stream;
 
@@ -530,7 +531,7 @@ DailyRotateFile.prototype._createStream = function () {
 //
 DailyRotateFile.prototype._getFile = function (inc) {
   var self = this,
-      filename = this._basename + this.getFormattedDate(),
+      filename = this._getFilename(),
       remaining;
 
   if (inc) {
@@ -555,6 +556,20 @@ DailyRotateFile.prototype._getFile = function (inc) {
   return this._created
     ? filename + '.' + this._created
     : filename;
+};
+
+//
+// ### @private function _getFilename ()
+// Returns the log filename depending on `this.prepend` option value
+//
+DailyRotateFile.prototype._getFilename = function () {
+	var formattedDate = this.getFormattedDate();
+
+	if (this.prepend) {
+		return formattedDate + this._basename;
+	}
+
+	return this._basename + formattedDate;
 };
 
 //

--- a/test/transports/daily-rotate-file-test.js
+++ b/test/transports/daily-rotate-file-test.js
@@ -25,14 +25,14 @@ var stream = fs.createWriteStream(
     streamTransport = new (winston.transports.DailyRotateFile)({ stream: stream });
 
 var streamPrepended = fs.createWriteStream(
-		path.join(__dirname, '..', 'fixtures', 'logs', '2015-03-21_testfile.log')
-		),
-		dailyRotateFileTransportPrepended = new (winston.transports.DailyRotateFile)({
-			filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfilename.log'),
-			datePattern: 'yyyy-MM-dd_',
-			prepend: true
-		}),
-		streamTransportPrepended = new (winston.transports.DailyRotateFile)({ stream: streamPrepended });
+      path.join(__dirname, '..', 'fixtures', 'logs', '2015-03-21_testfile.log')
+    ), 
+    dailyRotateFileTransportPrepended = new (winston.transports.DailyRotateFile)({
+      filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfilename.log'), 
+      datePattern: 'yyyy-MM-dd_', 
+      prepend: true
+    }), 
+    streamTransportPrepended = new (winston.transports.DailyRotateFile)({ stream: streamPrepended });
 
 vows.describe('winston/transports/daily-rotate-file').addBatch({
   "An instance of the Daily Rotate File Transport": {
@@ -54,21 +54,21 @@ vows.describe('winston/transports/daily-rotate-file').addBatch({
         assert.isTrue(logged);
       })
     }
-  },
-	"An instance of the Daily Rotate File Transport with 'prepend' option": {
-		"when passed a valid filename": {
-			"the log() method": helpers.testNpmLevels(dailyRotateFileTransportPrepended, "should respond with true", function (ign, err, logged) {
-				assert.isNull(err);
-				assert.isTrue(logged);
-			})
-		},
-		"when passed a valid file stream": {
-			"the log() method": helpers.testNpmLevels(streamTransportPrepended, "should respond with true", function (ign, err, logged) {
-				assert.isNull(err);
-				assert.isTrue(logged);
-			})
-		}
-	}
+  }, 
+  "An instance of the Daily Rotate File Transport with 'prepend' option": {
+    "when passed a valid filename": {
+      "the log() method": helpers.testNpmLevels(dailyRotateFileTransportPrepended, "should respond with true", function (ign, err, logged) {
+        assert.isNull(err);
+        assert.isTrue(logged);
+      })
+    }, 
+    "when passed a valid file stream": {
+      "the log() method": helpers.testNpmLevels(streamTransportPrepended, "should respond with true", function (ign, err, logged) {
+        assert.isNull(err);
+        assert.isTrue(logged);
+      })
+    }
+  }
 }).addBatch({
   "These tests have a non-deterministic end": {
     topic: function () {
@@ -82,10 +82,10 @@ vows.describe('winston/transports/daily-rotate-file').addBatch({
   "An instance of the Daily Rotate File Transport": transport(winston.transports.DailyRotateFile, {
     filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfile.log'),
     datePattern: '.2012-12-18'
-  }),
-	"An instance of the Daily Rotate File Transport with 'prepend' option": transport(winston.transports.DailyRotateFile, {
-		filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfile.log'),
-		datePattern: '2015-03-21_',
-		prepend: true
-	})
+  }), 
+  "An instance of the Daily Rotate File Transport with 'prepend' option": transport(winston.transports.DailyRotateFile, {
+    filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfile.log'), 
+    datePattern: '2015-03-21_', 
+    prepend: true
+  })
 }).export(module);

--- a/test/transports/daily-rotate-file-test.js
+++ b/test/transports/daily-rotate-file-test.js
@@ -24,6 +24,16 @@ var stream = fs.createWriteStream(
     }),
     streamTransport = new (winston.transports.DailyRotateFile)({ stream: stream });
 
+var streamPrepended = fs.createWriteStream(
+		path.join(__dirname, '..', 'fixtures', 'logs', '2015-03-21_testfile.log')
+		),
+		dailyRotateFileTransportPrepended = new (winston.transports.DailyRotateFile)({
+			filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfilename.log'),
+			datePattern: 'yyyy-MM-dd_',
+			prepend: true
+		}),
+		streamTransportPrepended = new (winston.transports.DailyRotateFile)({ stream: streamPrepended });
+
 vows.describe('winston/transports/daily-rotate-file').addBatch({
   "An instance of the Daily Rotate File Transport": {
     "when passed a valid filename": {
@@ -44,7 +54,21 @@ vows.describe('winston/transports/daily-rotate-file').addBatch({
         assert.isTrue(logged);
       })
     }
-  }
+  },
+	"An instance of the Daily Rotate File Transport with 'prepend' option": {
+		"when passed a valid filename": {
+			"the log() method": helpers.testNpmLevels(dailyRotateFileTransportPrepended, "should respond with true", function (ign, err, logged) {
+				assert.isNull(err);
+				assert.isTrue(logged);
+			})
+		},
+		"when passed a valid file stream": {
+			"the log() method": helpers.testNpmLevels(streamTransportPrepended, "should respond with true", function (ign, err, logged) {
+				assert.isNull(err);
+				assert.isTrue(logged);
+			})
+		}
+	}
 }).addBatch({
   "These tests have a non-deterministic end": {
     topic: function () {
@@ -58,5 +82,10 @@ vows.describe('winston/transports/daily-rotate-file').addBatch({
   "An instance of the Daily Rotate File Transport": transport(winston.transports.DailyRotateFile, {
     filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfile.log'),
     datePattern: '.2012-12-18'
-  })
+  }),
+	"An instance of the Daily Rotate File Transport with 'prepend' option": transport(winston.transports.DailyRotateFile, {
+		filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfile.log'),
+		datePattern: '2015-03-21_',
+		prepend: true
+	})
 }).export(module);


### PR DESCRIPTION
Hello,

I'm using winston in a project where is preferable that log files had the rolling date prepended instead of appended to the log name, so I added an option (`prepend`) to be available to configure this (the formatted date-time is still appended by default).

I hope you find it useful!