### PR TITLE
Update transports.js

### DIFF
--- a/lib/winston/transports.js
+++ b/lib/winston/transports.js
@@ -12,30 +12,30 @@ var fs = require('fs'),
 
 var transports = exports;
 
-transports.__defineGetter__('CONSOLE', function () {
-    return require('./transports/console.js')[name];
+transports.__defineGetter__('Console', function () {
+    return require('./transports/console.js')['Console'];
 });
 
-transports.__defineGetter__('FILE', function () {
-    return require('./transports/file.js')[name];
+transports.__defineGetter__('File', function () {
+    return require('./transports/file.js')['File'];
 });
-transports.__defineGetter__('HTTP', function () {
-    return require('./transports/http.js')[name];
-});
-
-transports.__defineGetter__('MEMORY', function () {
-    return require('./transports/memory.js')[name];
+transports.__defineGetter__('Http', function () {
+    return require('./transports/http.js')['Http'];
 });
 
-transports.__defineGetter__('TRANSPORT', function () {
-    return require('./transports/transport.js')[name];
+transports.__defineGetter__('Memory', function () {
+    return require('./transports/memory.js')['Memory'];
 });
 
-transports.__defineGetter__('WEBHOOK', function () {
-    return require('./transports/webhook.js')[name];
+transports.__defineGetter__('Transport', function () {
+    return require('./transports/transport.js')['Transport'];
 });
 
-transports.__defineGetter__('DAILY-ROTATE-FILE', function () {
-    return require('./transports/daily-rotate-file.js')[name];
+transports.__defineGetter__('Webhook', function () {
+    return require('./transports/webhook.js')['Webhook'];
+});
+
+transports.__defineGetter__('Daily-Rotate-File', function () {
+    return require('./transports/daily-rotate-file.js')['Daily-Rotate-File'];
 });
 

--- a/lib/winston/transports.js
+++ b/lib/winston/transports.js
@@ -12,23 +12,30 @@ var fs = require('fs'),
 
 var transports = exports;
 
-//
-// Setup all transports as lazy-loaded getters.
-//
-fs.readdirSync(path.join(__dirname, 'transports')).forEach(function (file) {
-  var transport = file.replace('.js', ''),
-      name  = common.capitalize(transport);
-
-  if (transport === 'transport') {
-    return;
-  }
-  else if (~transport.indexOf('-')) {
-    name = transport.split('-').map(function (part) {
-      return common.capitalize(part);
-    }).join('');
-  }
-
-  transports.__defineGetter__(name, function () {
-    return require('./transports/' + transport)[name];
-  });
+transports.__defineGetter__('CONSOLE', function () {
+    return require('./transports/console.js')[name];
 });
+
+transports.__defineGetter__('FILE', function () {
+    return require('./transports/file.js')[name];
+});
+transports.__defineGetter__('HTTP', function () {
+    return require('./transports/http.js')[name];
+});
+
+transports.__defineGetter__('MEMORY', function () {
+    return require('./transports/memory.js')[name];
+});
+
+transports.__defineGetter__('TRANSPORT', function () {
+    return require('./transports/transport.js')[name];
+});
+
+transports.__defineGetter__('WEBHOOK', function () {
+    return require('./transports/webhook.js')[name];
+});
+
+transports.__defineGetter__('DAILY-ROTATE-FILE', function () {
+    return require('./transports/daily-rotate-file.js')[name];
+});
+


### PR DESCRIPTION
This makes winston consumable by browserify - which does a static analysis of dependencies to bundle javascript.

See: https://github.com/jaws-framework/JAWS/issues/253