### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,5 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/winstonjs/winston/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/