### PR TITLE
Always pass a function to fs.close

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -63,7 +63,7 @@ exports.tailFile = function (options, iter) {
 
     (function read() {
       if (stream.destroyed) {
-        fs.close(fd);
+        fs.close(fd, nop);
         return;
       }
 
@@ -181,3 +181,5 @@ exports.warn = {
     });
   }
 };
+
+function nop () {}


### PR DESCRIPTION
This fixes DEP0013 in Node.js.
Without this fix Winston would break in Node.js 10.

See nodejs/node#18668 for more details.