### PR TITLE
Fix rendering of stack traces

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -239,9 +239,7 @@ exports.log = function (options) {
         delete meta.stack;
         delete meta.trace;
         output += ' ' + exports.serialize(meta);
-        output += '\n' + stack.map(function (s) {
-          return s + '\n';
-        });
+        output += '\n' + stack.join('\n');
       } else {
         output += ' ' + exports.serialize(meta);
       }

--- a/test/humanReadableUnhandledException-test.js
+++ b/test/humanReadableUnhandledException-test.js
@@ -33,7 +33,6 @@ vows.describe('winston/transport/humanReadableUnhandledException').addBatch({
           var msg = transport.writeOutput[0];
           assert.notEqual(-1, msg.indexOf('stack: date=dummy date, process=dummy, os=dummy\n'));
           assert.notEqual(-1, msg.indexOf(meta.stack[0] + '\n'));
-          assert.notEqual(-1, msg.indexOf(',' + meta.stack[1]));
         });
       }
     }


### PR DESCRIPTION
When humanReadableUnhandledException is true, render stack traces without trailing commas. This makes possible for an IDE to have clickable stack traces