### PR TITLE
aligns meta object in startTimer with profile

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -582,7 +582,7 @@ Logger.prototype.profile = function (id) {
     // Support variable arguments: msg, meta, callback
     args     = Array.prototype.slice.call(arguments);
     callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
-    meta     = typeof args[args.length - 1] === 'object' ? args.pop() : {};
+    meta     = typeof args[args.length - 1] === 'object' ? common.clone(args.pop()) : {};
     msg      = args.length === 2 ? args[1] : id;
 
     // Set the duration property of the metadata
@@ -722,7 +722,7 @@ function ProfileHandler(logger) {
 ProfileHandler.prototype.done = function (msg) {
   var args     = Array.prototype.slice.call(arguments),
       callback = typeof args[args.length - 1] === 'function' ? args.pop() : null,
-      meta     = typeof args[args.length - 1] === 'object' ? args.pop() : {};
+      meta     = typeof args[args.length - 1] === 'object' ? common.clone(args.pop()) : {};
 
   meta.durationMs = Date.now() - this.start;
   return this.logger.info(msg, meta, callback);

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -724,6 +724,6 @@ ProfileHandler.prototype.done = function (msg) {
       callback = typeof args[args.length - 1] === 'function' ? args.pop() : null,
       meta     = typeof args[args.length - 1] === 'object' ? args.pop() : {};
 
-  meta.duration = (Date.now()) - this.start + 'ms';
+  meta.durationMs = Date.now() - this.start;
   return this.logger.info(msg, meta, callback);
 };


### PR DESCRIPTION
The meta object in `.profile` is enriched with `durationMs`, and `startTimer`'s enrichment is `duration`. With the added `'ms'` the latter property is unusable in something like kibana. Also, having two different properties is not desirable.