### PR TITLE
Adjust the log file output order

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -189,14 +189,20 @@ exports.log = function (options) {
     if (options.logstash === true) {
       // use logstash format
       var logstashOutput = {};
-      if (output.message !== undefined) {
-        logstashOutput['@message'] = output.message;
-        delete output.message;
-      }
 
       if (output.timestamp !== undefined) {
         logstashOutput['@timestamp'] = output.timestamp;
         delete output.timestamp;
+      }
+
+      if (output.level !== undefined) {
+        logstashOutput['@level'] = output.level;
+        delete output.level;
+      }
+
+      if (output.message !== undefined) {
+        logstashOutput['@message'] = output.message;
+        delete output.message;
       }
 
       logstashOutput['@fields'] = exports.clone(output);


### PR DESCRIPTION
Adjust the log file output order from {'@message', '@ timestamp', '@ fields'} to {'@timestamp', '@ level', '@ message', '@ fields'}, easy to view the log files