### PR TITLE
[doc] Removing Yoda conditional from example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ var logger = new (winston.Logger)({
       },
       formatter: function(options) {
         // Return string will be passed to logger.
-        return options.timestamp() +' '+ options.level.toUpperCase() +' '+ (undefined !== options.message ? options.message : '') +
+        return options.timestamp() +' '+ options.level.toUpperCase() +' '+ (options.message ? options.message : '') +
           (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
       }
     })


### PR DESCRIPTION
Removing a Yoda conditional from the README.  I realize this is petty but I was legitimately confused as heck when I first tried to read it.  Felt this would be easier to brain parse.
