### PR TITLE
Fix 'Maximum call stack size exceeded' error with custom formatter

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -214,6 +214,7 @@ exports.log = function (options) {
   // Remark: this should really be a call to `util.format`.
   //
   if (typeof options.formatter == 'function') {
+    options.meta = meta;
     return String(options.formatter(exports.clone(options)));
   }
 


### PR DESCRIPTION
Fix for issue #862

As  @thinkkevin explains: "Need to have `options.meta` _decycled_ before `clone`".
