### PR TITLE
Fix handling of meta objects in log messages

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -165,13 +165,13 @@ Logger.prototype.log = function (level) {
   //
   //    logger.info('No interpolation symbols', 'ok', 'why', { meta: 'is-this' });
   //
+  // Updated approach is to check how many format chars there are in the string,
+  // keep those, and splice the rest into meta
   var metaType  = Object.prototype.toString.call(args[args.length - 1]),
       fmtMatch  = args[0].match && args[0].match(formatRegExp),
-      isFormat  = fmtMatch && fmtMatch.length,
-      validMeta = !isFormat
-        ? metaType === '[object Object]' || metaType === '[object Error]' || metaType === '[object Array]'
-        : metaType === '[object Object]',
-      meta = validMeta ? args.pop() : {},
+      isFormat  = fmtMatch ? fmtMatch.length : 0,
+      meta = isFormat > 0 ? args.splice(isFormat + 1, Math.max(0, args.length - isFormat)) : {},
+      meta = Array.isArray(meta) && meta.length === 1 ? meta[0] : meta,
       msg  = util.format.apply(null, args);
 
   //

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -169,7 +169,7 @@ Logger.prototype.log = function (level) {
   // keep those, and splice the rest into meta
   var fmtMatch  = args[0].match && args[0].match(formatRegExp),
       isFormat  = fmtMatch ? fmtMatch.length : 0,
-      meta = isFormat > 0 ? args.splice(isFormat + 1, Math.max(0, args.length - isFormat)) : {},
+      meta = args.splice(isFormat + 1, Math.max(0, args.length - isFormat)),
       meta = Array.isArray(meta) && meta.length === 1 ? meta[0] : meta,
       msg  = util.format.apply(null, args);
 

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -167,8 +167,7 @@ Logger.prototype.log = function (level) {
   //
   // Updated approach is to check how many format chars there are in the string,
   // keep those, and splice the rest into meta
-  var metaType  = Object.prototype.toString.call(args[args.length - 1]),
-      fmtMatch  = args[0].match && args[0].match(formatRegExp),
+  var fmtMatch  = args[0].match && args[0].match(formatRegExp),
       isFormat  = fmtMatch ? fmtMatch.length : 0,
       meta = isFormat > 0 ? args.splice(isFormat + 1, Math.max(0, args.length - isFormat)) : {},
       meta = Array.isArray(meta) && meta.length === 1 ? meta[0] : meta,


### PR DESCRIPTION
Fix handling of meta objects in log messages.  As of 2.0.0 objects that are passed to log statements and not bound by any format char were being identified as part of the msg instead of meta.