### PR TITLE
fix: update self.filename on ENOENT in fs.stat callback - fixes #1098

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -343,6 +343,8 @@ File.prototype.stat = function stat(callback) {
   fs.stat(fullpath, function (err, stat) {
     if (err && err.code === 'ENOENT') {
       debug('err ENOENT', fullpath);
+      // Update internally tracked filename with the new target name
+      self.filename = target;
       return callback(null, 0);
     }
 


### PR DESCRIPTION
This PR fixes a bug reported in #1098 where `maxsize` option appears to be ignored in `File` transport. 

The root cause was `self.filename` not being updated on `ENOENT` before calling `_createStream()` which effectively re-opens the existing file and continue writing to it.