### PR TITLE
Transport Console Improvements

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -348,7 +348,7 @@ exports.serialize = function (obj, key) {
       for (var j = 0, l = obj[keys[i]].length; j < l; j++) {
         msg += exports.serialize(obj[keys[i]][j]);
         if (j < l - 1) {
-          msg += ', ';
+          msg += ' ';
         }
       }
 
@@ -362,7 +362,7 @@ exports.serialize = function (obj, key) {
     }
 
     if (i < length - 1) {
-      msg += ', ';
+      msg += ' ';
     }
   }
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -259,13 +259,13 @@ exports.log = function (options) {
         var stack = meta.stack;
         delete meta.stack;
         delete meta.trace;
-        output += ' ' + exports.serialize(meta);
+        output += exports.serialize(meta);
 
         if (stack) {
           output += '\n' + stack.join('\n');
         }
       } else {
-        output += ' ' + exports.serialize(meta);
+        output += exports.serialize(meta);
       }
     }
   }


### PR DESCRIPTION
[logfmt](https://brandur.org/logfmt) is a De facto standard for logging.

It could be configurable, but what do you think about avoid `,` ? 

Less chars in logs, more simple.