### PR TITLE
Format timestamp and meta independently of log function and allow timestamp to be passed into to log function 

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -125,18 +125,20 @@ exports.clone = function (obj) {
 exports.log = function (options) {
   var timestamp   = exports.formatTimestamp(options.timestamp),
       showLevel   = options.showLevel === undefined ? true : options.showLevel,
-      meta        = options.meta !== null && options.meta !== undefined && !(options.meta instanceof Error)
-        ? exports.clone(cycle.decycle(options.meta))
-        : options.meta || null,
+      meta        = exports.formatMeta(options.meta, {
+                      raw: options.raw,
+                      json: options.json,
+                      logstash: options.logstash,
+                      prettyPrint: options.prettyPrint,
+                      depth: options.depth,
+                      colorize: options.colorize
+                    }),
       output;
 
   //
   // raw mode is intended for outputing winston as streaming JSON to STDOUT
   //
   if (options.raw) {
-    if (typeof meta !== 'object' && meta != null) {
-      meta = { meta: meta };
-    }
     output         = exports.clone(meta) || {};
     output.level   = options.level;
     output.message = options.message.stripColors;
@@ -147,10 +149,6 @@ exports.log = function (options) {
   // json mode is intended for pretty printing multi-line json to the terminal
   //
   if (options.json || true === options.logstash) {
-    if (typeof meta !== 'object' && meta != null) {
-      meta = { meta: meta };
-    }
-
     output         = exports.clone(meta) || {};
     output.level   = options.level;
     output.message = output.message || '';
@@ -208,39 +206,7 @@ exports.log = function (options) {
     : options.message;
 
   if (meta !== null && meta !== undefined) {
-    if (meta && meta instanceof Error && meta.stack) {
-      meta = meta.stack;
-    }
-
-    if (typeof meta !== 'object') {
-      output += ' ' + meta;
-    }
-    else if (Object.keys(meta).length > 0) {
-      if (typeof options.prettyPrint === 'function') {
-        output += ' ' + options.prettyPrint(meta);
-      } else if (options.prettyPrint) {
-        output += ' ' + '\n' + util.inspect(meta, false, options.depth || null, options.colorize);
-      } else if (
-        options.humanReadableUnhandledException
-          && Object.keys(meta).length === 5
-          && meta.hasOwnProperty('date')
-          && meta.hasOwnProperty('process')
-          && meta.hasOwnProperty('os')
-          && meta.hasOwnProperty('trace')
-          && meta.hasOwnProperty('stack')) {
-
-        //
-        // If meta carries unhandled exception data serialize the stack nicely
-        //
-        var stack = meta.stack;
-        delete meta.stack;
-        delete meta.trace;
-        output += ' ' + exports.serialize(meta);
-        output += '\n' + stack.join('\n');
-      } else {
-        output += ' ' + exports.serialize(meta);
-      }
-    }
+    output += ' ' + meta;
   }
 
   return output;
@@ -403,4 +369,52 @@ exports.formatTimestamp = function (timestamp) {
   timestamp = timestamp ? timestamp : null;
 
   return timestamp;
+};
+
+exports.formatMeta = function (meta, options) {
+  var meta = options.meta !== null && options.meta !== undefined && !(options.meta instanceof Error)
+    ? exports.clone(cycle.decycle(options.meta))
+    : options.meta || null
+
+  if (typeof meta !== 'object' && meta != null) {
+    if (options.raw || options.json || true === options.logstash) {
+      meta = { meta: meta };
+    } else {
+      if (meta && meta instanceof Error && meta.stack) {
+        meta = meta.stack;
+      }
+
+      if (typeof meta !== 'object') {
+        null;
+      }
+      else if (Object.keys(meta).length > 0) {
+        if (typeof options.prettyPrint === 'function') {
+          meta = options.prettyPrint(meta);
+        } else if (options.prettyPrint) {
+          meta = '\n' + util.inspect(meta, false, options.depth || null, options.colorize);
+        } else if (
+          options.humanReadableUnhandledException
+            && Object.keys(meta).length === 5
+            && meta.hasOwnProperty('date')
+            && meta.hasOwnProperty('process')
+            && meta.hasOwnProperty('os')
+            && meta.hasOwnProperty('trace')
+            && meta.hasOwnProperty('stack')) {
+
+          //
+          // If meta carries unhandled exception data serialize the stack nicely
+          //
+          var stack = meta.stack;
+          delete meta.stack;
+          delete meta.trace;
+          meta  = exports.serialize(meta);
+          meta += '\n' + stack.join('\n');
+        } else {
+          meta = exports.serialize(meta);
+        }
+      }
+    }
+  }
+
+  return meta;
 };

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -123,10 +123,7 @@ exports.clone = function (obj) {
 //    }
 //
 exports.log = function (options) {
-  var timestampFn = typeof options.timestamp === 'function'
-        ? options.timestamp
-        : exports.timestamp,
-      timestamp   = options.timestamp ? timestampFn() : null,
+  var timestamp   = exports.formatTimestamp(options.timestamp),
       showLevel   = options.showLevel === undefined ? true : options.showLevel,
       meta        = options.meta !== null && options.meta !== undefined && !(options.meta instanceof Error)
         ? exports.clone(cycle.decycle(options.meta))
@@ -393,4 +390,17 @@ exports.tailFile = function tail(options, callback) {
   }
 
   return destroy;
+};
+
+exports.formatTimestamp = function (timestamp) {
+  if (typeof timestamp === 'function') {
+    timestamp = timestamp();
+  } else if (timestamp && new Date(timestamp).toString() !== 'Invalid Date') {
+    null;
+  } else {
+    timestamp = exports.timestamp;
+  }
+  timestamp = timestamp ? timestamp : null;
+
+  return timestamp;
 };

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -116,9 +116,17 @@ Logger.prototype.extend = function (target) {
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Logger.prototype.log = function (level) {
+Logger.prototype.log = function (timestamp, level) {
   var self = this,
-      args = Array.prototype.slice.call(arguments, 1);
+      args;
+
+  if (new Date(timestamp).toString() === 'Invalid Date') {
+    args = Array.prototype.slice.call(arguments, 1);
+    level = timestamp;
+    timestamp = undefined;
+  } else {
+    args = Array.prototype.slice.call(arguments, 2);
+  }
 
   while(args[args.length - 1] === null) {
     args.pop();
@@ -183,7 +191,7 @@ Logger.prototype.log = function (level) {
     var transport = self.transports[name];
     if ((transport.level && self.levels[transport.level] <= self.levels[level])
       || (!transport.level && self.levels[self.level] <= self.levels[level])) {
-      transport.log(level, msg, meta, function (err) {
+      transport.log(timestamp, level, msg, meta, function (err) {
         if (err) {
           err.transport = transport;
           cb(err);

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -56,7 +56,7 @@ Console.prototype.name = 'console';
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Console.prototype.log = function (level, msg, meta, callback) {
+Console.prototype.log = function (timestamp, level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -71,7 +71,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
     message:     msg,
     meta:        meta,
     stringify:   this.stringify,
-    timestamp:   this.timestamp,
+    timestamp:   timestamp || this.timestamp,
     showLevel:   this.showLevel,
     prettyPrint: this.prettyPrint,
     raw:         this.raw,

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -148,7 +148,7 @@ DailyRotateFile.prototype.name = 'dailyRotateFile';
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
+DailyRotateFile.prototype.log = function (timestamp, level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -171,7 +171,7 @@ DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
     json:        this.json,
     colorize:    this.colorize,
     prettyPrint: this.prettyPrint,
-    timestamp:   this.timestamp,
+    timestamp:   timestamp || this.timestamp,
     label:       this.label,
     stringify:   this.stringify,
     showLevel:   this.showLevel,

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -123,7 +123,7 @@ File.prototype.name = 'file';
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-File.prototype.log = function (level, msg, meta, callback) {
+File.prototype.log = function (timestamp, level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -151,7 +151,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     logstash:    this.logstash,
     colorize:    this.colorize,
     prettyPrint: this.prettyPrint,
-    timestamp:   this.timestamp,
+    timestamp:   timestamp || this.timestamp,
     showLevel:   this.showLevel,
     stringify:   this.stringify,
     label:       this.label,

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -80,7 +80,7 @@ Http.prototype._request = function (options, callback) {
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Http.prototype.log = function (level, msg, meta, callback) {
+Http.prototype.log = function (timestamp, level, msg, meta, callback) {
   var self = this;
 
   if (typeof meta === 'function') {
@@ -180,7 +180,7 @@ Http.prototype.query = function (options, callback) {
 //
 Http.prototype.stream = function (options) {
   options = options || {};
-  
+
   var self = this,
       stream = new Stream,
       req,

--- a/lib/winston/transports/memory.js
+++ b/lib/winston/transports/memory.js
@@ -49,7 +49,7 @@ Memory.prototype.name = 'memory';
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Memory.prototype.log = function (level, msg, meta, callback) {
+Memory.prototype.log = function (timestamp, level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -64,7 +64,7 @@ Memory.prototype.log = function (level, msg, meta, callback) {
     message:     msg,
     meta:        meta,
     stringify:   this.stringify,
-    timestamp:   this.timestamp,
+    timestamp:   timestamp || this.timestamp,
     prettyPrint: this.prettyPrint,
     raw:         this.raw,
     label:       this.label,

--- a/lib/winston/transports/webhook.js
+++ b/lib/winston/transports/webhook.js
@@ -64,7 +64,7 @@ Webhook.prototype.name = 'webhook';
 // #### @callback {function} Continuation to respond to when complete.
 // Core logging method exposed to Winston. Metadata is optional.
 //
-Webhook.prototype.log = function (level, msg, meta, callback) {
+Webhook.prototype.log = function (timestamp, level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
   }
@@ -133,7 +133,7 @@ Webhook.prototype.log = function (level, msg, meta, callback) {
   //
 
   var params = common.clone(meta) || {};
-  params.timestamp = new Date();
+  params.timestamp = timestamp || new Date();
   params.message = msg;
   params.level = level;
 


### PR DESCRIPTION
I had a need to be able to format both timestamp and meta without making a call to common.log, so I separated those into separate functions.

The bigger issue is that I'm doing some logging directly within a database and also feeding the logging info back to node for console, etc. logging.  I want the timestamp to be consistent across both the database and other logging, so I want to be able to feed the timestamp directly into the call to log.

I made an effort to ensure that if the timestamp is not passed into the call to log, then existing functionality remains the same.