### PR TITLE
Revert "Remove deprecated functions"

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -77,7 +77,9 @@ var methods = [
   'extend',
   'cli',
   'handleExceptions',
-  'unhandleExceptions'
+  'unhandleExceptions',
+  'addRewriter',
+  'addFilter'
 ];
 common.setLevels(winston, null, defaultLogger.levels);
 methods.forEach(function (method) {


### PR DESCRIPTION
Reverts winstonjs/winston#818 This is actually a breaking change that will need to wait until `3.0.0`