### PR TITLE
Do not clone options passed to formatter

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -214,7 +214,7 @@ exports.log = function (options) {
   // Remark: this should really be a call to `util.format`.
   //
   if (typeof options.formatter == 'function') {
-    return String(options.formatter(exports.clone(options)));
+    return String(options.formatter(options));
   }
 
   output = timestamp ? timestamp + ' - ' : '';


### PR DESCRIPTION
Cloning options loses all the prototype data and makes logging errors useless
