### PR TITLE
Always pass a function to fs.close

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -412,7 +412,7 @@ exports.tailFile = function(options, callback) {
 
     (function read() {
       if (stream.destroyed) {
-        fs.close(fd);
+        fs.close(fd, nop);
         return;
       }
 
@@ -497,3 +497,5 @@ exports.stringArrayToSet = function (strArray, errMsg) {
     return set;
   }, Object.create(null));
 };
+
+function nop () {}


### PR DESCRIPTION
This fixes DEP0013 in Node.js.
Without this fix Winston would break in Node.js 10.