### PR TITLE
Add an endOfLine option to the console transport

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -30,6 +30,7 @@ var Console = exports.Console = function (options) {
   this.logstash    = options.logstash    || false;
   this.debugStdout = options.debugStdout || false;
   this.depth       = options.depth       || null;
+  this.endOfLine   = options.endOfLine   || '\n';
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -83,9 +84,9 @@ Console.prototype.log = function (level, msg, meta, callback) {
   });
 
   if (level === 'error' || (level === 'debug' && !this.debugStdout) ) {
-    process.stderr.write(output + '\n');
+    process.stderr.write(output + this.endOfLine);
   } else {
-    process.stdout.write(output + '\n');
+    process.stdout.write(output + this.endOfLine);
   }
 
   //

--- a/test/transports/console-test.js
+++ b/test/transports/console-test.js
@@ -63,6 +63,20 @@ vows.describe('winston/transports/console').addBatch({
         assert.isNull(err);
         assert.isTrue(logged);
       })
+    },
+    "with end-of-line": {
+      topic : function() {
+        npmTransport.endOfLine = 'X';
+        stdMocks.use();
+        npmTransport.log('info', '');
+      },
+      "should have end-of-line character appended": function () {
+        stdMocks.restore();
+        var output = stdMocks.flush(),
+            line   = output.stdout[0];
+
+        assert.equal(line, 'info: X');
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
It would sometimes be useful to be able to customise the EOL character used by the Console transport.  My use case is where I want to log a task as started, then add a check once it's completed.  Setting `endOfLine` to `''` would allow this:

```
log.info('Running task... ');
doTask();
log.info('done\n');
```

An alternative would be to allow setting the end-of-line character per log (e.g. `log.info('Running task...', {eol: ''})`), but I don't see a sane way of doing that while allowing string interpolation.