### PR TITLE
Suppress excessive Node warning from fs.unlink

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -530,7 +530,7 @@ File.prototype._createStream = function () {
 
         inp.pipe(gzip).pipe(out);
 
-        fs.unlink(String(self._archive));
+        fs.unlink(String(self._archive), function () {});
         self._archive = '';
       }
     }


### PR DESCRIPTION
Mutes this:

```
(node:2608) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```

at 

```js
fs.unlink(String(self._archive));
```