### PR TITLE
Fix query with http transport

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -62,8 +62,14 @@ Http.prototype._request = function (options, callback) {
 
   req.on('error', callback);
   req.on('response', function (res) {
+    var body = '';
+
+    res.on('data', function (chunk) {
+      body += chunk;
+    });
+
     res.on('end', function () {
-      callback(null, res);
+      callback(null, res, body);
     });
 
     res.resume();


### PR DESCRIPTION
Closes #786

Collects the response body from the response stream and passes it to the callback.

Before:
<img width="396" alt="screenshot 2016-01-16 15 55 02" src="https://cloud.githubusercontent.com/assets/404731/12374924/9a653ad6-bc69-11e5-825b-11725b178e29.png">

After:
<img width="413" alt="screenshot 2016-01-16 15 55 07" src="https://cloud.githubusercontent.com/assets/404731/12374925/9f115768-bc69-11e5-8984-9270bb021a56.png">

