### PR TITLE
Do not modify Error or Date objects when logging. Fixes #610

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -80,17 +80,25 @@ exports.clone = function (obj) {
   //
   // We only need to clone reference types (Object)
   //
+  var copy = {};
+
   if (obj instanceof Error) {
-    return obj;
+    // With potential custom Error objects, this might not be exactly correct,
+    // but probably close-enough for purposes of this lib.
+    copy = new Error(obj.message);
+    for (var i in obj) {
+      copy[i] = obj[i];
+    }
+
+    return copy;
   }
   else if (!(obj instanceof Object)) {
     return obj;
   }
   else if (obj instanceof Date) {
-    return obj;
+    return new Date(obj.getTime());
   }
 
-  var copy = {};
   for (var i in obj) {
     if (Array.isArray(obj[i])) {
       copy[i] = obj[i].slice(0);

--- a/test/transports/file-test.js
+++ b/test/transports/file-test.js
@@ -92,6 +92,42 @@ vows.describe('winston/transports/file').addBatch({
     }
   }
 }).addBatch({
+  "Error object in metadata #610": {
+    topic: function () {
+      var myErr = new Error("foo");
+
+      fileTransport.log('info', 'test message', myErr, this.callback.bind(this, null, myErr));
+    },
+    "should not be modified": function (err, myErr) {
+      assert.equal(myErr.message, "foo");
+      // Not sure if this is the best possible way to check if additional props appeared
+      assert.deepEqual(Object.getOwnPropertyNames(myErr), Object.getOwnPropertyNames(new Error("foo")));
+    }
+  }
+}).addBatch({
+  "Date object in metadata": {
+    topic: function () {
+      var obj = new Date(1000);
+
+      fileTransport.log('info', 'test message', obj, this.callback.bind(this, null, obj));
+    },
+    "should not be modified": function (err, obj) {
+      // Not sure if this is the best possible way to check if additional props appeared
+      assert.deepEqual(Object.getOwnPropertyNames(obj), Object.getOwnPropertyNames(new Date()));
+    }
+  }
+}).addBatch({
+  "Plain object in metadata": {
+    topic: function () {
+      var obj = { message: "foo" };
+
+      fileTransport.log('info', 'test message', obj, this.callback.bind(this, null, obj));
+    },
+    "should not be modified": function (err, obj) {
+      assert.deepEqual(obj, { message: "foo" });
+    }
+  }
+}).addBatch({
   "An instance of the File Transport": transport(winston.transports.File, {
     filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfile.log')
   })

--- a/test/winston-test.js
+++ b/test/winston-test.js
@@ -93,6 +93,36 @@ vows.describe('winston').addBatch({
             assert.isTrue(typeof winston[key] === 'undefined');
           });
       }
+    },
+    "the clone() method": {
+      "with Error object": {
+        topic: function () {
+          var original = new Error("foo");
+          original.name = "bar";
+
+          var copy = winston.clone(original);
+
+          return { original: original, copy: copy };
+        },
+        "should clone the value": function (result) {
+          assert.notEqual(result.original, result.copy);
+          assert.equal(result.original.message, result.copy.message);
+          assert.equal(result.original.name, result.copy.name);
+        }
+      },
+      "with Date object": {
+        topic: function () {
+          var original = new Date(1000);
+
+          var copy = winston.clone(original);
+
+          return { original: original, copy: copy };
+        },
+        "should clone the value": function (result) {
+          assert.notEqual(result.original, result.copy);
+          assert.equal(result.original.getTime(), result.copy.getTime());
+        }
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
Hi,

Ended up taking a stab on this issue, but not 100% sure if this is the best way to do it (and is this all) since I'm not that familiar with this lib - review welcome, luckily there's not much changes.

My concerns/notes:

- I'm on Windows, where a bunch of tests fails locally, but I'm sure travis will tell if things are ok or not
- Are there perf concerns here in some envs since now creating new `Error`/`Date` objects - probably not a real issue
- Are tests in logical places and as good as they can be (not familiar with vows previously either)

The fact that these types of objects were returned as-is from `clone()` in the first place puzzles me a bit, wonder if there was something non-obvious behind that approach.

In case there's something to fix, please let me know.
