### PR TITLE
The prototype methods should return like the original method

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -51,7 +51,7 @@ module.exports = function (opts) {
       // 1. v3 API: log(obj)
       // 2. v1/v2 API: log(level, msg, ... [string interpolate], [{metadata}], [callback])
       //
-      this.log.apply(this, [level].concat(Array.prototype.slice.call(arguments)));
+      return this.log.apply(this, [level].concat(Array.prototype.slice.call(arguments)));
     };
   });
 


### PR DESCRIPTION
The function error/info/warn.. should return object as log function.

[https://github.com/winstonjs/winston/issues/1152](https://github.com/winstonjs/winston/issues/1152)