### PR TITLE
Remove deprecated functions

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -77,9 +77,7 @@ var methods = [
   'extend',
   'cli',
   'handleExceptions',
-  'unhandleExceptions',
-  'addRewriter',
-  'addFilter'
+  'unhandleExceptions'
 ];
 common.setLevels(winston, null, defaultLogger.levels);
 methods.forEach(function (method) {


### PR DESCRIPTION
Finish removing what [f71e638] started by removing `addRewriter` and `addFilter` functions from `winston` #732