### PR TITLE
Add `picking` option to Console transport

### DIFF
--- a/examples/log-picking.js
+++ b/examples/log-picking.js
@@ -1,0 +1,16 @@
+var winston = require('../lib/winston');
+
+var logger = module.exports = new(winston.Logger)({
+  transports: [
+    new(winston.transports.Console)({
+      picking: ['World', 'nice'],
+    })
+  ]
+});
+
+logger.log('info', 'Hello World');
+logger.log('info', 'Howdy?');
+logger.log('info', 'What a nice day.');
+logger.log('info', 'The World Is Great!');
+logger.log('info', 'Goodbye everyone.');
+logger.log('info', 'Bye.');

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -139,9 +139,9 @@ Console.prototype.log = function (level, msg, meta, callback) {
  * @param {Array} - keywords contained in log message to be picked up
  * @return {Boolean}
  */
-function shouldPickup(msg, picking = []) {
+function shouldPickup(msg, picking) {
   if (!msg) return false;
-  if (picking.length <= 0) return true; // if no picking filters, go through
+  if (!Array.isArray(picking) || picking.length <= 0) return true; // if no picking filters, go through
   let m;
   for (let len = picking.length, i = 0; i < len; i++) {
     m = msg.match(picking[i]);

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -142,8 +142,8 @@ Console.prototype.log = function (level, msg, meta, callback) {
 function shouldPickup(msg, picking) {
   if (!msg) return false;
   if (!Array.isArray(picking) || picking.length <= 0) return true; // if no picking filters, go through
-  let m;
-  for (let len = picking.length, i = 0; i < len; i++) {
+  var m;
+  for (var len = picking.length, i = 0; i < len; i++) {
     m = msg.match(picking[i]);
     if (m) return true;
   }

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -33,6 +33,7 @@ var Console = exports.Console = function (options) {
   this.align        = options.align       || false;
   this.stderrLevels = setStderrLevels(options.stderrLevels, options.debugStdout);
   this.eol          = options.eol   || os.EOL;
+  this.picking = options.picking || null;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -93,6 +94,10 @@ Console.prototype.log = function (level, msg, meta, callback) {
     return callback(null, true);
   }
 
+  if (this.picking && !shouldPickup(msg, this.picking)) {
+    return callback(null, true);
+  }
+  
   var self = this,
       output;
 
@@ -128,3 +133,19 @@ Console.prototype.log = function (level, msg, meta, callback) {
   self.emit('logged');
   callback(null, true);
 };
+
+/**
+ * @param {String} - log message
+ * @param {Array} - keywords contained in log message to be picked up
+ * @return {Boolean}
+ */
+function shouldPickup(msg, picking = []) {
+  if (!msg) return false;
+  if (picking.length <= 0) return true; // if no picking filters, go through
+  let m;
+  for (let len = picking.length, i = 0; i < len; i++) {
+    m = msg.match(picking[i]);
+    if (m) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Hi. I always use this lovely great logging library. So helpful.
Now, I have customized to `Console` transport to be able to pick log messages having any keywords you specified. Isn't it good? I want you to merge this feature if you'd like. First, please check `example/log-picking.js`.
Thanks.