### PR TITLE
Simplify serialize

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -334,7 +334,7 @@ exports.serialize = function (obj, key) {
   }
 
   if (typeof obj !== 'object') {
-    if (typeof obj === 'string' && hasWhiteSpace(obj)) obj = "'" + obj + "'";
+    if (key && typeof obj === 'string' && hasWhiteSpace(obj)) obj = "'" + obj + "'";
     return key ? key + '=' + obj : obj;
   }
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -14,6 +14,10 @@ var util = require('util'),
     Stream = require('stream').Stream,
     config = require('./config');
 
+function hasWhiteSpace(s) {
+  return s.indexOf(' ') !== -1;
+}
+
 //
 // ### function setLevels (target, past, current)
 // #### @target {Object} Object on which to set levels.
@@ -330,6 +334,7 @@ exports.serialize = function (obj, key) {
   }
 
   if (typeof obj !== 'object') {
+    if (typeof obj === 'string' && hasWhiteSpace(obj)) obj = "'" + obj + "'";
     return key ? key + '=' + obj : obj;
   }
 
@@ -348,7 +353,7 @@ exports.serialize = function (obj, key) {
       for (var j = 0, l = obj[keys[i]].length; j < l; j++) {
         msg += exports.serialize(obj[keys[i]][j]);
         if (j < l - 1) {
-          msg += ', ';
+          msg += ' ';
         }
       }
 
@@ -362,7 +367,7 @@ exports.serialize = function (obj, key) {
     }
 
     if (i < length - 1) {
-      msg += ', ';
+      msg += ' ';
     }
   }
 

--- a/test/humanReadableUnhandledException-test.js
+++ b/test/humanReadableUnhandledException-test.js
@@ -31,7 +31,7 @@ vows.describe('winston/transport/humanReadableUnhandledException').addBatch({
           assert.equal(1, transport.writeOutput.length);
 
           var msg = transport.writeOutput[0];
-          assert.notEqual(-1, msg.indexOf('stack: date=dummy date, process=dummy, os=dummy\n'));
+          assert.notEqual(-1, msg.indexOf('stack: date=\'dummy date\' process=dummy os=dummy\n'));
           assert.notEqual(-1, msg.indexOf(meta.stack[0] + '\n'));
         });
       }

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -335,7 +335,7 @@ vows.describe('winton/logger').addBatch({
           var output = stdMocks.flush(),
               line   = output.stdout[0];
 
-          assert.match(line, /message\=in/);
+          assert.match(line, /message\='in/);
         }
       },
       "when passed a escaped percent sign": {


### PR DESCRIPTION
It's based in the [logfmt](https://brandur.org/logfmt) format that is a little more simple that the current winston serializer.

Basically it is based in use white space as separator.

If a string with whitespace need to be serialize, then it is encapsulate under `'` symbols.

This change minimize the number of chars necessary for print the same information.

Before:

```
info:  date=dummy date, process=dummy, os=dummy, trace=dummy, stack=[first line, second line]
```

After:

```
info:  date='dummy date' process=dummy os=dummy trace=dummy stack=['first line' 'second line']
```
