### PR TITLE
winston.log('my message') logs 'my message' at the info level

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -111,6 +111,13 @@ Logger.prototype.log = function (level) {
       self = this,
       transports;
 
+  // If the user did not specify a level that winston recognizes, it's likely they are a new or lazy user
+  // they probbaly did "winston.log('my message')" expecting winston to log 'my message' at the default level
+  if (typeof self.levels[level] === 'undefined') {
+    args = ['info'].concat(Array.prototype.slice.call(arguments))
+    return self.log.apply(self, args)
+  }
+
   while (args[args.length - 1] === null) {
     args.pop();
   }

--- a/test/logger-levels-test.js
+++ b/test/logger-levels-test.js
@@ -19,6 +19,19 @@ vows.describe('winston/logger/levels').addBatch({
         new (winston.transports.Console)()
       ]
     }),
+    "the log() method": {
+      "when passed an unrecognized log level": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.log('yo', 'mama', { goes_to_college: true })
+        },
+        "should log all arguments at the 'info' level": function (transport, level, msg, meta) {
+          assert.strictEqual(level, 'info');
+          assert.strictEqual(msg, 'yo mama');
+          assert.deepEqual(meta, { goes_to_college: true });
+        }
+      }
+    },
     "the info() method": {
       "when passed metadata": {
         topic: function (logger) {


### PR DESCRIPTION
Found feature request #641 and thought it would be nice for new/lazy developers. If a logging level is not found, all arguments (including the first one that is normally the level) will be logged at the info level.

Added test for this case. No other tests broke.