### PR TITLE
Fix Console transport to log error to both stdoud and stderr.

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -33,6 +33,7 @@ var Console = exports.Console = function (options) {
   this.align        = options.align       || false;
   this.stderrLevels = setStderrLevels(options.stderrLevels, options.debugStdout);
   this.eol          = options.eol   || os.EOL;
+  this.logErrorOnOut = options.logErrorOnOut || true;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -112,11 +113,15 @@ Console.prototype.log = function (level, msg, meta, callback) {
     depth:       this.depth,
     formatter:   this.formatter,
     align:       this.align,
+    logErrorOnOut:this.logErrorOnOut,
     humanReadableUnhandledException: this.humanReadableUnhandledException
   });
 
   if (this.stderrLevels[level]) {
     process.stderr.write(output + '\n');
+    if (this.logErrorOnOut){
+      process.stdout.write(output + this.eol);
+    }
   } else {
     process.stdout.write(output + this.eol);
   }


### PR DESCRIPTION
This is the expected behavior in other languages loggers: python, java, etc.. 
Since it helps handle errors in context of what happend before in the stdout log. 
I added a configurtion if someone wants the previous behavior