### PR TITLE
[fix] Use Buffer.alloc and Buffer.from instead of new Buffer

### DIFF
--- a/lib/winston/tail-file.js
+++ b/lib/winston/tail-file.js
@@ -12,7 +12,7 @@ function nop() {}
 // `tail -f` a file. Options must include file.
 //
 module.exports = function tailFile(options, iter) {
-  const buffer = new Buffer(64 * 1024);
+  const buffer = Buffer.alloc(64 * 1024);
   const decode = new StringDecoder('utf8');
   const stream = new Stream();
   let buff = '';

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -202,5 +202,5 @@ Http.prototype._request = function (options, callback) {
     }).resume();
   });
 
-  req.end(new Buffer(JSON.stringify(options), 'utf8'));
+  req.end(Buffer.from(JSON.stringify(options), 'utf8'));
 };


### PR DESCRIPTION
Changed two instances of `new Buffer` to `Buffer.alloc`/`Buffer.from`. Fixes #1244.