### PR TITLE
Fix file transport not using formatter

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -214,6 +214,9 @@ exports.log = function (options) {
   // Remark: this should really be a call to `util.format`.
   //
   if (typeof options.formatter == 'function') {
+    if (options.timestamp  === true)
+      options.timestamp = timestampFn();
+
     return String(options.formatter(exports.clone(options)));
   }
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -72,7 +72,7 @@ var File = exports.File = function (options) {
     throw new Error('Cannot log to file without filename or stream.');
   }
 
-  this.json        = options.json !== false;
+  this.json        = !(options.json === false || typeof options.formatter === "function");
   this.logstash    = options.logstash    || false;
   this.colorize    = options.colorize    || false;
   this.maxsize     = options.maxsize     || null;


### PR DESCRIPTION
 File transport only used options.formatter if options.json
 was also set to false.
 Now defining formatter function is sufficient.