### PR TITLE
fix logs when no meta is passed

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -170,8 +170,9 @@ Logger.prototype.log = function (level) {
   var hasFormat = args && args[0] && args[0].match && args[0].match(formatRegExp) !== null;
   var tokens = (hasFormat) ? args[0].match(formatRegExp) : [];
   var ptokens = tokens.filter(function(t) { return t === '%%' });
-  if (((args.length - 1) - (tokens.length - ptokens.length)) > 0 || args.length === 1) {
-    // last arg is meta
+  
+  if (((args.length - 1) - (tokens.length - ptokens.length)) > 0 && args.length != 1) {
+    // last arg is meta if there are more than one args
     meta = args[args.length - 1] || args;
     var metaType = Object.prototype.toString.call(meta);
     validMeta = metaType === '[object Object]' ||


### PR DESCRIPTION
the log method in logger.js assumes that the last argument after
extracting log level and callback will be meta but the assumption is
wrong if meta object is not passed in the arguments.

Modified the conditions to correctly handle the arguments when no meta
is passed.