### PR TITLE
Use eol setting for stderr output.

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -116,7 +116,7 @@ Console.prototype.log = function (level, msg, meta, callback) {
   });
 
   if (this.stderrLevels[level]) {
-    process.stderr.write(output + '\n');
+    process.stderr.write(output + this.eol);
   } else {
     process.stdout.write(output + this.eol);
   }


### PR DESCRIPTION
If you set eol to something like ' ' (space, not '' to avoid defaulting due to poor use of || in eol setting) to trim extra lines between console output it only works for output through stdout. That means using something like debug level logging (which uses stderr) results in some lines using the eol setting and some not. This simple patch solves that problem.
