### PR TITLE
Allow file transport to support 'align' option

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -87,6 +87,7 @@ var File = exports.File = function (options) {
   this.depth       = options.depth       || null;
   this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
   this.maxRetries  = options.maxRetries || 2;
+  this.align       = options.align || false;
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -158,6 +159,7 @@ File.prototype.log = function (level, msg, meta, callback) {
     label:       this.label,
     depth:       this.depth,
     formatter:   this.formatter,
+    align:       this.align,
     humanReadableUnhandledException: this.humanReadableUnhandledException
   });
 


### PR DESCRIPTION
Currently the file transport does not honor the `align` option as the console transport does. Since they both call the `common.log` function, the `align` option should be made optionally available.
