### PR TITLE
Fixed the priority values for syslog levels

### DIFF
--- a/lib/winston/config/syslog-config.js
+++ b/lib/winston/config/syslog-config.js
@@ -9,23 +9,23 @@
 var syslogConfig = exports;
 
 syslogConfig.levels = {
-  emerg: 0,
-  alert: 1,
-  crit: 2,
-  error: 3,
-  warning: 4,
-  notice: 5,
-  info: 6,
-  debug: 7,
+  debug: 0,
+  info: 1,
+  notice: 2,
+  warning: 3,
+  error: 4,
+  crit: 5,
+  alert: 6,
+  emerg: 7,
 };
 
 syslogConfig.colors = {
-  emerg: 'red',
-  alert: 'yellow',
-  crit: 'red',
-  error: 'red',
-  warning: 'red',
-  notice: 'yellow',
-  info: 'green',
   debug: 'blue',
+  info: 'green',
+  notice: 'yellow',
+  warning: 'red',
+  error: 'red',
+  crit: 'red',
+  alert: 'yellow',
+  emerg: 'red',
 };


### PR DESCRIPTION
The syslog levels (debug, info, notice, warning, error, crit, alert) defined by `winston.config.syslog.levels` appear to be reversed. For example, when the syslog level is set to `notice`, then `notice`, `warning`, `error`, `crit`, and `alert` messages should be displayed. However, the reverse is happening: `debug`, `info`, and `notice` are displayed and the others are not.

The following test code illustrates this error:
```
var winston = require('winston');

// Uncomment the next line to fix the bug
// winston.config.syslog.levels = { debug: 0, info: 1, notice: 2, warning: 3, error: 4, crit: 5, alert: 6, emerg: 7 };

winston.setLevels(winston.config.syslog.levels);
winston.level = 'notice';

winston.debug('This should NOT be logged');
winston.info('This should NOT be logged');
winston.notice('This should be logged');
winston.warning('This should be logged');
```

This pull request fixes the logging levels for `winston.config.syslog.levels` so it behaves correctly.

Note: The default logging levels for Winston (`silly, debug, verbose, info, warn, error`) work perfectly. It's only the syslog levels that are defined backwards.