### PR TITLE
Update logger.js to fix docs in winston 1.x

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -477,11 +477,9 @@ Logger.prototype.add = function (transport, options, created) {
 };
 
 //
-// ### function addRewriter (transport, [options])
-// #### @transport {Transport} Prototype of the Transport object to add.
-// #### @options {Object} **Optional** Options for the Transport to add.
-// #### @instance {Boolean} **Optional** Value indicating if `transport` is already instantiated.
-// Adds a transport of the specified type to this instance.
+// ### function addRewriter (rewriter)
+// #### @rewriter (level: string, msg: string, meta: any) : any Function that transforms the metadata
+// Adds a metadata rewriter to the stack of rewriters.
 //
 Logger.prototype.addRewriter = function (rewriter) {
   this.rewriters.push(rewriter);


### PR DESCRIPTION
Docs for rewriter were wrong, which had knock-on effects for the d.ts in DefinitelyTyped (also updated)