### PR TITLE
Introduce log level aliasing

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -221,18 +221,29 @@ Logger.prototype.log = function (level) {
   }
 
   //
+  // Instead of using the key as level, use the value.
+  // Provided the following example, level would be changed from info to 1337,
+  // or from 1337 into info.
+  //
+  //    logger.setLevels({info: 1337});
+  //    logger.info(message) -> logger.log(1337, message)
+  //    logger['1337'](message) -> logger.log('info', message)
+  //
+  var _level = this.alias ? self.levels[level] : level;
+
+  //
   // Log for each transport and emit 'logging' event
   //
   function transportLog(name, next) {
     var transport = self.transports[name];
-    transport.log(level, msg, meta, function (err) {
+    transport.log(_level, msg, meta, function (err) {
       if (err) {
         err.transport = transport;
         finish(err);
         return next();
       }
 
-      self.emit('logging', transport, level, msg, meta);
+      self.emit('logging', transport, _level, msg, meta);
       next();
     });
   }
@@ -593,9 +604,16 @@ Logger.prototype.profile = function (id) {
 //
 // ### function setLevels (target)
 // #### @target {Object} Target levels to use on this instance
+// #### @alias {Boolean} Send the value of the level, instead of the key
 // Sets the `target` levels specified on this instance.
 //
-Logger.prototype.setLevels = function (target) {
+Logger.prototype.setLevels = function (target, alias) {
+  this.alias = alias;
+  if (alias) {
+    Object.keys(target).forEach(function(key) {
+      target[target[key]] = key;
+    });
+  }
   return common.setLevels(this, this.levels, target);
 };
 


### PR DESCRIPTION
## The problem
The system we log to requires us to send log levels that are integers. However, Winston logs the level by name.

Actual:
```javascript
logger.info(message) - > logger.log('info', message)
```

Wanted:
```javascript
logger.info(message) -> logger.log(1337, message)
```

## The solution without changing Winston:
```javascript
logger['1337'](message) -> logger.log(1337, message)
```
But this is really ugly for us to write, so we don't want this.

## A nice solution
The following solution allows Winston to alias logging levels, which would result in:
```javascript
logger.info(message) -> logger.log(1337, message)
```
Because the code is rather tightly coupled, I decided to take the easy approach and simply add logging levels not just for keys, but also for values. Performance of the `setLevels` function is decreased slightly, and the `log` function now contains an additional ternary operator, which should not make any realistic difference in performance, as the `log` function is already big enough.

This change is written in a way that will not break any compatibility with existing implementations.
