### PR TITLE
Logger.log check for an undefined callback

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -110,7 +110,7 @@ Logger.prototype.log = function (level) {
       self = this,
       transports;
 
-  while (args[args.length - 1] === null) {
+  while (args[args.length - 1] === null || args[args.length - 1] === undefined) {
     args.pop();
   }
 


### PR DESCRIPTION
I had setup Console transport with `{prettyPrint: true, depth:12}` and I was passing in metadata but still getting `{ blah: [Object] ]`, I discovered this is because the callback I was passing through was undefined, and so the code wasn't getting to `util.inspect`.