### PR TITLE
avoid current log file being archived and unlinked when tailable is true

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -384,8 +384,6 @@ File.prototype.open = function (callback) {
     return this._createStream();
   }
 
-  this._archive = this.zippedArchive ? this._stream.path : null;
-
   //
   // Otherwise we have a valid (and ready) stream.
   //


### PR DESCRIPTION
I encounter a bug with this configuration:
```javascript
winston.loggers.add('accesslog', {
    file: {
        level: 'info',
        timestamp: true,
        filename: 'logs/access.log',
        maxsize: 50 * 1024 * 1024,
        maxFiles: 3,
        tailable: true,
        zippedArchive: true,
    },
});
```
Suddenly the file 'access.log' was missing but still opened by NodeJS
according to Mac OS X Activity Monitor, and there was a small file
'access.log.gz' whose size never increased.

I think the deleted line leads to this bug, the line is unncessary
because both _checkMaxFilesIncrementing() and _checkMaxFilesTailable()
called by _incFile() already set 'this._archive'.

The issue may happen when 'this._size' is inaccurately calculated and
actual 'stats.size' is less than 'self.maxsize' at line 546, then
function 'createAndFlush()' will not rotate log files but compress
the current log file.