### PR TITLE
Set timestamp when using formatter

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -214,6 +214,9 @@ exports.log = function (options) {
   // Remark: this should really be a call to `util.format`.
   //
   if (typeof options.formatter == 'function') {
+    if (options.timestamp  === true)
+      options.timestamp = timestampFn();
+
     return String(options.formatter(exports.clone(options)));
   }
 


### PR DESCRIPTION
 Using file transport and formatter function, the formatter
 received options.timestamp = true. Now receives  a timestamp
as expected.