### PR TITLE
Fix race condition with compressing file in tail mode

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -385,7 +385,9 @@ File.prototype.open = function (callback) {
     return this._createStream();
   }
 
-  this._archive = this.zippedArchive ? this._stream.path : null;
+  if ( ! this._archive && ! this.tailable && this.zippedArchive ) {
+    this._archive = this._stream.path;
+  }
 
   //
   // Otherwise we have a valid (and ready) stream.
@@ -511,6 +513,7 @@ File.prototype._createStream = function () {
 
         self.opening = false;
         self.emit('open', fullname);
+        compressFile();
       });
       //
       // Remark: It is possible that in the time it has taken to find the
@@ -518,8 +521,9 @@ File.prototype._createStream = function () {
       // but for sensible limits (10s - 100s of MB) this seems unlikely in less
       // than one second.
       //
-      self.flush();
-      compressFile();
+      self._stream.once('open', function () {
+        self.flush();
+      });
     }
 
     function compressFile() {


### PR DESCRIPTION
When writing fast enough to a log with a fast enough rotation, one might "reset" the archive filename which will result in error something similar to:
```
ENOENT: no such file or directory, open 'logs/somename1.log'
```

Also, we should wait for file's writable stream "open" event to emit before we continue further.  

Can reproduce the error with this test app:
https://github.com/yurynix/winston-test

Might fix #800 