### PR TITLE
Bugfix: logger throws if passed null or undefined

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -40,7 +40,9 @@ module.exports = function (opts) {
       // Optimize the hot-path which is the single object.
       //
       if (arguments.length === 1) {
-        const info = msg.message && msg || { message: msg };
+        const info = msg && msg.hasOwnProperty('message') ?
+              msg : 
+              { message: msg };
         info.level = info[LEVEL] = level;
         this.write(info);
         return this;


### PR DESCRIPTION
**Before:**
```
logger.debug(null) // Throws
```
**After:**
```
logger.debug(null) // Logs { message: null }
```