### PR TITLE
Transform errors into plain objects since they don't stringify well

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -85,7 +85,7 @@ exports.clone = function (obj) {
   if (obj instanceof Error) {
     // With potential custom Error objects, this might not be exactly correct,
     // but probably close-enough for purposes of this lib.
-    copy = new Error(obj.message);
+    copy = { message: obj.message };
     Object.getOwnPropertyNames(obj).forEach(function (key) {
       copy[key] = obj[key];
     });


### PR DESCRIPTION
I haven't found any output tests or I would've added one. Anyways - this restores proper error output behaviour.

`log('msg', { error: err })` still doesn't work because of cycle.js, but `log('msg', err)` now returns
```
2015-12-21T20:23:43.904Z - error: [26934] msg Error: ha
    at null._onTimeout (/path/to/my.js:14:13)
    at Timer.listOnTimeout (timers.js:92:15)
```

In json mode:
```
{
  "message": "msg",
  "stack": "Error: ha\n    at null._onTimeout (/path/to/my/js:14:13)\n    at Timer.listOnTimeout (timers.js:92:15)",
  "level": "error",
  "label": "27635",
  "timestamp": "2015-12-21T20:29:15.983Z"
}
```

(There were no traces of either error.message, nor error.stack before.)