### PR TITLE
Make sure closed event always fires, even if stream already closed

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -400,13 +400,17 @@ File.prototype.close = function () {
   var self = this;
 
   if (this._stream) {
-    this._stream.end();
-    this._stream.destroySoon();
-
     this._stream.once('finish', function () {
       self.emit('flush');
       self.emit('closed');
     });
+
+    this._stream.end();
+    this._stream.destroySoon();
+
+  } else {
+    self.emit('flush');
+    self.emit('closed');
   }
 };
 


### PR DESCRIPTION
In an effort to cope with #280 and #228 I'm watching for the closed event to be fired before taking my next action and found that sometimes the file was already closed or the stream wasn't open and thus no `closed` event was being fired. In these cases the `closed` event should fire acknowledging that the state of the stream is, in fact, closed.
