### PR TITLE
regression brought by 2.3.1

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -80,7 +80,7 @@ exports.clone = function (obj) {
   //
   // We only need to clone reference types (Object)
   //
-  var copy = {};
+  var copy;
 
   if (obj instanceof Error) {
     // With potential custom Error objects, this might not be exactly correct,
@@ -99,6 +99,7 @@ exports.clone = function (obj) {
     return new Date(obj.getTime());
   }
 
+  copy = Array.isArray(obj) ? [] : {};
   for (var i in obj) {
     if (Array.isArray(obj[i])) {
       copy[i] = obj[i].slice(0);

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -215,7 +215,7 @@ exports.log = function (options) {
   // Remark: this should really be a call to `util.format`.
   //
   if (typeof options.formatter == 'function') {
-    options.meta = meta;
+    options.meta = meta || options.meta;
     return String(options.formatter(exports.clone(options)));
   }
 


### PR DESCRIPTION
Hi, the fix 2.3.1 has brought two small regression on array printing and falsy value printing.
Here a proposal to fix that.

`['a', 'b']` was transformed as `{ '0': 'a', '1': 'b' }`
`undefined` was transformed as `null`