### PR TITLE
Fixed name of winston logger in README.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ Adding a custom transport (say for one of the datastore on the Roadmap) is actua
   var util = require('util'),
       winston = require('winston');
 
-  var CustomLogger = winston.transports.CustomerLogger = function (options) {
+  var CustomLogger = winston.transports.CustomLogger = function (options) {
     //
     // Name this logger
     //


### PR DESCRIPTION
Just made a simple change to the README.txt file to add consistency to the name of the Custom Logger in the code example.  Suspect it was just a typo in the first place.