### PR TITLE
Change transports.js to use static requires

### DIFF
--- a/lib/winston/transports.js
+++ b/lib/winston/transports.js
@@ -11,17 +11,21 @@ var path = require('path');
 //
 // Setup all transports as lazy-loaded getters.
 //
+var transports = {
+  Console: function() { return require('./transports/console.js').Console; },
+  File: function() { return require('./transports/file.js').File; },
+  Http: function() { return require('./transports/http.js').Http; },
+  Memory: function() { return require('./transports/memory.js').Memory; }
+}
+
 Object.defineProperties(
   exports,
-  ['Console', 'File', 'Http', 'Memory']
+  Object.keys(transports)
     .reduce(function (acc, name) {
       acc[name] = {
         configurable: true,
         enumerable: true,
-        get: function () {
-          var fullpath = path.join(__dirname, 'transports', name.toLowerCase());
-          return require(fullpath)[name];
-        }
+        get: transports[name]
       };
 
       return acc;


### PR DESCRIPTION
Module loaders like [SystemJS](https://github.com/systemjs/systemjs) have trouble resolving dynamic requires used in this file... if they are explicitly defined like this then there's no problem.
Yes, it does add a little bit of duplication (reducing the array is much cleaner), but it's only 4 files, so it's not a large price to pay
