### PR TITLE
Explain a little more about formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,13 @@ formats": `json`, `logstash`, `printf`, `prettyPrint`, and `simple`.
 ## Formats
 
 Formats in `winston` can be accessed from `winston.format`. They are
-implemented in, `logform`, a separate module from `winston`. This allows
-flexibility when writing your own transports in case you wish to include a
-default format with your transport.
+implemented in [`logform`](https://github.com/winstonjs/logform), a separate
+module from `winston`. This allows flexibility when writing your own transports
+in case you wish to include a default format with your transport.
 
-In modern versions of `node` template strings are very performant and are the recommended way for doing most end-user formatting. If you want to bespoke format your logs, `winston.format.printf` is for you:
+In modern versions of `node` template strings are very performant and are the
+recommended way for doing most end-user formatting. If you want to bespoke
+format your logs, `winston.format.printf` is for you:
 
 ``` js
 const { createLogger, format, transports } = require('winston');
@@ -246,6 +248,10 @@ const logger = createLogger({
   transports: [new transports.Console()]
 });
 ```
+
+To see what built-in formats are available and learn more about creating your
+own custom logging formats, see
+[`logform`](https://github.com/winstonjs/logform).
 
 ### Combining formats
 


### PR DESCRIPTION
In the README, link to the `logform` project, and tell readers to look there to learn more about logging formats.