### PR TITLE
align message level

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -118,6 +118,7 @@ exports.clone = function (obj) {
 //      message:   'message to serialize',
 //      meta:      'additional logging metadata to serialize',
 //      colorize:  false, // Colorizes output (only if `.json` is false)
+//      align:     false  // Align message level.
 //      timestamp: true   // Adds a timestamp to the serialized message
 //      label:     'label to prepend the message'
 //    }
@@ -204,6 +205,7 @@ exports.log = function (options) {
       : options.level;
   }
 
+  output += (options.align) ? '\t' : '';
   output += (timestamp || showLevel) ? ': ' : '';
   output += options.label ? ('[' + options.label + '] ') : '';
   output += options.colorize === 'all' || options.colorize === 'message'

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -30,6 +30,7 @@ var Console = exports.Console = function (options) {
   this.logstash    = options.logstash    || false;
   this.debugStdout = options.debugStdout || false;
   this.depth       = options.depth       || null;
+  this.align       = options.align       || false;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -79,6 +80,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
     logstash:    this.logstash,
     depth:       this.depth,
     formatter:   this.formatter,
+    align:       this.align,
     humanReadableUnhandledException: this.humanReadableUnhandledException
   });
 

--- a/test/transports/console-test.js
+++ b/test/transports/console-test.js
@@ -63,6 +63,34 @@ vows.describe('winston/transports/console').addBatch({
         assert.isNull(err);
         assert.isTrue(logged);
       })
+    },
+    "with align on": {
+      topic : function() {
+        npmTransport.align = true;
+        stdMocks.use();
+        npmTransport.log('info', '');
+      },
+      "should have logs aligned": function () {
+        stdMocks.restore();
+        var output = stdMocks.flush(),
+            line   = output.stdout[0];
+
+        assert.equal(line, 'info\011: \n');
+      }
+    },
+    "with align off": {
+      topic : function() {
+        npmTransport.align = false;
+        stdMocks.use();
+        npmTransport.log('info', '');
+      },
+      "should not have logs aligned": function () {
+        stdMocks.restore();
+        var output = stdMocks.flush(),
+            line   = output.stdout[0];
+
+        assert.equal(line, 'info: \n');
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
![screen shot 2015-05-08 at 10 51 10](https://cloud.githubusercontent.com/assets/2096101/7533263/49337e7c-f570-11e4-92c3-7c2c54bf22ac.png)

Ideally would be aligned calculating the level with more characters as reference and adding the spaces necessary for each level to be align. 