### PR TITLE
File transport bug so latest logs show up in desc order

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -43,8 +43,8 @@ var File = exports.File = function (options) {
   if (options.filename || options.dirname) {
     throwIf('filename or dirname', 'stream');
     this._basename = this.filename = options.filename
-        ? path.basename(options.filename)
-        : 'winston.log';
+      ? path.basename(options.filename)
+      : 'winston.log';
 
     this.dirname = options.dirname || path.dirname(options.filename);
     this.options = options.options || { flags: 'a' };
@@ -145,21 +145,21 @@ File.prototype.log = function (level, msg, meta, callback) {
   }
 
   var output = common.log({
-        level:       level,
-        message:     msg,
-        meta:        meta,
-        json:        this.json,
-        logstash:    this.logstash,
-        colorize:    this.colorize,
-        prettyPrint: this.prettyPrint,
-        timestamp:   this.timestamp,
-        showLevel:   this.showLevel,
-        stringify:   this.stringify,
-        label:       this.label,
-        depth:       this.depth,
-        formatter:   this.formatter,
-        humanReadableUnhandledException: this.humanReadableUnhandledException
-      }) + this.eol;
+    level:       level,
+    message:     msg,
+    meta:        meta,
+    json:        this.json,
+    logstash:    this.logstash,
+    colorize:    this.colorize,
+    prettyPrint: this.prettyPrint,
+    timestamp:   this.timestamp,
+    showLevel:   this.showLevel,
+    stringify:   this.stringify,
+    label:       this.label,
+    depth:       this.depth,
+    formatter:   this.formatter,
+    humanReadableUnhandledException: this.humanReadableUnhandledException
+  });
 
 
   if (!this.filename) {
@@ -198,8 +198,8 @@ File.prototype._write = function(data, callback) {
   if (this._isStreams2) {
     this._stream.write(data);
     return callback && process.nextTick(function () {
-          callback(null, true);
-        });
+      callback(null, true);
+    });
   }
 
   // If this is a file write stream, we could use the builtin
@@ -245,8 +245,8 @@ File.prototype.query = function (options, callback) {
     }
     if (!callback) return;
     return err.code !== 'ENOENT'
-        ? callback(err)
-        : callback(null, results);
+      ? callback(err)
+      : callback(null, results);
   });
 
   stream.on('data', function (data) {
@@ -586,8 +586,8 @@ File.prototype._getFile = function () {
   // is never stored.
   //
   return !this.tailable && this._created
-      ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
-      : basename + ext;
+    ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
+    : basename + ext;
 };
 
 //
@@ -597,7 +597,7 @@ File.prototype._getFile = function () {
 //
 File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
   var oldest, target,
-      self = this;
+    self = this;
 
   if (self.zippedArchive) {
     self._archive = path.join(self.dirname, basename +
@@ -613,7 +613,7 @@ File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
 
   oldest = self._created - self.maxFiles;
   target = path.join(self.dirname, basename + (oldest !== 0 ? oldest : '') + ext +
-      (self.zippedArchive ? '.gz' : ''));
+    (self.zippedArchive ? '.gz' : ''));
   fs.unlink(target, callback);
 };
 
@@ -636,14 +636,14 @@ File.prototype._checkMaxFilesTailable = function (ext, basename, callback) {
     tasks.push(function (i) {
       return function (cb) {
         var tmppath = path.join(self.dirname, basename + (i - 1) + ext +
-            (self.zippedArchive ? '.gz' : ''));
+          (self.zippedArchive ? '.gz' : ''));
         fs.exists(tmppath, function (exists) {
           if (!exists) {
             return cb(null);
           }
 
           fs.rename(tmppath, path.join(self.dirname, basename + i + ext +
-              (self.zippedArchive ? '.gz' : '')), cb);
+            (self.zippedArchive ? '.gz' : '')), cb);
         });
       };
     }(x));
@@ -654,9 +654,9 @@ File.prototype._checkMaxFilesTailable = function (ext, basename, callback) {
   }
   async.series(tasks, function (err) {
     fs.rename(
-        path.join(self.dirname, basename + ext),
-        path.join(self.dirname, basename + 1 + ext),
-        callback
+      path.join(self.dirname, basename + ext),
+      path.join(self.dirname, basename + 1 + ext),
+      callback
     );
   });
 };

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -43,8 +43,8 @@ var File = exports.File = function (options) {
   if (options.filename || options.dirname) {
     throwIf('filename or dirname', 'stream');
     this._basename = this.filename = options.filename
-      ? path.basename(options.filename)
-      : 'winston.log';
+        ? path.basename(options.filename)
+        : 'winston.log';
 
     this.dirname = options.dirname || path.dirname(options.filename);
     this.options = options.options || { flags: 'a' };
@@ -145,21 +145,21 @@ File.prototype.log = function (level, msg, meta, callback) {
   }
 
   var output = common.log({
-    level:       level,
-    message:     msg,
-    meta:        meta,
-    json:        this.json,
-    logstash:    this.logstash,
-    colorize:    this.colorize,
-    prettyPrint: this.prettyPrint,
-    timestamp:   this.timestamp,
-    showLevel:   this.showLevel,
-    stringify:   this.stringify,
-    label:       this.label,
-    depth:       this.depth,
-    formatter:   this.formatter,
-    humanReadableUnhandledException: this.humanReadableUnhandledException
-  }) + this.eol;
+        level:       level,
+        message:     msg,
+        meta:        meta,
+        json:        this.json,
+        logstash:    this.logstash,
+        colorize:    this.colorize,
+        prettyPrint: this.prettyPrint,
+        timestamp:   this.timestamp,
+        showLevel:   this.showLevel,
+        stringify:   this.stringify,
+        label:       this.label,
+        depth:       this.depth,
+        formatter:   this.formatter,
+        humanReadableUnhandledException: this.humanReadableUnhandledException
+      }) + this.eol;
 
 
   if (!this.filename) {
@@ -198,8 +198,8 @@ File.prototype._write = function(data, callback) {
   if (this._isStreams2) {
     this._stream.write(data);
     return callback && process.nextTick(function () {
-      callback(null, true);
-    });
+          callback(null, true);
+        });
   }
 
   // If this is a file write stream, we could use the builtin
