### PR TITLE
Added ability to log only the specified level through levelOnly flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# winston [![Build Status](https://secure.travis-ci.org/winstonjs/winston.svg?branch=master)](http://travis-ci.org/winstonjs/winston)
+
+IMPORTANT: 
+THis is a fork of the original winston package.
+The fork is at https://github.com/damianof/winston
+This version adds a levelOnly option to make winston log only the specified level.
+I needed this functionality for my current projects.
+There is also a pending pull request I created on the author branch. If the pull request is accepted, then I will remove this package.
+
 
 A multi-transport async logging library for node.js. <span style="font-size:28px; font-weight:bold;">&quot;CHILL WINSTON! ... I put it in the logs.&quot;</span>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ THis is a fork of the original winston package.
 The fork is at https://github.com/damianof/winston
 This version adds a levelOnly option to make winston log only the specified level.
 I needed this functionality for my current projects.
-There is also a pending pull request I created on the author branch. If the pull request is accepted, then I will remove this package.
+There is also a pending pull request I created on the author branch (https://github.com/winstonjs/winston/pull/627).
+If the pull request is accepted, then I will remove this package from npm as soon as the original winston package will be updated with this feature.
 
 
 A multi-transport async logging library for node.js. <span style="font-size:28px; font-weight:bold;">&quot;CHILL WINSTON! ... I put it in the logs.&quot;</span>

--- a/README.md
+++ b/README.md
@@ -119,12 +119,14 @@ var logger = new (winston.Logger)({
     new (winston.transports.File)({
       name: 'info-file',
       filename: 'filelog-info.log',
-      level: 'info'
+      level: 'info',
+	  levelOnly: false // if true, will only log the specified level, if false will log from the specified level and above
     }),
     new (winston.transports.File)({
       name: 'error-file',
       filename: 'filelog-error.log',
-      level: 'error'
+      level: 'error',
+	  levelOnly: false // if true, will only log the specified level, if false will log from the specified level and above
     })
   ]
 });

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -181,8 +181,17 @@ Logger.prototype.log = function (level) {
   //
   function emit(name, next) {
     var transport = self.transports[name];
-    if ((transport.level && self.levels[transport.level] <= self.levels[level])
-      || (!transport.level && self.levels[self.level] <= self.levels[level])) {
+	
+	var proceed = false;
+	if (transport.levelOnly == true){
+		 proceed = ((transport.level && self.levels[transport.level] == self.levels[level])
+      		|| (!transport.level && self.levels[self.level] == self.levels[level]));
+	} else {
+		proceed = ((transport.level && self.levels[transport.level] <= self.levels[level])
+      		|| (!transport.level && self.levels[self.level] <= self.levels[level]));
+	}
+	
+    if (proceed) {
       transport.log(level, msg, meta, function (err) {
         if (err) {
           err.transport = transport;

--- a/lib/winston/transports/transport.js
+++ b/lib/winston/transports/transport.js
@@ -23,7 +23,8 @@ var Transport = exports.Transport = function (options) {
   this.raw       = options.raw    || false;
   this.name      = options.name   || this.name;
   this.formatter = options.formatter;
-
+  this.levelOnly = options.levelOnly || false;
+  
   //
   // Do not set a default level. When `level` is falsey on any
   // `Transport` instance, any `Logger` instance uses the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "winston",
+  "name": "winston-levelonly",
   "description": "A multi-transport async logging library for Node.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-levelonly",
   "description": "A multi-transport async logging library for Node.js",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>"

--- a/test/levelOnly-test.js
+++ b/test/levelOnly-test.js
@@ -1,0 +1,42 @@
+/**
+	* This is a visual test. You have to look in the console to confirm only expected output is emitted.
+*/
+'use strict';
+var winston = require('../lib/winston');
+winston.default.transports.console.colorize = true;
+
+winston.default.transports.console.levelOnly = false;
+winston.default.transports.console.level = 'info';//should log only warn and error
+
+var refErr = new ReferenceError('This is bad');
+var fn = function(){
+	try{
+		winston.silly('---some silly we need to log - should not log this---');// should not log this
+		winston.debug('---some debug we need to log - should not log this---');// should not log this
+		winston.info('---some info we need to log - should not log this---');// should not log this
+		winston.warn('some warn we need to log');
+		winston.error('some error we need to log');
+	} catch(e) {
+		throw refErr;
+	}
+};
+console.log('_____ First Test _____');
+fn();
+
+
+winston.default.transports.console.levelOnly = true;
+winston.default.transports.console.level = 'debug';//should log only debug
+var refErr = new ReferenceError('This is bad');
+var fn = function(){
+	try{
+		winston.silly('---some silly we need to log - should not log this---');// should not log this
+		winston.debug('some debug we need to log');
+		winston.info('---some info we need to log - should not log this---');// should not log this
+		winston.warn('---some warn we need to log - should not log this---');// should not log this
+		winston.error('---some error we need to log - should not log this---');// should not log this
+	} catch(e) {
+		throw refErr;
+	}
+};
+console.log('_____ Second Test _____');
+fn();

--- a/test/levelOnly-test.js
+++ b/test/levelOnly-test.js
@@ -3,10 +3,20 @@
 */
 'use strict';
 var winston = require('../lib/winston');
-winston.default.transports.console.colorize = true;
 
-winston.default.transports.console.levelOnly = false;
-winston.default.transports.console.level = 'info';//should log only warn and error
+//winston.default.transports.console.colorize = true;
+//winston.default.transports.console.levelOnly = false;
+//winston.default.transports.console.level = 'info';//should log only warn and error
+
+winston.remove(winston.transports.Console);
+winston.add(winston.transports.Console, {
+	level: 'info',
+	levelOnly: false,
+	colorize: true,
+	'timestamp': function() {
+		return (new Date());
+	}
+});
 
 var refErr = new ReferenceError('This is bad');
 var fn = function(){
@@ -24,8 +34,19 @@ console.log('_____ First Test _____');
 fn();
 
 
-winston.default.transports.console.levelOnly = true;
-winston.default.transports.console.level = 'debug';//should log only debug
+// winston.default.transports.console.levelOnly = true;
+// winston.default.transports.console.level = 'debug';//should log only debug
+
+winston.remove(winston.transports.Console);
+winston.add(winston.transports.Console, {
+	level: 'debug',
+	levelOnly: true,
+	colorize: true,
+	'timestamp': function() {
+		return (new Date());
+	}
+});
+
 var refErr = new ReferenceError('This is bad');
 var fn = function(){
 	try{


### PR DESCRIPTION
Added ability to log only the specified level (not just that level and above as per default functionality).

This is done through levelOnly boolean flag.
If levelOnly=false, standard functionality will execute (the specified level and above will be logged).
If levelOnly=true, only the specified level will be logged.

var logger = new (winston.Logger)({
  transports: [
    new (winston.transports.File)({
      name: 'warnings-file',
      filename: 'filelog-warnings.log',
      level: 'warn',
      levelOnly: true // if true, will only log the specified level, if false will log from the specified level and above
    }),
    new (winston.transports.File)({
      name: 'error-file',
      filename: 'filelog-error.log',
      level: 'error',
	  levelOnly: false // if true, will only log the specified level, if false will log from the specified level and above
    })
  ]
});

Here is an example	 with console:

var winston = require('../lib/winston');
winston.default.transports.console.colorize = true;

// levelOnly flag set to true:
winston.default.transports.console.levelOnly = true;
winston.default.transports.console.level = 'debug';//should log only debug
winston.silly('---some silly we need to log - should not log this---');// should not log this
winston.debug('some debug we need to log - only this will be logged');
winston.info('---some info we need to log - should not log this---');// should not log this
winston.warn('---some warn we need to log - should not log this---');// should not log this
winston.error('---some error we need to log - should not log this---');// should not log this