### PR TITLE
Remove absolute imports.

### DIFF
--- a/lib/winston/transports.js
+++ b/lib/winston/transports.js
@@ -19,7 +19,7 @@ Object.defineProperties(
         configurable: true,
         enumerable: true,
         get: function () {
-          var fullpath = path.join(__dirname, 'transports', name.toLowerCase());
+          var fullpath = '.' + path.sep + path.join('transports', name.toLowerCase());
           return require(fullpath)[name];
         }
       };


### PR DESCRIPTION
This seems to confuse webpack (causes "Cannot find module
'/transport/console' errors) and seems unnecessary.
