### PR TITLE
Allow passing of an agent to the HTTP Transport

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -21,6 +21,7 @@ var Http = exports.Http = function (options) {
   this.port = options.port;
   this.auth = options.auth;
   this.path = options.path || '';
+  this.agent = options.agent;
 
   if (!this.port) {
     this.port = this.ssl ? 443 : 80;
@@ -57,6 +58,7 @@ Http.prototype._request = function (options, callback) {
     path: '/' + path.replace(/^\//, ''),
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    agent: this.agent,
     auth: (auth) ? auth.username + ':' + auth.password : ''
   });
 


### PR DESCRIPTION
For those of us behind a Corporate Proxy this allows us to pass an agent through to the HTTP transport (e.g. a proxy agent) which allows usage of this behind a proxy.
