### PR TITLE
[fix] Container.add() 'filters' and 'rewriters' option passing to logger

### DIFF
--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -58,7 +58,7 @@ Container.prototype.get = Container.prototype.add = function (id, options) {
     }
 
     Object.keys(options).forEach(function (key) {
-      if (key === 'transports') {
+      if (key === 'transports' || key === 'filters' || key === 'rewriters') {
         return;
       }
 

--- a/test/container-test.js
+++ b/test/container-test.js
@@ -53,6 +53,20 @@ vows.describe('winston/container').addBatch({
           assert.isTrue(!container.loggers['default-test']);
         }
       }
+    },
+    "the add() method transports rewriters and filters options to logger": {
+      topic: function (container) {
+        var options = {
+          'rewriters': [function () { }],
+          'filters':   [function () { }, function () { }],
+        }
+        return container.add('options-test', options);
+      },
+      "should respond with logger that have the rewriters/filters provided by options": function (logger) {
+        assert.instanceOf(logger, winston.Logger);
+        assert.equal(helpers.size(logger.rewriters), 1);
+        assert.equal(helpers.size(logger.filters), 2);
+      }
     }
   },
   "An instance of winston.Container with explicit transports": {


### PR DESCRIPTION
In "Container.add(id, options)" every key in 'options' is tried to be resolved to an existing transports id and an error is thrown if this was not possible (line 68).

These options are directly passed as constructor parameter to the created Logger instance. Therefore, to be able to support setting 'filters' and 'rewriters' options for the created Logger these settings have to be skipped (similar to the 'transports' option) during the namedOptions resolution.