### PR TITLE
Updating README.md: Events example has a syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,7 +883,7 @@ message:
 ``` js
 const transport = new winston.transports.Console();
 const logger = winston.createLogger({
-  transports: [transport];
+  transports: [transport]
 });
 
 transport.on('logged', function (info) {


### PR DESCRIPTION
- Removing miswritten semicolon.