### PR TITLE
call fs.close synchronously

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -408,7 +408,7 @@ exports.tailFile = function(options, callback) {
 
     (function read() {
       if (stream.destroyed) {
-        fs.close(fd);
+        fs.closeSync(fd);
         return;
       }
 


### PR DESCRIPTION
As https://github.com/nodejs/node/pull/12562 landed in Node.js,
`fs.close` call without callback function will fail in Node.js v8.