### PR TITLE
Remove pkginfo.

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -11,7 +11,7 @@ var winston = exports;
 //
 // Expose version using `pkginfo`
 //
-require('pkginfo')(module, 'version');
+exports.version = require('../package.json').version;
 
 //
 // Include transports defined by default by winston

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "cycle": "1.0.x",
     "eyes": "0.1.x",
     "isstream": "0.1.x",
-    "pkginfo": "0.3.x",
     "stack-trace": "0.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Node `require()` supports json.  This drops a dependency and improves
compatibility with bundlers.
