### PR TITLE
increase allowed maxlisteners for multiple loggers

### DIFF
--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -57,22 +57,6 @@ Container.prototype.get = Container.prototype.add = function (id, options) {
       options.transports.push(this.default.transports[0]);
     }
 
-    Object.keys(options).forEach(function (key) {
-      if (key === 'transports') {
-        return;
-      }
-
-      var name = common.capitalize(key);
-
-      if (!winston.transports[name]) {
-        throw new Error('Cannot add unknown transport: ' + name);
-      }
-
-      var namedOptions = options[key];
-      namedOptions.id = id;
-      options.transports.push(new (winston.transports[name])(namedOptions));
-    });
-
     options.id = id;
     this.loggers[id] = new winston.Logger(options);
 

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -431,6 +431,7 @@ Logger.prototype.handleExceptions = function () {
 
   if (!this.catchExceptions) {
     this.catchExceptions = this._uncaughtException.bind(this);
+	process.setMaxListeners(process.getMaxListeners() + 1);
     process.on('uncaughtException', this.catchExceptions);
   }
 };
@@ -460,6 +461,7 @@ Logger.prototype.unhandleExceptions = function () {
     })
 
     process.removeListener('uncaughtException', this.catchExceptions);
+	process.setMaxListeners(process.getMaxListeners() - 1
     this.catchExceptions = false;
   }
 };

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -431,7 +431,7 @@ Logger.prototype.handleExceptions = function () {
 
   if (!this.catchExceptions) {
     this.catchExceptions = this._uncaughtException.bind(this);
-	process.setMaxListeners(process.getMaxListeners() + 1);
+    process.setMaxListeners(process.getMaxListeners() + 1);
     process.on('uncaughtException', this.catchExceptions);
   }
 };
@@ -461,7 +461,7 @@ Logger.prototype.unhandleExceptions = function () {
     })
 
     process.removeListener('uncaughtException', this.catchExceptions);
-	process.setMaxListeners(process.getMaxListeners() - 1
+    process.setMaxListeners(process.getMaxListeners() - 1);
     this.catchExceptions = false;
   }
 };


### PR DESCRIPTION
Adding many logger instances using winston.loggers.get resulted in a node maxlisteners warning, so when creating/destroying logger instances I increase and decrease limit accordingly.
