### PR TITLE
Updated docs on tailable, added "maxfiles" dependency.

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -83,7 +83,7 @@ The File transport should really be the 'Stream' transport since it will accept 
 * __logstash:__ If true, messages will be logged as JSON and formatted for logstash (default false).
 * __showLevel:__ Boolean flag indicating if we should prepend output with level (default true).
 * __formatter:__ If function is specified and `json` is set to `false`, its return value will be used instead of default output. (default undefined)
-* __tailable:__ If true, log files will be rolled based on maxsize and maxfiles, but in ascending order. The __filename__ will always have the most recent log lines. The larger the appended number, the older the log file.
+* __tailable:__ If true, log files will be rolled based on maxsize and maxfiles, but in ascending order. The __filename__ will always have the most recent log lines. The larger the appended number, the older the log file.  This option requires __maxFiles__ to be set, or it will be ignored.
 * __maxRetries:__ The number of stream creation retry attempts before entering a failed state. In a failed state the transport stays active but performs a NOOP on it's log function. (default 2)
 * __zippedArchive:__ If true, all log files but the current one will be zipped.
 * __options:__ options passed to `fs.createWriteStream` (default `{flags: 'a'}`).


### PR DESCRIPTION
If you enable the "tailable" option by itself, the docs imply that it'll start rotating files, but it just quits logging after the first one fills up.

Tailable depends on "maxfiles".  I updated the docs to reflect this.  It'd be even nicer if the implementation was more intuitive (ie. if you don't set maxfiles, then it just grows without limit).  But for now, at least this will save someone else for pulling out their hair when tailable doesn't seem to work.