### PR TITLE
Add silent option to Console transport

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -70,6 +70,11 @@ Console.prototype.name = 'console';
 // Core logging method exposed to Winston.
 //
 Console.prototype.log = function (info, callback) {
+  if (this.silent) {
+    callback();
+    return true;
+  }
+
   var self = this;
   setImmediate(function () {
     self.emit('logged', info);


### PR DESCRIPTION
Hi, we use the `silent` option to suppress certain logs while running tests. It seems to be missing from this version of Winston.