### PR TITLE
Flush buffer again after first "flush" event in daily-rotate-file transport

### DIFF
--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -501,6 +501,11 @@ DailyRotateFile.prototype._createStream = function () {
       // and thus can emit the `open` event.
       //
       self.once('flush', function () {
+        // Because "flush" event is based on native stream "drain" event,
+        // logs could be written inbetween "self.flush()" and here
+        // Therefore, we need to flush again to make sure everything is flushed
+        self.flush();
+
         self.opening = false;
         self.emit('open', fullname);
       });


### PR DESCRIPTION
Same fix as 0c28041f6d62d515f5cda870c5ac450ff4a9fba1 (related to #150) but for the daily-rotate-file transport.

Will fix #567 