### PR TITLE
Fixed event subscription on transport close

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -394,7 +394,7 @@ File.prototype.close = function () {
     this._stream.end();
     this._stream.destroySoon();
 
-    this._stream.once('drain', function () {
+    this._stream.once('finish', function () {
       self.emit('flush');
       self.emit('closed');
     });


### PR DESCRIPTION
We should listen to 'finish' event from stream to close transport.