### PR TITLE
Update http.js - Add support for headers - Fixes #1020

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -22,6 +22,8 @@ var Http = exports.Http = function (options) {
   this.auth = options.auth;
   this.path = options.path || '';
   this.agent = options.agent;
+  this.headers = options.headers || {};
+  this.headers['Content-Type'] = 'application/json';
 
   if (!this.port) {
     this.port = this.ssl ? 443 : 80;
@@ -57,7 +59,7 @@ Http.prototype._request = function (options, callback) {
     port: this.port,
     path: '/' + path.replace(/^\//, ''),
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: this.headers,
     agent: this.agent,
     auth: (auth) ? auth.username + ':' + auth.password : ''
   });


### PR DESCRIPTION
Sometimes you need oAuth or anything else negotiated with Headers.

Headers should be customizabe through options.

See #1020