### PR TITLE
[fix] Bind this context for _onDrain and _onError methods

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -383,15 +383,21 @@ File.prototype._needsNewFile = function (size) {
   return this.maxsize && size >= this.maxsize;
 };
 
-File.prototype._onDrain = function onDrain() {
-  if (--this._drains) return;
-  var next = this._next;
-  this._next = noop;
-  next();
+File.prototype._onDrain = function () {
+  function onDrain() {
+    if (--this._drains) return;
+    var next = this._next;
+    this._next = noop;
+    next();
+  }
+  return onDrain.bind(this);
 };
 
-File.prototype._onError = function onError(err) {
-  this.emit('error', err);
+File.prototype._onError = function () {
+  function onError(err) {
+    this.emit('error', err);
+  }
+  return onError.bind(this);
 };
 
 File.prototype._setupStream = function (stream) {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -48,6 +48,12 @@ var File = module.exports = function (options) {
   //
   this._stream = new PassThrough();
 
+  //
+  // Bind this context for listener functions
+  //
+  this._onDrain = this._onDrain.bind(this);
+  this._onError = this._onError.bind(this);
+
   if (options.filename || options.dirname) {
     throwIf('filename or dirname', 'stream');
     this._basename = this.filename = options.filename
@@ -383,21 +389,15 @@ File.prototype._needsNewFile = function (size) {
   return this.maxsize && size >= this.maxsize;
 };
 
-File.prototype._onDrain = function () {
-  function onDrain() {
-    if (--this._drains) return;
-    var next = this._next;
-    this._next = noop;
-    next();
-  }
-  return onDrain.bind(this);
+File.prototype._onDrain = function onDrain() {
+  if (--this._drains) return;
+  var next = this._next;
+  this._next = noop;
+  next();
 };
 
-File.prototype._onError = function () {
-  function onError(err) {
-    this.emit('error', err);
-  }
-  return onError.bind(this);
+File.prototype._onError = function onError(err) {
+  this.emit('error', err);
 };
 
 File.prototype._setupStream = function (stream) {


### PR DESCRIPTION
Binds the this context for _onDrain and _onError methods in the File
transport to allow access to the this._next and this._drains properties.

See issue #1102 for more information