### PR TITLE
Propagating error stack to formatter

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -171,6 +171,11 @@ Logger.prototype.log = function log(level, msg, meta) {
   }
 
   const info = Object.assign({}, meta, { [LEVEL]: level, level, message: msg });
+
+  if (meta.stack) {
+    info.stack = meta.stack;
+  }
+
   this.write(info);
   return this;
 };


### PR DESCRIPTION
Hello team,

I found that Winston logger is losing Error stack property when it is copying properties from original `meta` properties to `info` object properties. Since `stack` is not enumerable, it is lost during the assignment, and then formatters have no way to access this information. 

This is three-liner fix to copy `stack` separately. Let me know if you think it makes sense, I'll then add a test case to cover this flow.