### PR TITLE
Can pass null or undefined message

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -40,7 +40,7 @@ module.exports = function (opts) {
       // Optimize the hot-path which is the single object.
       //
       if (arguments.length === 1) {
-        const info = msg.message && msg || { message: msg };
+        const info = msg && msg.message && msg || { message: msg };
         info.level = info[LEVEL] = level;
         this.write(info);
         return this;


### PR DESCRIPTION
Otherwise throws 'Cannot read property 'message' of null' when logging null.