### PR TITLE
Fix the anchor for [Google Stackdriver Logging]

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -31,7 +31,7 @@ There are several [core transports](#winston-core) included in `winston`, which 
   * [Logsene](#logsene-transport) (including Log-Alerts and Anomaly Detection)
   * [Logz.io](#logzio-transport)
   * [Pusher](#pusher-transport)
-  * [Google Stackdriver Logging)(#google-stackdriver-transport)
+  * [Google Stackdriver Logging](#google-stackdriver-transport)
 
 ## Winston Core
 


### PR DESCRIPTION
The anchor is broken due to a typo, I'm trying to fix that.