### PR TITLE
Added watch to file to transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -477,6 +477,10 @@ File.prototype._createStream = function () {
         self._stream.destroySoon();
       }
 
+      if(self._streamWatcher) {
+	      self._streamWatcher.close();
+      }
+
       self._size = size;
       self.filename = target;
       self._stream = fs.createWriteStream(fullname, self.options);
@@ -490,6 +494,7 @@ File.prototype._createStream = function () {
           self.emit('error', error);
         }
       });
+
       //
       // We need to listen for drain events when
       // write() returns false. This can make node
@@ -511,6 +516,7 @@ File.prototype._createStream = function () {
         self.opening = false;
         self.emit('open', fullname);
       });
+
       //
       // Remark: It is possible that in the time it has taken to find the
       // next logfile to be written more data than `maxsize` has been buffered,
@@ -518,6 +524,16 @@ File.prototype._createStream = function () {
       // than one second.
       //
       self.flush();
+
+      self._streamWatcher = fs.watch(fullname, function(eventName) {
+          if(eventName === 'rename') {
+              self._stream.close(function() {
+                  self._stream = null;
+                  self._streamWatcher.close();
+              });
+          }
+      });
+
       compressFile();
     }
 


### PR DESCRIPTION
Hi,

i've added a file watcher to the file transport, to get rid of the problem if the file was moved or deleted when the process is running. I'm well are of the failing unit tests. Could someone be so kind and help me out with that problem? I'm not deep enough in the code to fix them in a acceptable amount of time.

This fixes #705 and #956.