### PR TITLE
Add separator to filenames ending in numbers

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -550,6 +550,20 @@ File.prototype._createStream = function () {
 };
 
 
+//
+// ### @private function _appendFileNumber ()
+// Append number to filename, separating with period if filename
+// ends with a number to avoid nonsense numbers, e.g.
+// 'log-2015-07-14.log' -> 'log-2015-07-14.1.log', not
+// 'log-2015-07-141.log'
+//
+File.prototype._appendFileNumber = function (basename, num) {
+  return /\d$/.test(basename) ?
+    (basename + '.' + num) :
+    (basename + num);
+};
+
+
 File.prototype._incFile = function (callback) {
   var ext = path.extname(this._basename),
       basename = path.basename(this._basename, ext),
@@ -572,16 +586,21 @@ File.prototype._incFile = function (callback) {
 //
 File.prototype._getFile = function () {
   var ext = path.extname(this._basename),
-      basename = path.basename(this._basename, ext);
+    basename = path.basename(this._basename, ext);
 
   //
   // Caveat emptor (indexzero): rotationFormat() was broken by design
   // when combined with max files because the set of files to unlink
   // is never stored.
   //
-  return !this.tailable && this._created
-    ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
-    : basename + ext;
+  if (!this.tailable && this._created) {
+    return this._appendFileNumber(
+      basename,
+      (this.rotationFormat ? this.rotationFormat() : this._created)
+    ) + ext;
+  } else {
+    return basename + ext;
+  }
 };
 
 //
@@ -593,9 +612,13 @@ File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
   var oldest, target,
     self = this;
 
+  var appendBaseName = /\d$/.test(basename) ?
+    basename + '.' :
+    basename;
+
   if (self.zippedArchive) {
-    self._archive = path.join(self.dirname, basename +
-        ((self._created === 1) ? '' : self._created-1) +
+    self._archive = path.join(self.dirname,
+        ((self._created === 1) ? basename : (appendBaseName + self._created-1)) +
         ext);
   }
 
@@ -606,7 +629,8 @@ File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
   }
 
   oldest = self._created - self.maxFiles;
-  target = path.join(self.dirname, basename + (oldest !== 0 ? oldest : '') + ext +
+  target = path.join(self.dirname,
+    (oldest !== 0 ? (appendBaseName + oldest) : basename ) + ext +
     (self.zippedArchive ? '.gz' : ''));
   fs.unlink(target, callback);
 };
@@ -626,17 +650,19 @@ File.prototype._checkMaxFilesTailable = function (ext, basename, callback) {
   if (!this.maxFiles)
     return;
 
+  var appendBaseName = /\d$/.test(basename) ? (basename + '.') : basename;
+
   for (var x = this.maxFiles - 1; x > 0; x--) {
     tasks.push(function (i) {
       return function (cb) {
-        var tmppath = path.join(self.dirname, basename + (i - 1) + ext +
+        var tmppath = path.join(self.dirname, appendBaseName + (i - 1) + ext +
           (self.zippedArchive ? '.gz' : ''));
         fs.exists(tmppath, function (exists) {
           if (!exists) {
             return cb(null);
           }
 
-          fs.rename(tmppath, path.join(self.dirname, basename + i + ext +
+          fs.rename(tmppath, path.join(self.dirname, appendBaseName + i + ext +
             (self.zippedArchive ? '.gz' : '')), cb);
         });
       };
@@ -644,12 +670,12 @@ File.prototype._checkMaxFilesTailable = function (ext, basename, callback) {
   }
 
   if (self.zippedArchive) {
-    self._archive = path.join(self.dirname, basename + 1 + ext);
+    self._archive = path.join(self.dirname, appendBaseName + 1 + ext);
   }
   async.series(tasks, function (err) {
     fs.rename(
       path.join(self.dirname, basename + ext),
-      path.join(self.dirname, basename + 1 + ext),
+      path.join(self.dirname, appendBaseName + 1 + ext),
       callback
     );
   });


### PR DESCRIPTION
Currently, if you have Winston configured to append numbers to filenames, it can end up looking pretty funky if your filenames already end in numbers, e.g.

`mylog-2015-07-14.log` -> `mylog-2015-07-141.log`

Add a separator to avoid munging numbers.

`mylog-2015-07-14.log` -> `mylog-2015-07-14.1.log`