### PR TITLE
Bump async version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tools"
   ],
   "dependencies": {
-    "async": "0.9.x",
+    "async": "~1.0.0",
     "colors": "1.0.x",
     "cycle": "1.0.x",
     "eyes": "0.1.x",


### PR DESCRIPTION
https://github.com/caolan/async/blob/master/CHANGELOG.md#v100

`async` is now actively develop on `1.0.0`, the upgrade shouldn't includes breaking changes.