### PR TITLE
fixes #1138 stream.Stream is not a constructor

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -412,7 +412,7 @@ Logger.prototype.query = function query(options, callback) {
 // #### @options {Object} Stream options for this instance.
 // Returns a log stream for all transports. Options object is optional.
 //
-Logger.prototype.stream = function stream(options) {
+Logger.prototype.stream = function _stream(options) {
   options = options || {};
 
   const out = new stream.Stream();

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -70,6 +70,13 @@ describe('Logger', function () {
     logger.log(expected);
   });
 
+  it('.stream()', function () {
+    var logger = winston.createLogger();
+    var outStream = logger.stream();
+
+    assume(isStream(outStream)).true();
+  });
+
   it('.configure()', function () {
     var logger = winston.createLogger({
       transports: [new winston.transports.Console()]


### PR DESCRIPTION
fixes #1138 

additionally, I think there is a typo [here](https://github.com/winstonjs/winston/blob/master/test/logger.test.js#L27), but I didn't want to mix concerns, I might create a new PR for this.