### PR TITLE
[fix] handle close errors

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -63,7 +63,15 @@ exports.tailFile = function (options, iter) {
 
     (function read() {
       if (stream.destroyed) {
-        fs.close(fd);
+        fs.close(fd, function (err) {
+          if (err) {
+            if (!iter) {
+              stream.emit('error', err);
+            } else {
+              iter(err);
+            }
+          }
+        });
         return;
       }
 


### PR DESCRIPTION
Not using a callback is deprecated. Errors should properly be
handled and this a adds callback to do so.

Refs: https://github.com/nodejs/node/pull/18668