### PR TITLE
Require the package.json by its full name.

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -15,7 +15,7 @@ const winston = exports;
 // Expose version. Use `require` method
 // for `webpack` support.
 //
-winston.version = require('../package').version;
+winston.version = require('../package.json').version;
 
 //
 // Include transports defined by default by winston


### PR DESCRIPTION
When using Winston with Rollup and [rollup-plugin-json](https://github.com/rollup/rollup-plugin-json), the following error is thrown:

```
./node_modules/.bin/rollup -c

index.js → lib/bundle.js...
[!] Error: Could not resolve '../package' from node_modules/winston/lib/winston.js
Error: Could not resolve '../package' from node_modules/winston/lib/winston.js
```

The code change in this PR fixes that and gets one step closer to using Rollup to bundle Winston.