### PR TITLE
Update file.js - objectMode writable stream

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -119,7 +119,7 @@ File.prototype.name = 'file';
 // ### function log (level, msg, [meta], callback)
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
-// #### @meta {Object_} **Optional** Additional metadata to attach
+// #### @meta {Object} **Optional** Additional metadata to attach
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -119,7 +119,7 @@ File.prototype.name = 'file';
 // ### function log (level, msg, [meta], callback)
 // #### @level {string} Level at which to log the message.
 // #### @msg {string} Message to log
-// #### @meta {Object} **Optional** Additional metadata to attach
+// #### @meta {Object_} **Optional** Additional metadata to attach
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
@@ -158,8 +158,11 @@ File.prototype.log = function (level, msg, meta, callback) {
     depth:       this.depth,
     formatter:   this.formatter,
     humanReadableUnhandledException: this.humanReadableUnhandledException
-  }) + this.eol;
-
+  });
+  
+  if(typeof output === 'string') {
+      output += this.eol;
+  }
 
   if (!this.filename) {
     //


### PR DESCRIPTION
Appending this.eol explicitly to the result that common.log returns makes the output always become a string. That eliminates the possibility of piping js objects to the writable stream (which could be extremely handy for some cases). The proposed change won't break the code as the only case for the output not to be a string would be if this.stringify is explicitly rewritten to return objects (i.e. transport.stringify = function(obj){return obj})