### PR TITLE
Make assert less timing sensitive

### DIFF
--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -190,7 +190,7 @@ vows.describe('winton/logger').addBatch({
             assert.equal(level, 'info');
 
             assert.isNumber(meta.durationMs);
-            assert.isTrue(meta.durationMs >= 50 && meta.durationMs < 100);
+            assert.isTrue(meta.durationMs >= 50 && meta.durationMs < 500);
           }
         }
       },


### PR DESCRIPTION
This is causing `nodejs`'s CITGM to report a fail in testing regressions in `winston`
Ref: https://github.com/nodejs/node/wiki/CITGM-know-flakes