### PR TITLE
Removed indenting from Console Transport

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -36,7 +36,7 @@ var Console = exports.Console = function (options) {
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
-      return JSON.stringify(obj, null, 2);
+      return JSON.stringify(obj);
     };
   }
 


### PR DESCRIPTION
The console transport JSON output should not be printed with new lines and indents.

This breaks / complicates log aggregation.