### PR TITLE
Roadmap & guidelines for contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at charlie.robbins@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ TL;DR? The `winston` project is actively working towards getting `3.0.0` out of 
    - [Bugs][#bugs]
    - [Documentation](#documentation)
    - [Feature Requests](#feature-requests)
+- [Be kind & actively empathetic to one another](CODE_OF_CONDUCT.md)
 
 Looking for somewhere to help? Checkout the [Roadmap](#roadmap) & help triage open issues! Find an issue that looks like a duplicate? It probably is! Comment on it so we know it's maybe a duplicate 🙏.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,91 @@
+# CONTRIBUTING
+
+TL;DR? The `winston` project is actively working towards getting `3.0.0` out of RC (currently `3.0.0-rc1`). 
+
+- [What makes up `winston@3.0.0`?](#what-makes-up-winston-3.0.0)
+- [What about `winston@2.x`?!](#what-about-winston-2.x)
+- [Roadmap](#roadmap)
+   - [Bugs][#bugs]
+   - [Documentation](#documentation)
+   - [Feature Requests](#feature-requests)
+
+Looking for somewhere to help? Checkout the [Roadmap](#roadmap) & help triage open issues! Find an issue that looks like a duplicate? It probably is! Comment on it so we know it's maybe a duplicate 🙏.
+
+## What makes up `winston@3.0.0`?
+
+As of `winston@3.0.0` the project has been broken out into a few modules:
+
+- [winston-transport]: `Transport` stream implementation & legacy `Transport` wrapper.
+- [logform]: All formats exports through `winston.format` 
+- `LEVEL` and `MESSAGE` symbols exposed through [triple-beam].
+- [Shared test suite][abstract-winston-transport] for community transports 
+
+Let's dig in deeper. The example below has been annotated to demonstrate the different packages that compose the example itself:
+
+``` js
+const { createLogger, transports, format } = require('winston');
+const Transport = require('winston-transport');
+const logform = require('logform');
+const { combine, timestamp, label, printf } = logform.format;
+
+// winston.format is require('logform')
+console.log(logform.format === format) // true
+
+const logger = createLogger({
+  format: combine(
+    label({ label: 'right meow!' }),
+    timestamp(),
+    printf(nfo => {
+      return `${nfo.timestamp} [${nfo.label}] ${nfo.level}: ${nfo.message}`;
+    })
+  ),
+  transports: [new transports.Console()]
+});
+```
+
+
+## What about `winston@2.x`?!
+
+> _If you are opening an issue regarding the `2.x` release-line please know that 2.x work has ceased. The `winston` team will review PRs that fix issues, but as issues are opened we will close them._
+
+## Roadmap
+
+Below is the list of items that make up the roadmap through `3.1.0`. We are actively triaging the open issues, so it is likely a few more critical path items will be added to this list before `3.0.0` gets out of RC.
+
+- [Bugs][#bugs]
+- [Documentation](#documentation)
+- [Feature Requests](#feature-requests)
+
+### Bugs
+
+#### Show stoppers before `3.0.0`
+
+- [ ] https://github.com/winstonjs/winston/issues/1144: this is _the_ purpose of `winston`. If we cannot log at high-volume we cannot ship out of RC. There was [test coverage for this][stress-test] that should be failing, but isnt
+- [ ] Triage all open issues.
+
+### Documentation
+
+- [ ] Finish `3.0.0` upgrade guide: https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md
+- [ ] Update `docs/transports.md`.
+
+### Feature Requests
+
+Below is the known set of high-priority feature requests to support the community. Don't see your request here? Get more 👍!
+
+#### Must have before `3.0.0`
+
+There are no known feature requests that are considered **must have** for `3.0.0` to get out of RC. 
+
+#### Must have before `3.1.0`
+
+- [Type definitions for TypeScript](https://github.com/winstonjs/winston/issues/1096)
+- [Browser support](https://github.com/winstonjs/winston/issues/287)
+- Benchmarking for `File` and `Stream` transports:
+   - See: https://github.com/winstonjs/logmark
+   - See also: https://github.com/pinojs/pino/pull/232
+
+[winston-transport]: https://github.com/winstonjs/winston-transport
+[logform]: https://github.com/winstonjs/logform
+[triple-beam]: https://github.com/winstonjs/triple-beam
+[abstract-winston-transport]: https://github.com/winstonjs/abstract-winston-transport
+[stress-test]: https://github.com/winstonjs/winston/blob/master/test/transports/file-stress.test.js


### PR DESCRIPTION
> _Since publishing the `3.0.0-rc` this past November a number of things have kept me quite busy in my personal life. I won't go into the details, but those who know me know it's been a rough 18-months. Things have not calmed down, but hey, that's life._

The purpose of this PR is to outline the current roadmap in the context of issues that have been triaged. There are a number still to triage so the list may change. If you're interested in contributing please respond to this issue with the number of hours per month you could dedicate and how complex of an issue on a scale of 1 - 10 you feel you want to take on:

- 1 being trivial, probably a duplicate. 
- 10 being you feel comfortable running a custom build of `node` to verify it's not a bug in `node` itself if it comes to that.

A few folks have volunteered to help triage issues _(virtually)_ face-to-face over the next month to six weeks. Current strawman goal is to ship `3.0.0` out of RC by end of March.