### PR TITLE
Update downloads badge to point to graph of downloads over time 📈 instead of duplicating link to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A logger for just about everything.
 
-[![Version npm](https://img.shields.io/npm/v/winston.svg?style=flat-square)](https://www.npmjs.com/package/winston)[![npm Downloads](https://img.shields.io/npm/dm/winston.svg?style=flat-square)](https://www.npmjs.com/package/winston)[![Build Status](https://img.shields.io/travis/winstonjs/winston/master.svg?style=flat-square)](https://travis-ci.org/winstonjs/winston)[![Dependencies](https://img.shields.io/david/winstonjs/winston.svg?style=flat-square)](https://david-dm.org/winstonjs/winston)
+[![Version npm](https://img.shields.io/npm/v/winston.svg?style=flat-square)](https://www.npmjs.com/package/winston)[![npm Downloads](https://img.shields.io/npm/dm/winston.svg?style=flat-square)](https://npmcharts.com/compare/winston?minimal=true)[![Build Status](https://img.shields.io/travis/winstonjs/winston/master.svg?style=flat-square)](https://travis-ci.org/winstonjs/winston)[![Dependencies](https://img.shields.io/david/winstonjs/winston.svg?style=flat-square)](https://david-dm.org/winstonjs/winston)
 
 [![NPM](https://nodei.co/npm/winston.png?downloads=true&downloadRank=true)](https://nodei.co/npm/winston/)
 


### PR DESCRIPTION
Hi! I noticed that your "npm" badge and "downloads" badge currently both point to the same page for the project on npmjs.org  

I was wondering if you might prefer having the download badge point to a [download chart](https://npmcharts.com/compare/winston?minimal=true) instead?

If not, feel free to close and apologies for the drive-by PR 😄