### PR TITLE
encapsulating filename property

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -42,7 +42,7 @@ var File = exports.File = function (options) {
 
   if (options.filename || options.dirname) {
     throwIf('filename or dirname', 'stream');
-    this._basename = this.filename = options.filename
+    this._basename = options.filename
       ? path.basename(options.filename)
       : 'winston.log';
 
@@ -165,7 +165,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     output += this.eol;
   }
 
-  if (!this.filename) {
+  if (!this._getFilename()) {
     //
     // If there is no `filename` on this instance then it was configured
     // with a raw `WriteableStream` instance and we should not perform any
@@ -232,7 +232,7 @@ File.prototype.query = function (options, callback) {
     options = {};
   }
 
-  var file = path.join(this.dirname, this.filename),
+  var file = path.join(this.dirname, this._getFilename()),
       options = this.normalizeQuery(options),
       buff = '',
       results = [],
@@ -332,7 +332,7 @@ File.prototype.query = function (options, callback) {
 // Returns a log stream for this transport. Options object is optional.
 //
 File.prototype.stream = function (options) {
-  var file = path.join(this.dirname, this.filename),
+  var file = path.join(this.dirname, this._getFilename()),
       options = options || {},
       stream = new Stream;
 
@@ -558,10 +558,13 @@ File.prototype._createStream = function () {
   })(this._getFile());
 };
 
+File.prototype._getFilename = function () {
+  return this._basename;
+};
 
 File.prototype._incFile = function (callback) {
-  var ext = path.extname(this._basename),
-      basename = path.basename(this._basename, ext),
+  var ext = path.extname(this._getFilename()),
+      basename = path.basename(this._getFilename(), ext),
       oldest,
       target;
 
@@ -580,8 +583,8 @@ File.prototype._incFile = function (callback) {
 // in the case that log filesizes are being capped.
 //
 File.prototype._getFile = function () {
-  var ext = path.extname(this._basename),
-      basename = path.basename(this._basename, ext);
+  var ext = path.extname(this._getFilename()),
+      basename = path.basename(this._getFilename(), ext);
 
   //
   // Caveat emptor (indexzero): rotationFormat() was broken by design

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -165,7 +165,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     output += this.eol;
   }
 
-  if (!this._getFilename()) {
+  if (!this.filename) {
     //
     // If there is no `filename` on this instance then it was configured
     // with a raw `WriteableStream` instance and we should not perform any
@@ -232,7 +232,7 @@ File.prototype.query = function (options, callback) {
     options = {};
   }
 
-  var file = path.join(this.dirname, this._getFilename()),
+  var file = path.join(this.dirname, this.filename),
       options = this.normalizeQuery(options),
       buff = '',
       results = [],
@@ -332,7 +332,7 @@ File.prototype.query = function (options, callback) {
 // Returns a log stream for this transport. Options object is optional.
 //
 File.prototype.stream = function (options) {
-  var file = path.join(this.dirname, this._getFilename()),
+  var file = path.join(this.dirname, this.filename),
       options = options || {},
       stream = new Stream;
 
@@ -558,13 +558,14 @@ File.prototype._createStream = function () {
   })(this._getFile());
 };
 
-File.prototype._getFilename = function () {
-  return this._basename;
-};
+Object.defineProperty(File.prototype, 'filename', {
+  enumerable: true,
+  get: function () { return this._basename; }
+});
 
 File.prototype._incFile = function (callback) {
-  var ext = path.extname(this._getFilename()),
-      basename = path.basename(this._getFilename(), ext),
+  var ext = path.extname(this.filename),
+      basename = path.basename(this.filename, ext),
       oldest,
       target;
 
@@ -583,8 +584,8 @@ File.prototype._incFile = function (callback) {
 // in the case that log filesizes are being capped.
 //
 File.prototype._getFile = function () {
-  var ext = path.extname(this._getFilename()),
-      basename = path.basename(this._getFilename(), ext);
+  var ext = path.extname(this.filename),
+      basename = path.basename(this.filename, ext);
 
   //
   // Caveat emptor (indexzero): rotationFormat() was broken by design


### PR DESCRIPTION
Some areas of the file use `this._basename` and others used `this.filename`. This attempts to consolidate the filename retrieval in a single method.
