### PR TITLE
Fix compatibility with Babel 6.26.0 (latest)

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -353,14 +353,14 @@ Logger.prototype.query = function query(options, callback) {
 
   options = options || {};
   const results = {};
-  const query = common.clone(options.query) || {};
+  const queryObject = common.clone(options.query) || {};
 
   //
   // Helper function to query a single transport
   //
   function queryTransport(transport, next) {
     if (options.query) {
-      options.query = transport.formatQuery(query);
+      options.query = transport.formatQuery(queryObject);
     }
 
     transport.query(options, function (err, results) {


### PR DESCRIPTION
Babel 6.26.0 does not support `const` locals that have the same name as the enclosing function. This PR renames a variable to work around that.