### PR TITLE
Don't swallow Error message/stack when using formatter

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -219,6 +219,11 @@ exports.log = function (options) {
   //
   if (typeof options.formatter == 'function') {
     options.meta = meta || options.meta;
+    if (options.meta instanceof Error) {
+      // Force converting the Error to an plain object now so it
+      // will not be messed up by decycle() when cloning options
+      options.meta = exports.clone(options.meta);
+    }
     return String(options.formatter(exports.clone(options)));
   }
 


### PR DESCRIPTION
Fixes #1178

When we use a formatter and pass an `Error` object in as `meta`,
we end up removing the Error's message and stack information when
`decycle`ing it. `clone` checks if the passed-in object is an `Error`
and does not `decycle` it in that case, but when we use a formatter,
this check does not happen because we `clone` the whole `options` object
instead of just cloning `options.meta`.

By `clone`ing `meta` alone when it is an Error,
the `instanceof Error` check will catch it and copy `message` and `stack`
into a new, non-Error object. So when that's buried in `options.meta`,
re-`clone`ing it won't hurt.