### PR TITLE
Delete extra space

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -259,13 +259,18 @@ exports.log = function (options) {
         var stack = meta.stack;
         delete meta.stack;
         delete meta.trace;
-        output += ' ' + exports.serialize(meta);
+
+        var isLastCharSpace;
+
+        isLastCharSpace = output[output.legnth - 1] === ' '
+        output += isLastCharSpace ? exports.serialize(meta) : ' ' + exports.serialize(meta)
 
         if (stack) {
           output += '\n' + stack.join('\n');
         }
       } else {
-        output += ' ' + exports.serialize(meta);
+        isLastCharSpace = output[output.legnth - 1] === ' '
+        output += isLastCharSpace ? exports.serialize(meta) : ' ' + exports.serialize(meta)
       }
     }
   }


### PR DESCRIPTION
before:

```
info: hello world
info:  foo=bar
info: hello world
```

after:

```
info: hello world
info: foo=bar
info: hello world
```
