### PR TITLE
fix silent options for file and console transports

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -70,6 +70,11 @@ Console.prototype.name = 'console';
 // Core logging method exposed to Winston.
 //
 Console.prototype.log = function (info, callback) {
+  if (this.silent) {
+    callback();
+    return true;
+  }
+
   var self = this;
   setImmediate(function () {
     self.emit('logged', info);

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -11,6 +11,8 @@ const util = require('util');
 const { LEVEL, MESSAGE } = require('triple-beam');
 const TransportStream = require('winston-transport');
 
+var noop = function () {};
+
 //
 // ### function Console (options)
 // #### @options {Object} Options for this instance.
@@ -23,6 +25,7 @@ var Console = module.exports = function (options) {
 
   this.stderrLevels = getStderrLevels(options.stderrLevels, options.debugStdout);
   this.eol = options.eol || os.EOL;
+  this.silent = options.silent || false;
 
   //
   // Convert stderrLevels into an Object for faster key-lookup times than an Array.
@@ -70,6 +73,8 @@ Console.prototype.name = 'console';
 // Core logging method exposed to Winston.
 //
 Console.prototype.log = function (info, callback) {
+  callback = callback || noop;
+
   if (this.silent) {
     callback();
     return true;

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -81,6 +81,7 @@ var File = module.exports = function (options) {
   this.maxFiles    = options.maxFiles    || null;
   this.eol         = options.eol || os.EOL;
   this.tailable    = options.tailable    || false;
+  this.silent      = options.silent    || false;
 
   //
   // Internal state variables representing the number

--- a/test/transports/console.test.js
+++ b/test/transports/console.test.js
@@ -36,7 +36,8 @@ const transports = {
       epsilon: 4,
     },
     stderrLevels: ['delta', 'epsilon']
-  })
+  }),
+  silent: new winston.transports.Console({ silent: true })
 };
 
 /**
@@ -77,6 +78,35 @@ describe('Console transport', function () {
       assume(output.stderr).length(2);
       assume(output.stdout).is.an('array');
       assume(output.stdout).length(5);
+    });
+
+    it("should set stderrLevels to ['error', 'debug'] by default", assertStderrLevels(
+      transports.defaults,
+      ['error', 'debug']
+    ));
+
+    it('does not log to console if silent is true', function () {
+      stdMocks.use({ print: true });
+
+      transports.silent.levels = defaultLevels;
+      Object.keys(defaultLevels)
+        .forEach(function (level) {
+          const info = {
+            [LEVEL]: level,
+            message: `This is level ${level}`,
+            level
+          };
+
+          info[MESSAGE] = JSON.stringify(info);
+          transports.silent.log(info);
+        });
+
+      stdMocks.restore();
+      var output = stdMocks.flush();
+      assume(output.stderr).is.an('array');
+      assume(output.stderr).length(0);
+      assume(output.stdout).is.an('array');
+      assume(output.stdout).length(0);
     });
 
     it("should set stderrLevels to ['error', 'debug'] by default", assertStderrLevels(


### PR DESCRIPTION
These changes fix the silent option in the file and console transports so that winston behaves as expected from the documentation [here](https://github.com/winstonjs/winston/blob/master/docs/transports.md#winston-core). This PR includes some fixed changes from the PR from @bjisa [here](https://github.com/winstonjs/winston/pull/1170).

I've added tests for this option for both transports.