### PR TITLE
Support meta type of [object Arguments]

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -174,8 +174,10 @@ Logger.prototype.log = function (level) {
     // last arg is meta
     meta = args[args.length - 1] || args;
     var metaType = Object.prototype.toString.call(meta);
-    validMeta = metaType === '[object Object]' ||
-      metaType === '[object Error]' || metaType === '[object Array]';
+    validMeta = metaType === '[object Object]'
+        || metaType === '[object Error]'
+        || metaType === '[object Array]'
+        || metaType === '[object Arguments]';
     meta = validMeta ? args.pop() : {};
   }
   msg = util.format.apply(null, args);


### PR DESCRIPTION
When making a call such as `winston.debug("myFunction", arguments);` from within a function, the `arguments` object is appended to the message after being formatted with `util.format`. This doesn't happen with 'regular' object. Since `Arguments` is a valid built-in type of `Object`, it should be supported.

Example:
http://jsbin.com/sefetileve/1/edit?js,console
