### PR TITLE
Add how to colorize output in the custom formatter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,8 +784,12 @@ var logger = new (winston.Logger)({
         return Date.now();
       },
       formatter: function(options) {
-        // Return string will be passed to logger.
-        return options.timestamp() +' '+ options.level.toUpperCase() +' '+ (options.message ? options.message : '') +
+        // - Return string will be passed to logger.
+        // - Optionally, use options.colorize(options.level, <string>) to
+        //   colorize output based on the log level.
+        return options.timestamp() + ' ' +
+          options.colorize(options.level, options.level.toUpperCase()) + ' ' +
+          (options.message ? options.message : '') +
           (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
       }
     })


### PR DESCRIPTION
It took me a while to figure out why my format function wasn't colorizing anything in the output. Thought this might make the example clearer and more complete.

Open to any suggestions/feedback.