### PR TITLE
fix: clone() cloning prototype's custom methods for 2.x

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -104,17 +104,19 @@ function clone(obj) {
   var copy = Array.isArray(obj) ? [] : {};
 
   for (var i in obj) {
-    if (Array.isArray(obj[i])) {
-      copy[i] = obj[i].slice(0);
-    }
-    else if (obj[i] instanceof Buffer) {
+    if (obj.hasOwnProperty(i)) {
+      if (Array.isArray(obj[i])) {
         copy[i] = obj[i].slice(0);
-    }
-    else if (typeof obj[i] != 'function') {
-      copy[i] = obj[i] instanceof Object ? exports.clone(obj[i]) : obj[i];
-    }
-    else if (typeof obj[i] === 'function') {
-      copy[i] = obj[i];
+      }
+      else if (obj[i] instanceof Buffer) {
+        copy[i] = obj[i].slice(0);
+      }
+      else if (typeof obj[i] != 'function') {
+        copy[i] = obj[i] instanceof Object ? exports.clone(obj[i]) : obj[i];
+      }
+      else if (typeof obj[i] === 'function') {
+        copy[i] = obj[i];
+      }
     }
   }
 


### PR DESCRIPTION
Hi @indexzero 

I created this pull request for the version 2.x references to my old pull request [#1078](https://github.com/winstonjs/winston/pull/1078)

fix: clone method in common.js should not clone the prototype custom methods for 2.x version

```
var a = [1,2];
Array.prototype.try = function() {return true;};
winston.info(a);  // info:  0=1, 1=2, try=function () {return true;}
```