### PR TITLE
Added ability to provide dynamic label.

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -231,7 +231,24 @@ exports.log = function (options) {
 
   output += (options.align) ? '\t' : '';
   output += (timestamp || showLevel) ? ': ' : '';
-  output += options.label ? ('[' + options.label + '] ') : '';
+
+  if (options.label) {
+    var label;
+
+    // checking if label is dynamic callable, or static object.
+    if((typeof options.label) === 'function') {
+      // label is dynamic callable. getting returned value from function.
+      label = options.label();
+    }
+    else {
+      // label is static.
+      label = options.label;
+    }
+    
+    // appending to output.
+    output += '[' + label + '] ';
+  }
+
   output += options.colorize === 'all' || options.colorize === 'message'
     ? config.colorize(options.level, options.message)
     : options.message;


### PR DESCRIPTION
In a personal project, I wanted to be able to provide a dynamic stacktrace for log functions in the label of the logs. The workaround I used was creating a new winston object wrapped in my own "debug/info/etc..." functions. This change allows you to pass in a function to the label option that will be executed at runtime and yield the dynamic label.

example:
```javascript
var logger = new (winston.Logger)({
    transports: [
        new (winston.transports.Console)({
            label: function() {
                return "dynamic label";
            }
        })
    ]
});
logger.log('info', 'test'); // -> "info: [dynamic label] test"
```