@@ -245,21 +245,14 @@ File.prototype.query = function (options, callback) {
     }
     if (!callback) return;
     return err.code !== 'ENOENT'
-      ? callback(err)
-      : callback(null, results);
+        ? callback(err)
+        : callback(null, results);
   });
 
   stream.on('data', function (data) {
     var data = (buff + data).split(/\n+/),
         l = data.length - 1,
         i = 0;
-
-    if (options.order === 'desc') {
-      data = data.reverse();
-      if (data[0] === '') {
-        data.push(data.shift()); // At the end of the array is an emtpy string
-      }
-    }
 
     for (; i < l; i++) {
       if (!options.start || row >= options.start) {
@@ -273,6 +266,9 @@ File.prototype.query = function (options, callback) {
 
   stream.on('close', function () {
     if (buff) add(buff, true);
+    if (options.order === 'desc') {
+      results = results.reverse();
+    }
     if (callback) callback(null, results);
   });
 
@@ -288,7 +284,8 @@ File.prototype.query = function (options, callback) {
   }
 
   function push(log) {
-    if (options.rows && results.length >= options.rows) {
+    if (options.rows && results.length >= options.rows
+        && options.order != 'desc') {
       if (stream.readable) {
         stream.destroy();
       }
@@ -303,6 +300,11 @@ File.prototype.query = function (options, callback) {
       log = obj;
     }
 
+    if (options.order === 'desc') {
+      if (results.length >= options.rows) {
+        results.shift();
+      }
+    }
     results.push(log);
   }
 
@@ -584,8 +586,8 @@ File.prototype._getFile = function () {
   // is never stored.
   //
   return !this.tailable && this._created
-    ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
-    : basename + ext;
+      ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
+      : basename + ext;
 };
 
 //
@@ -595,7 +597,7 @@ File.prototype._getFile = function () {
 //
 File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
   var oldest, target,
-    self = this;
+      self = this;
 
   if (self.zippedArchive) {
     self._archive = path.join(self.dirname, basename +
@@ -611,7 +613,7 @@ File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
 
   oldest = self._created - self.maxFiles;
   target = path.join(self.dirname, basename + (oldest !== 0 ? oldest : '') + ext +
-    (self.zippedArchive ? '.gz' : ''));
+      (self.zippedArchive ? '.gz' : ''));
   fs.unlink(target, callback);
 };
 
@@ -634,14 +636,14 @@ File.prototype._checkMaxFilesTailable = function (ext, basename, callback) {
     tasks.push(function (i) {
       return function (cb) {
         var tmppath = path.join(self.dirname, basename + (i - 1) + ext +
-          (self.zippedArchive ? '.gz' : ''));
+            (self.zippedArchive ? '.gz' : ''));
         fs.exists(tmppath, function (exists) {
           if (!exists) {
             return cb(null);
           }
 
           fs.rename(tmppath, path.join(self.dirname, basename + i + ext +
-            (self.zippedArchive ? '.gz' : '')), cb);
+              (self.zippedArchive ? '.gz' : '')), cb);
         });
       };
     }(x));
@@ -652,9 +654,9 @@ File.prototype._checkMaxFilesTailable = function (ext, basename, callback) {
   }
   async.series(tasks, function (err) {
     fs.rename(
-      path.join(self.dirname, basename + ext),
-      path.join(self.dirname, basename + 1 + ext),
-      callback
+        path.join(self.dirname, basename + ext),
+        path.join(self.dirname, basename + 1 + ext),
+        callback
     );
   });
 };

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -159,7 +159,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     depth:       this.depth,
     formatter:   this.formatter,
     humanReadableUnhandledException: this.humanReadableUnhandledException
-  });
+  }) + this.eol;
 
 
   if (!this.filename) {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -254,6 +254,13 @@ File.prototype.query = function (options, callback) {
         l = data.length - 1,
         i = 0;
 
+    if (options.order === 'desc') {
+      data = data.reverse();
+      if (data[0] === '') {
+        data.push(data.shift()); // At the end of the array is an emtpy string
+      }
+    }
+
     for (; i < l; i++) {
       if (!options.start || row >= options.start) {
         add(data[i]);
@@ -266,9 +273,6 @@ File.prototype.query = function (options, callback) {
 
   stream.on('close', function () {
     if (buff) add(buff, true);
-    if (options.order === 'desc') {
-      results = results.reverse();
-    }
     if (callback) callback(null, results);
   });
 


### PR DESCRIPTION
This fixes #536 so that when you select desc order the latest logs will be returned as would be expected.