### PR TITLE
Add support for "silent" option. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ A logger accepts the following parameters:
 | `format`      | `winston.formats.json` | Formatting for `info` messages  (see: [Formats])           |
 | `transports`  | `[]` _(No transports)_ | Set of logging targets for `info` messages                 |
 | `exitOnError` | `true`                 | If false, handled exceptions will not cause `process.exit` |
+| `silent`      | `false`                | If true, all logs are suppressed |
 
 The levels provided to `createLogger` will be defined as convenience methods
 on the `logger` returned. 

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -43,6 +43,7 @@ Logger.prototype.configure = function (options) {
   }
 
   options = options || {};
+  this.silent = options.silent;
   this.format = options.format || this.format || require('logform/json')();
 
   var levels = options.levels || this.levels || config.npm.levels;
@@ -187,6 +188,10 @@ Logger.prototype.log = function log(level, msg, meta) {
  * our pipe targets.
  */
 Logger.prototype._transform = function _transform(info, enc, callback) {
+  if (this.silent) {
+    return callback();
+  }
+
   //
   // [LEVEL] is only soft guaranteed to be set here since we are a proper
   // stream. It is likely that `info` came in through `.log(info)` or

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "one-time": "0.0.4",
     "stack-trace": "0.0.x",
     "triple-beam": "^1.0.1",
-    "winston-transport": "^3.0.1"
+    "winston-transport": "^3.1.0"
   },
   "devDependencies": {
     "abstract-winston-transport": ">= 0.5.1",

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -165,6 +165,26 @@ describe('Logger', function () {
     logger.clear();
     assume(logger.transports.length).equals(0);
   });
+
+  it('{ silent: true }', function (done) {
+    const neverLogTo = new TransportStream({
+      log: function (info) {
+        assume(false).true('TransportStream was improperly written to');
+      }
+    });
+
+    var logger = winston.createLogger({
+      transports: [neverLogTo],
+      silent: true
+    });
+
+    logger.log({
+      level: 'info',
+      message: 'This should be ignored'
+    });
+
+    setImmediate(() => done());
+  });
 });
 
 describe('Logger (multiple transports of the same type)', function () {


### PR DESCRIPTION
Also upgrades to version of `winston-transport` that supports "silent" on TransportStream instances.

``` js
const winston = require('winston');

const logger = winston.createLogger({
  silent: true
});

// No matter what you do
// ...
// No matter what transports get added
// ...
// Nothing gets out of the Logger ._transform method
```

For context it made sense to bring back this option from `winston@2` because it had specifically to do with cardinality of objects being written through the pipe-chain of `objectMode` streams that make up `winston@3`.