### PR TITLE
Add example demonstrating how `meta` objects BECOME the `info` object.

### DIFF
--- a/examples/metadata.js
+++ b/examples/metadata.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const winston = require('../');
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format(function (info, opts) {
+      console.log(`{ reason: ${info.reason}, promise: ${info.promise} }`);
+      return info;
+    })(),
+    winston.format.json()
+  ),
+  transports: [
+    new winston.transports.Console()
+  ]
+});
+
+logger.info('my message', { reason: 'whatever', promise: 'whenever' });


### PR DESCRIPTION
Demonstrative example attempting to fill the gap in the docs that led to #1225. In the presence of a `meta` object using the legacy api:

``` js
logger.log(level, msg, meta);
logger[level](msg, meta);
```

The `meta` object **BECOMES** the `info` object passed to a format in:

``` js
const yourFormat = winston.format(info => {
  // info **IS** the same object reference as meta here.
});
```

Fixes #1225.