### PR TITLE
transport: update Logzio Transport documentation

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -180,7 +180,7 @@ var winston = require('winston');
 var logzioWinstonTransport = require('winston-logzio');
 
 var loggerOptions = {
-    apiToken: '__YOUR_API_TOKEN__'
+    token: '__YOUR_API_TOKEN__'
 };
 winston.add(logzioWinstonTransport, loggerOptions);
 


### PR DESCRIPTION
The documentation for Logzio Transport in docs/transport.md
references 'apiToken', but in looking at the winston-logzio repo, this
key is referenced as 'token.'
