### PR TITLE
[refactor] Move code base to es6 and setup for api documentation.

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -1,146 +1,182 @@
-/*
+/**
  * winston.js: Top-level include defining Winston.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
-const common = require('./winston/common');
-const warn = common.warn;
+'use strict';
 
+const logform = require('logform');
+const { warn } = require('./winston/common');
+
+/**
+ * Setup to expose.
+ * @type {Object}
+ */
 const winston = exports;
 
-//
-// Expose version. Use `require` method
-// for `webpack` support.
-//
+/**
+ * Expose version. Use `require` method for `webpack` support.
+ * @type {string}
+ */
 winston.version = require('../package.json').version;
-
-//
-// Include transports defined by default by winston
-//
+/**
+ * Include transports defined by default by winston
+ * @type {Array}
+ */
 winston.transports = require('./winston/transports');
-
-//
-// Expose utility methods
-//
-winston.config    = require('./winston/config');
-
-//
-// Hoist format-related functionality from logform.
-//
-const logform = require('logform');
+/**
+ * Expose utility methods
+ * @type {Object}
+ */
+winston.config = require('./winston/config');
+/**
+ * Hoist format-related functionality from logform.
+ * @type {Object}
+ */
 winston.addColors = logform.levels;
-winston.format    = logform.format;
-
-//
-// Expose core Logging-related prototypes.
-//
-winston.createLogger     = require('./winston/create-logger');
+/**
+ * Hoist format-related functionality from logform.
+ * @type {Object}
+ */
+winston.format = logform.format;
+/**
+ * Expose core Logging-related prototypes.
+ * @type {function}
+ */
+winston.createLogger = require('./winston/create-logger');
+/**
+ * Expose core Logging-related prototypes.
+ * @type {Object}
+ */
 winston.ExceptionHandler = require('./winston/exception-handler');
-winston.Container        = require('./winston/container').Container;
-winston.Transport        = require('winston-transport');
-
-//
-// Throw a useful error when users attempt to run `new winston.Logger`.
-//
-warn.moved(winston, 'createLogger', 'Logger');
-
-//
-// We create and expose a default `Container` to `winston.loggers` so that the
-// programmer may manage multiple `winston.Logger` instances without any additional overhead.
-//
-// ### some-file1.js
-//
-//     var logger = require('winston').loggers.get('something');
-//
-// ### some-file2.js
-//
-//     var logger = require('winston').loggers.get('something');
-//
+/**
+ * Expose core Logging-related prototypes.
+ * @type {Container}
+ */
+winston.Container = require('./winston/container');
+/**
+ * Expose core Logging-related prototypes.
+ * @type {Object}
+ */
+winston.Transport = require('winston-transport');
+/**
+ * We create and expose a default `Container` to `winston.loggers` so that the
+ * programmer may manage multiple `winston.Logger` instances without any
+ * additional overhead.
+ * @example
+ *   // some-file1.js
+ *   var logger = require('winston').loggers.get('something');
+ *
+ *   // some-file2.js
+ *   var logger = require('winston').loggers.get('something');
+ */
 winston.loggers = new winston.Container();
 
-//
-// We create and expose a 'defaultLogger' so that the programmer may do the
-// following without the need to create an instance of winston.Logger directly:
-//
-//     var winston = require('winston');
-//     winston.log('info', 'some message');
-//     winston.error('some error');
-//
-var defaultLogger = winston.createLogger();
+/**
+ * We create and expose a 'defaultLogger' so that the programmer may do the
+ * following without the need to create an instance of winston.Logger directly:
+ * @example
+ *   const winston = require('winston');
+ *   winston.log('info', 'some message');
+ *   winston.error('some error');
+ */
+const defaultLogger = winston.createLogger();
 
-//
 // Pass through the target methods onto `winston.
-//
 Object.keys(winston.config.npm.levels).concat([
-  'log',    'query', 'stream',  'add',
-  'remove', 'clear', 'profile', 'startTimer',
-  'handleExceptions', 'unhandleExceptions',
+  'log',
+  'query',
+  'stream',
+  'add',
+  'remove',
+  'clear',
+  'profile',
+  'startTimer',
+  'handleExceptions',
+  'unhandleExceptions',
   'configure'
-]).forEach(function (method) {
+]).forEach(method => {
   winston[method] = function () {
     return defaultLogger[method].apply(defaultLogger, arguments);
   };
 });
 
-//
-// Define getter / setter for the default logger level
-// which need to be exposed by winston.
-//
+/**
+ * Define getter / setter for the default logger level which need to be exposed
+ * by winston.
+ * @type {string}
+ */
 Object.defineProperty(winston, 'level', {
-  get: function () {
+  get() {
     return defaultLogger.level;
   },
-  set: function (val) {
+  set(val) {
     defaultLogger.level = val;
   }
 });
 
-//
-// Define getter for `exceptions` which replaces
-// `handleExceptions` and `unhandleExceptions`
-//
+/**
+ * Define getter for `exceptions` which replaces `handleExceptions` and
+ * `unhandleExceptions`.
+ * @type {Object}
+ */
 Object.defineProperty(winston, 'exceptions', {
-  get: function () { return defaultLogger.exceptions; }
+  get() {
+    return defaultLogger.exceptions;
+  }
 });
 
-//
-// Have friendlier breakage notices for properties that
-// were exposed by default on winston < 3.0
-//
-warn.deprecated(winston, 'setLevels');
-warn.forFunctions(winston,  'useFormat',  ['cli']);
-warn.forProperties(winston, 'useFormat',  ['padLevels', 'stripColors']);
-warn.forFunctions(winston,  'deprecated', ['addRewriter', 'addFilter', 'clone', 'extend']);
-warn.forProperties(winston, 'deprecated', ['emitErrs', 'levelLength']);
-
-//
-// Define getters / setters for appropriate properties of the
-// default logger which need to be exposed by winston.
-//
-['paddings', 'exitOnError'].forEach(function (prop) {
+/**
+ * Define getters / setters for appropriate properties of the default logger
+ * which need to be exposed by winston.
+ * @type {Logger}
+ */
+[
+  'paddings',
+  'exitOnError'
+].forEach(prop => {
   Object.defineProperty(winston, prop, {
-    get: function () {
+    get() {
       return defaultLogger[prop];
     },
-    set: function (val) {
+    set(val) {
       defaultLogger[prop] = val;
     }
   });
 });
 
-//
-// @default {Object}
-// The default transports and exceptionHandlers for
-// the default winston logger.
-//
+/**
+ * The default transports and exceptionHandlers for the default winston logger.
+ * @type {Object}
+ */
 Object.defineProperty(winston, 'default', {
-  get: function () {
+  get() {
     return {
       exceptionHandlers: defaultLogger.exceptionHandlers,
       transports: defaultLogger.transports
     };
   }
 });
+
+// Have friendlier breakage notices for properties that were exposed by default
+// on winston < 3.0.
+warn.deprecated(winston, 'setLevels');
+warn.forFunctions(winston,  'useFormat',  ['cli']);
+warn.forProperties(winston, 'useFormat',  [
+  'padLevels',
+  'stripColors'
+]);
+warn.forFunctions(winston,  'deprecated', [
+  'addRewriter',
+  'addFilter',
+  'clone',
+  'extend'
+]);
+warn.forProperties(winston, 'deprecated', [
+  'emitErrs',
+  'levelLength'
+]);
+// Throw a useful error when users attempt to run `new winston.Logger`.
+warn.moved(winston, 'createLogger', 'Logger');

--- a/lib/winston.js
+++ b/lib/winston.js
@@ -97,11 +97,9 @@ Object.keys(winston.config.npm.levels).concat([
   'handleExceptions',
   'unhandleExceptions',
   'configure'
-]).forEach(method => {
-  winston[method] = function () {
-    return defaultLogger[method].apply(defaultLogger, arguments);
-  };
-});
+]).forEach(method => (
+  winston[method] = args => defaultLogger[method](...args)
+));
 
 /**
  * Define getter / setter for the default logger level which need to be exposed

--- a/lib/winston.js
+++ b/lib/winston.js
@@ -67,10 +67,10 @@ winston.Transport = require('winston-transport');
  * additional overhead.
  * @example
  *   // some-file1.js
- *   var logger = require('winston').loggers.get('something');
+ *   const logger = require('winston').loggers.get('something');
  *
  *   // some-file2.js
- *   var logger = require('winston').loggers.get('something');
+ *   const logger = require('winston').loggers.get('something');
  */
 winston.loggers = new winston.Container();
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -1,56 +1,56 @@
-/*
- * common.js: Internal helper and utility functions for winston
+/**
+ * common.js: Internal helper and utility functions for winston.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
+
+'use strict';
 
 const { format } = require('util');
 
 /**
- * @property {RegExp} formatRegExp
  * Captures the number of format (i.e. %s strings) in a given string.
  * Based on `util.format`, see Node.js source:
  * https://github.com/nodejs/node/blob/b1c8f15c5f169e021f7c46eb7b219de95fe97603/lib/util.js#L201-L230
+ * @type {RegExp}
  */
 exports.formatRegExp = /%[sdjifoO%]/g;
 
 /**
- * @property {RegExp} escapedPercent
  * Captures the number of escaped % signs in a format string (i.e. %s strings).
+ * @type {RegExp}
  */
 exports.escapedPercent = /%%/g;
 
 /**
- * @property {Object} warn
- * Set of simple deprecation notices and a way
- * to expose them for a set of properties.
- *
- * @api private
+ * Set of simple deprecation notices and a way to expose them for a set of
+ * properties.
+ * @type {Object}
+ * @private
  */
 exports.warn = {
-  deprecated: function warnDeprecated(prop) {
-    return function () {
+  deprecated(prop) {
+    return () => {
       throw new Error(format('{ %s } was removed in winston@3.0.0.', prop));
     };
   },
-  useFormat: function warnFormat(prop) {
-    return function () {
+  useFormat(prop) {
+    return () => {
       throw new Error([
         format('{ %s } was removed in winston@3.0.0.', prop),
         'Use a custom winston.format = winston.format(function) instead.'
       ].join('\n'));
     };
   },
-  forFunctions: function (obj, type, props) {
-    props.forEach(function (prop) {
+  forFunctions(obj, type, props) {
+    props.forEach(prop => {
       obj[prop] = exports.warn[type](prop);
     });
   },
-  moved: function (obj, movedTo, prop) {
+  moved(obj, movedTo, prop) {
     function movedNotice() {
-      return function () {
+      return () => {
         throw new Error([
           format('winston.%s was moved in winston@3.0.0.', prop),
           format('Use a winston.%s instead.', movedTo)
@@ -63,9 +63,9 @@ exports.warn = {
       set: movedNotice
     });
   },
-  forProperties: function (obj, type, props) {
-    props.forEach(function (prop) {
-      var notice = exports.warn[type](prop);
+  forProperties(obj, type, props) {
+    props.forEach(prop => {
+      const notice = exports.warn[type](prop);
       Object.defineProperty(obj, prop, {
         get: notice,
         set: notice

--- a/lib/winston/config/cli.js
+++ b/lib/winston/config/cli.js
@@ -1,11 +1,16 @@
-/*
+/**
  * cli.js: Config that conform to commonly used CLI logging levels.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
+'use strict';
+
+/**
+ * Default levels for the CLI configuration.
+ * @type {Object}
+ */
 exports.levels = {
   error: 0,
   warn: 1,
@@ -19,6 +24,10 @@ exports.levels = {
   silly: 9
 };
 
+/**
+ * Default colors for the CLI configuration.
+ * @type {Object}
+ */
 exports.colors = {
   error: 'red',
   warn: 'yellow',

--- a/lib/winston/config/index.js
+++ b/lib/winston/config/index.js
@@ -1,22 +1,34 @@
-/*
+/**
  * index.js: Default settings for all levels that winston knows about
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
+
+'use strict';
 
 const logform = require('logform');
 
-//
-// Export config sets
-//
-exports.cli    = logform.levels(require('./cli'));
-exports.npm    = logform.levels(require('./npm'));
+/**
+ * Export config set for the CLI.
+ * @type {Object}
+ */
+exports.cli = logform.levels(require('./cli'));
+
+/**
+ * Export config set for npm.
+ * @type {Object}
+ */
+exports.npm = logform.levels(require('./npm'));
+
+/**
+ * Export config set for the syslog.
+ * @type {Object}
+ */
 exports.syslog = logform.levels(require('./syslog'));
 
-//
-// Hoist addColors from logform where it was refactored
-// into in winston@3.
-//
+/**
+ * Hoist addColors from logform where it was refactored into in winston@3.
+ * @type {Object}
+ */
 exports.addColors = logform.levels;

--- a/lib/winston/config/index.js
+++ b/lib/winston/config/index.js
@@ -1,5 +1,5 @@
 /**
- * index.js: Default settings for all levels that winston knows about
+ * index.js: Default settings for all levels that winston knows about.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE

--- a/lib/winston/config/npm.js
+++ b/lib/winston/config/npm.js
@@ -1,11 +1,16 @@
-/*
+/**
  * npm.js: Config that conform to npm logging levels.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
+'use strict';
+
+/**
+ * Default levels for the npm configuration.
+ * @type {Object}
+ */
 exports.levels = {
   error: 0,
   warn: 1,
@@ -16,6 +21,10 @@ exports.levels = {
   silly: 6
 };
 
+/**
+ * Default levels for the npm configuration.
+ * @type {Object}
+ */
 exports.colors = {
   error: 'red',
   warn: 'yellow',

--- a/lib/winston/config/syslog.js
+++ b/lib/winston/config/syslog.js
@@ -1,11 +1,16 @@
-/*
+/**
  * syslog.js: Config that conform to syslog logging levels.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
+'use strict';
+
+/**
+ * Default levels for the syslog configuration.
+ * @type {Object}
+ */
 exports.levels = {
   emerg: 0,
   alert: 1,
@@ -17,6 +22,10 @@ exports.levels = {
   debug: 7
 };
 
+/**
+ * Default levels for the syslog configuration.
+ * @type {Object}
+ */
 exports.colors = {
   emerg: 'red',
   alert: 'yellow',

--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -20,8 +20,7 @@ module.exports = class Container {
    * @param {!Object} [options={}] - Default pass-thru options for Loggers.
    */
   constructor(options = {}) {
-    // TODO: replace `loggers` object with a Map.
-    this.loggers = {};
+    this.loggers = new Map();
     this.options = options;
   }
 
@@ -33,7 +32,7 @@ module.exports = class Container {
    * @returns {Logger} - A configured Logger instance with a specified id.
    */
   add(id, options) {
-    if (!this.loggers[id]) {
+    if (!this.loggers.has(id)) {
       // Remark: Simple shallow clone for configuration options in case we pass
       // in instantiated protoypal objects
       options = Object.assign({}, options || this.options);
@@ -43,11 +42,12 @@ module.exports = class Container {
       // make copies of those references.
       options.transports = existing ? existing.slice() : [];
 
-      this.loggers[id] = createLogger(options);
-      this.loggers[id].on('close', () => this._delete(id));
+      const logger = createLogger(options);
+      logger.on('close', () => this._delete(id));
+      this.loggers.set(id, logger);
     }
 
-    return this.loggers[id];
+    return this.loggers.get(id);
   }
 
   /**
@@ -68,7 +68,7 @@ module.exports = class Container {
    * logger with the specified `id`.
    */
   has(id) {
-    return !!this.loggers[id];
+    return !!this.loggers.has(id);
   }
 
   /**
@@ -82,7 +82,7 @@ module.exports = class Container {
       return this._removeLogger(id);
     }
 
-    Object.keys(this.loggers).forEach(this._removeLogger.bind(this));
+    this.loggers.keys().forEach(this._removeLogger.bind(this));
   }
 
   /**
@@ -92,11 +92,12 @@ module.exports = class Container {
    * @private
    */
   _removeLogger(id) {
-    if (!this.loggers[id]) {
+    if (!this.loggers.has(id)) {
       return;
     }
 
-    this.loggers[id].close();
+    const logger = this.loggers.get(id);
+    logger.close();
     this._delete(id);
   }
 
@@ -108,6 +109,6 @@ module.exports = class Container {
    * @private
    */
   _delete(id) {
-    delete this.loggers[id];
+    this.loggers.delete(id);
   }
 };

--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -1,100 +1,113 @@
-/*
- * container.js: Inversion of control container for winston logger instances
+/**
+ * container.js: Inversion of control container for winston logger instances.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
+'use strict';
+
 const createLogger = require('./create-logger');
-const extend = require('util')._extend;
 
-//
-// ### function Container (options)
-// #### @options {Object} Default pass-thru options for Loggers
-// Constructor function for the Container object responsible for managing
-// a set of `winston.Logger` instances based on string ids.
-//
-var Container = exports.Container = function (options) {
-  this.loggers = {};
-  this.options = options || {};
-};
-
-//
-// ### function get / add (id, options)
-// #### @id {string} Id of the Logger to get
-// #### @options {Object} **Optional** Options for the Logger instance
-// Retreives a `winston.Logger` instance for the specified `id`. If
-// an instance does not exist, one is created.
-//
-Container.prototype.get = Container.prototype.add = function (id, options) {
-  const self = this;
-  let existing;
-
-  if (!this.loggers[id]) {
-    //
-    // Remark: Simple shallow clone for configuration options in case we pass in
-    // instantiated protoypal objects
-    //
-    options = extend({}, options || this.options);
-    existing = options.transports || this.options.transports;
-
-    //
-    // Remark: Make sure if we have an array of transports we slice it to make copies
-    // of those references.
-    //
-    options.transports = existing ? existing.slice() : [];
-
-    this.loggers[id] = createLogger(options);
-    this.loggers[id].on('close', function () {
-      self._delete(id);
-    });
+/**
+ * Inversion of control container for winston logger instances.
+ * @type {Container}
+ */
+module.exports = class Container {
+  /**
+   * Constructor function for the Container object responsible for managing a
+   * set of `winston.Logger` instances based on string ids.
+   * @param {!Object} [options={}] - Default pass-thru options for Loggers.
+   */
+  constructor(options = {}) {
+    // TODO: replace `loggers` object with a Map.
+    this.loggers = {};
+    this.options = options;
   }
 
-  return this.loggers[id];
-};
+  /**
+   * Retreives a `winston.Logger` instance for the specified `id`. If an
+   * instance does not exist, one is created.
+   * @param {!string} id - The id of the Logger to get.
+   * @param {?Object} [options] - Options for the Logger instance.
+   * @returns {Logger} - A configured Logger instance with a specified id.
+   */
+  add(id, options) {
+    if (!this.loggers[id]) {
+      // Remark: Simple shallow clone for configuration options in case we pass
+      // in instantiated protoypal objects
+      options = Object.assign({}, options || this.options);
+      const existing = options.transports || this.options.transports;
 
-//
-// ### function close (id)
-// #### @id {string} **Optional** Id of the Logger instance to find
-// Returns a boolean value indicating if this instance
-// has a logger with the specified `id`.
-//
-Container.prototype.has = function (id) {
-  return !!this.loggers[id];
-};
+      // Remark: Make sure if we have an array of transports we slice it to
+      // make copies of those references.
+      options.transports = existing ? existing.slice() : [];
 
-//
-// ### function close (id)
-// #### @id {string} **Optional** Id of the Logger instance to close
-// Closes a `Logger` instance with the specified `id` if it exists.
-// If no `id` is supplied then all Loggers are closed.
-//
-Container.prototype.close = function (id) {
-  var self = this;
+      this.loggers[id] = createLogger(options);
+      this.loggers[id].on('close', () => this._delete(id));
+    }
 
-  function removeLogger(id) {
-    if (!self.loggers[id]) {
+    return this.loggers[id];
+  }
+
+  /**
+   * Retreives a `winston.Logger` instance for the specified `id`. If
+   * an instance does not exist, one is created.
+   * @param {!string} id - The id of the Logger to get.
+   * @param {?Object} [options] - Options for the Logger instance.
+   * @returns {Logger} - A configured Logger instance with a specified id.
+   */
+  get(id, options) {
+    return this.add(id, options);
+  }
+
+  /**
+   * Check if the container has a logger with the id.
+   * @param {?string} id - The id of the Logger instance to find.
+   * @returns {boolean} - Boolean value indicating if this instance has a
+   * logger with the specified `id`.
+   */
+  has(id) {
+    return !!this.loggers[id];
+  }
+
+  /**
+   * Closes a `Logger` instance with the specified `id` if it exists.
+   * If no `id` is supplied then all Loggers are closed.
+   * @param {?string} id - The id of the Logger instance to close.
+   * @returns {undefined}
+   */
+  close(id) {
+    if (id) {
+      return this._removeLogger(id);
+    }
+
+    Object.keys(this.loggers).forEach(this._removeLogger.bind(this));
+  }
+
+  /**
+   * Remove a logger based on the id.
+   * @param {!string} id - The id of the logger to remove.
+   * @returns {undefined}
+   * @private
+   */
+  _removeLogger(id) {
+    if (!this.loggers[id]) {
       return;
     }
 
-    self.loggers[id].close();
-    self._delete(id);
+    this.loggers[id].close();
+    this._delete(id);
   }
 
-  if (id) {
-    return removeLogger(id);
+  /**
+   * Deletes a `Logger` instance with the specified `id`.
+   * @param {!string} id - The id of the Logger instance to delete from
+   * container.
+   * @returns {undefined}
+   * @private
+   */
+  _delete(id) {
+    delete this.loggers[id];
   }
-
-  Object.keys(this.loggers).forEach(removeLogger);
 };
-
-//
-// ### @private function _delete (id)
-// #### @id {string} Id of the Logger instance to delete from container
-// Deletes a `Logger` instance with the specified `id`.
-//
-Container.prototype._delete = function (id) {
-  delete this.loggers[id];
-};
-

--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -1,59 +1,77 @@
+/**
+ * create-logger.js: Logger factory for winston logger instances.
+ *
+ * (C) 2010 Charlie Robbins
+ * MIT LICENCE
+ */
+
 'use strict';
 
-const util = require('util');
 const { LEVEL } = require('triple-beam');
 const config = require('./config');
 const Logger = require('./logger');
 const debug = require('diagnostics')('winston:create-logger');
 
-//
-// ### function createLogger (opts)
-// #### @opts {Object} Options for the created logger.
-// Create a new instance of a winston Logger. Creates a new
-// prototype for each instance.
-//
-module.exports = function (opts) {
-  opts = opts || {};
-  opts.levels = opts.levels || config.npm.levels;
+/**
+ * DerivedLogger to attach the logs level methods.
+ * @type {DerivedLogger}
+ * @extends {Logger}
+ */
+class DerivedLogger extends Logger {
+  /**
+   * Create a new class derived logger for which the levels can be attached to
+   * the prototype of. This is a V8 optimization that is well know to increase
+   * performance of prototype functions.
+   * @param {!Object} options - Options for the created logger.
+   */
+  constructor(options) {
+    super(options);
+    this._setupLevels();
+  }
 
-  //
-  // Create a new prototypal derived logger for which the levels
-  // can be attached to the prototype of. This is a V8 optimization
-  // that is well know to increase performance of prototype functions.
-  //
-  function DerivedLogger(options) { Logger.call(this, options); }
-  util.inherits(DerivedLogger, Logger);
-
-  Object.keys(opts.levels).forEach(function (level) {
-    debug('Define prototype method for "%s"', level);
-    if (level === 'log') {
-      console.warn('Level "log" not defined: conflicts with the method "log". Use a different level name.');
-      return;
-    }
-
-    //
-    // Define prototype methods for each log level
-    // e.g. logger.log('info', msg) <––> logger.info(msg)
-    //
-    DerivedLogger.prototype[level] = function (msg) {
-      //
-      // Optimize the hot-path which is the single object.
-      //
-      if (arguments.length === 1) {
-        const info = msg && msg.message && msg || { message: msg };
-        info.level = info[LEVEL] = level;
-        this.write(info);
-        return this;
+  /**
+   * Create the log level methods for the derived logger.
+   * @returns {undefined}
+   * @private
+   */
+  _setupLevels() {
+    Object.keys(this.levels).forEach(level => {
+      debug('Define prototype method for "%s"', level);
+      if (level === 'log') {
+        // eslint-disable-next-line no-console
+        console.warn('Level "log" not defined: conflicts with the method "log". Use a different level name.');
+        return;
       }
 
-      //
-      // Otherwise build argument list which could potentially conform to either
-      // 1. v3 API: log(obj)
-      // 2. v1/v2 API: log(level, msg, ... [string interpolate], [{metadata}], [callback])
-      //
-      return this.log.apply(this, [level].concat(Array.prototype.slice.call(arguments)));
-    };
-  });
+      // Define prototype methods for each log level
+      // e.g. logger.log('info', msg) <––> logger.info(msg)
+      DerivedLogger.prototype[level] = function (msg) {
+        // Optimize the hot-path which is the single object.
+        if (arguments.length === 1) {
+          const info = msg && msg.message && msg || { message: msg };
+          info.level = info[LEVEL] = level;
+          this.write(info);
+          return this;
+        }
 
+        // Otherwise build argument list which could potentially conform to
+        // either:
+        // . v3 API: log(obj)
+        // 2. v1/v2 API: log(level, msg, ... [string interpolate], [{metadata}], [callback])
+        return this.log.apply(this, [level]
+          .concat(Array.prototype.slice.call(arguments)));
+      };
+    });
+  }
+}
+
+/**
+ * Create a new instance of a winston Logger. Creates a new
+ * prototype for each instance.
+ * @param {!Object} opts - Options for the created logger.
+ * @returns {Logger} - A newly created logger instance.
+ */
+module.exports = (opts = {}) => {
+  opts.levels = opts.levels || config.npm.levels;
   return new DerivedLogger(opts);
 };

--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -45,9 +45,10 @@ class DerivedLogger extends Logger {
 
       // Define prototype methods for each log level
       // e.g. logger.log('info', msg) <––> logger.info(msg)
-      DerivedLogger.prototype[level] = function (msg) {
+      this[level] = (...args) => {
         // Optimize the hot-path which is the single object.
-        if (arguments.length === 1) {
+        if (args.length === 1) {
+          const [msg] = args;
           const info = msg && msg.message && msg || { message: msg };
           info.level = info[LEVEL] = level;
           this.write(info);
@@ -58,8 +59,7 @@ class DerivedLogger extends Logger {
         // either:
         // . v3 API: log(obj)
         // 2. v1/v2 API: log(level, msg, ... [string interpolate], [{metadata}], [callback])
-        return this.log.apply(this, [level]
-          .concat(Array.prototype.slice.call(arguments)));
+        return this.log(level, ...args);
       };
     });
   }

--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -37,9 +37,8 @@ module.exports = class ExceptionHandler {
    * handlers passed in.
    * @returns {undefined}
    */
-  handle() {
+  handle(...args) {
     const self = this;
-    const args = Array.prototype.slice.call(arguments);
 
     // Helper function
     function add(handler) {

--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -1,9 +1,8 @@
-/*
+/**
  * exception-handler.js: Object for handling uncaughtException events.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
 'use strict';
@@ -15,247 +14,232 @@ const once = require('one-time');
 const stackTrace = require('stack-trace');
 const ExceptionStream = require('./exception-stream');
 
-var ExceptionHandler = module.exports = function (logger) {
-  if (!logger) {
-    throw new Error('Logger is required to handle exceptions');
+/**
+ * Object for handling uncaughtException events.
+ * @type {ExceptionHandler}
+ */
+module.exports = class ExceptionHandler {
+  /**
+   * TODO: add contructor description
+   * @param {!Logger} logger - TODO: add param description
+   */
+  constructor(logger) {
+    if (!logger) {
+      throw new Error('Logger is required to handle exceptions');
+    }
+
+    this.logger = logger;
+    this.handlers = new Map();
   }
 
-  this.logger = logger;
-  this.handlers = new Map();
-};
+  /**
+   * Handles `uncaughtException` events for the current process by adding any
+   * handlers passed in.
+   * @returns {undefined}
+   */
+  handle() {
+    const self = this;
+    const args = Array.prototype.slice.call(arguments);
 
-/*
- * function handle ([tr0, tr1...] || tr0, tr1, ...)
- * Handles `uncaughtException` events for the current process by
- * ADDING any handlers passed in.
- */
-ExceptionHandler.prototype.handle = function () {
-  const self = this;
-  const args = Array.prototype.slice.call(arguments);
+    // Helper function
+    function add(handler) {
+      if (!self.handlers.has(handler)) {
+        handler.handleExceptions = true;
+        const wrapper = new ExceptionStream(handler);
+        self.handlers.set(handler, wrapper);
+        self.logger.pipe(wrapper);
+      }
+    }
 
-  //
-  // Helper function
-  //
-  function add(handler) {
-    var wrapper;
-    if (!self.handlers.has(handler)) {
-      handler.handleExceptions = true;
-      wrapper = new ExceptionStream(handler);
-      self.handlers.set(handler, wrapper);
-      self.logger.pipe(wrapper);
+    args.forEach(arg => {
+      if (Array.isArray(arg)) {
+        return arg.forEach(add);
+      }
+
+      add(arg);
+    });
+
+    if (!this.catcher) {
+      this.catcher = this._uncaughtException.bind(this);
+      process.on('uncaughtException', this.catcher);
     }
   }
 
-  args.forEach(function (arg) {
-    if (Array.isArray(arg)) {
-      return arg.forEach(add);
+  /**
+   * Removes any handlers to `uncaughtException` events for the current
+   * process. This does not modify the state of the `this.handlers` set.
+   * @returns {undefined}
+   */
+  unhandle() {
+    if (this.catcher) {
+      process.removeListener('uncaughtException', this.catcher);
+      this.catcher = false;
+
+      Array.from(this.handlers.values())
+        .forEach(wrapper => this.logger.unpipe(wrapper));
+    }
+  }
+
+  /**
+   * TODO: add method description
+   * @param {Error} err - Error to get information about.
+   * @returns {mixed} - TODO: add return description.
+   */
+  getAllInfo(err) {
+    let { message } = err;
+    if (!message && typeof err === 'string') {
+      message = err;
     }
 
-    add(arg);
-  });
-
-  if (!this.catcher) {
-    this.catcher = this._uncaughtException.bind(this);
-    process.on('uncaughtException', this.catcher);
+    return {
+      error: err,
+      // TODO (indexzero): how do we configure this?
+      level: 'error',
+      message: [
+        `uncaughtException: ${(message || '(no error message)')}`,
+        err.stack || '  No stack trace'
+      ].join('\n'),
+      stack: err.stack,
+      exception: true,
+      date: new Date().toString(),
+      process: this.getProcessInfo(),
+      os: this.getOsInfo(),
+      trace: this.getTrace(err)
+    };
   }
-};
 
-/*
- * function unhandle ()
- *
- * Removes any handlers to `uncaughtException` events
- * for the current process. This DOES NOT modify the
- * state of the `this.handlers` Set.
- */
-ExceptionHandler.prototype.unhandle = function () {
-  var self = this;
-  if (this.catcher) {
-    process.removeListener('uncaughtException', this.catcher);
-    this.catcher = false;
+  /**
+   * Gets all relevant process information for the currently running process.
+   * @returns {mixed} - TODO: add return description.
+   */
+  getProcessInfo() {
+    return {
+      pid: process.pid,
+      uid: process.getuid ? process.getuid() : null,
+      gid: process.getgid ? process.getgid() : null,
+      cwd: process.cwd(),
+      execPath: process.execPath,
+      version: process.version,
+      argv: process.argv,
+      memoryUsage: process.memoryUsage()
+    };
+  }
 
-    Array.from(this.handlers.values()).forEach(function (wrapper) {
-      self.logger.unpipe(wrapper);
+  /**
+   * Gets all relevant OS information for the currently running process.
+   * @returns {mixed} - TODO: add return description.
+   */
+  getOsInfo() {
+    return {
+      loadavg: os.loadavg(),
+      uptime: os.uptime()
+    };
+  }
+
+  /**
+   * Gets a stack trace for the specified error.
+   * @param {mixed} err - TODO: add param description.
+   * @returns {mixed} - TODO: add return description.
+   */
+  getTrace(err) {
+    const trace = err ? stackTrace.parse(err) : stackTrace.get();
+    return trace.map(site => {
+      return {
+        column: site.getColumnNumber(),
+        file: site.getFileName(),
+        function: site.getFunctionName(),
+        line: site.getLineNumber(),
+        method: site.getMethodName(),
+        native: site.isNative()
+      };
     });
   }
-};
 
-/*
- * function getAllInfo (err)
- * @param {Error} err Error to get information about.
- */
-ExceptionHandler.prototype.getAllInfo = function (err) {
-  var message = err.message;
-  if (!message && typeof err === 'string') {
-    message = err;
-  }
+  /**
+   * Logs all relevant information around the `err` and exits the current
+   * process.
+   * @param {Error} err - Error to handle
+   * @returns {mixed} - TODO: add return description.
+   * @private
+   */
+  _uncaughtException(err) {
+    const info = this.getAllInfo(err);
+    const handlers = this._getExceptionHandlers();
+    // Calculate if we should exit on this error
+    let doExit = typeof this.logger.exitOnError === 'function'
+      ? this.logger.exitOnError(err)
+      : this.logger.exitOnError;
+    let timeout;
 
-  return {
-    error: err,
-    //
-    // TODO (indexzero): how do we configure this?
-    //
-    level: 'error',
-    message: [
-      'uncaughtException: ' + (message || '(no error message)'),
-      err.stack || '  No stack trace'
-    ].join('\n'),
-    stack: err.stack,
-    exception: true,
-    date: new Date().toString(),
-    process: this.getProcessInfo(),
-    os: this.getOsInfo(),
-    trace: this.getTrace(err)
-  };
-};
+    if (!handlers.length && doExit) {
+      // eslint-disable-next-line no-console
+      console.warn('winston: exitOnError cannot be false with no exception handlers.');
+      // eslint-disable-next-line no-console
+      console.warn('winston: exiting process.');
+      doExit = false;
+    }
 
-/*
- * function getProcessInfo()
- * Gets all relevant process information for the currently
- * running process.
- */
-ExceptionHandler.prototype.getProcessInfo = function () {
-  return {
-    pid: process.pid,
-    uid: process.getuid ? process.getuid() : null,
-    gid: process.getgid ? process.getgid() : null,
-    cwd: process.cwd(),
-    execPath: process.execPath,
-    version: process.version,
-    argv: process.argv,
-    memoryUsage: process.memoryUsage()
-  };
-};
+    function gracefulExit() {
+      debug('doExit', doExit);
+      debug('process._exiting', process._exiting);
 
-/*
- * function getOsInfo()
- * Gets all relevant OS information for the currently
- * running process.
- */
-ExceptionHandler.prototype.getOsInfo = function () {
-  return {
-    loadavg: os.loadavg(),
-    uptime: os.uptime()
-  };
-};
+      if (doExit && !process._exiting) {
+        // Remark: Currently ignoring any exceptions from transports when
+        // catching uncaught exceptions.
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        // eslint-disable-next-line no-process-exit
+        process.exit(1);
+      }
+    }
 
-/*
- * function getTrace(err)
- * Gets a stack trace for the specified error.
- */
-ExceptionHandler.prototype.getTrace = function (err) {
-  var trace = err ? stackTrace.parse(err) : stackTrace.get();
-  return trace.map(function (site) {
-    return {
-      column: site.getColumnNumber(),
-      file: site.getFileName(),
-      function: site.getFunctionName(),
-      line: site.getLineNumber(),
-      method: site.getMethodName(),
-      native: site.isNative()
-    };
-  });
-};
+    if (!handlers || handlers.length === 0) {
+      return process.nextTick(gracefulExit);
+    }
 
-/*
- * function _uncaughtException (err)
- * @param {Error} err Error to handle
- *
- * Logs all relevant information around the `err` and
- * exits the current process.
- *
- * @api private
- */
-ExceptionHandler.prototype._uncaughtException = function (err) {
-  const info = this.getAllInfo(err);
-  const handlers = this._getExceptionHandlers();
-  let timeout;
-  let doExit;
+    // Log to all transports attempting to listen for when they are completed.
+    asyncForEach(handlers, (handler, next) => {
+      // TODO: Change these to the correct WritableStream events so that we
+      // wait until exit.
+      const done = once(next);
+      const transport = handler.transport || handler;
 
-  //
-  // Calculate if we should exit on this error
-  //
-  doExit = typeof this.logger.exitOnError === 'function'
-    ? this.logger.exitOnError(err)
-    : this.logger.exitOnError;
+      // Debug wrapping so that we can inspect what's going on under the covers.
+      function onDone(event) {
+        return () => {
+          debug(event);
+          done();
+        };
+      }
 
-  if (!handlers.length && doExit) {
-    console.warn('winston: exitOnError cannot be false with no exception handlers.');
-    console.warn('winston: exiting process.');
-    doExit = false;
-  }
+      transport.once('logged', onDone('logged'));
+      transport.once('error', onDone('error'));
+    }, gracefulExit);
 
-  function gracefulExit() {
-    debug('doExit', doExit);
-    debug('process._exiting', process._exiting);
+    this.logger.log(info);
 
-    if (doExit && !process._exiting) {
-      //
-      // Remark: Currently ignoring any exceptions from transports
-      // when catching uncaught exceptions.
-      //
-      if (timeout) { clearTimeout(timeout); }
-      process.exit(1);
+    // If exitOnError is true, then only allow the logging of exceptions to
+    // take up to `3000ms`.
+    if (doExit) {
+      timeout = setTimeout(gracefulExit, 3000);
     }
   }
 
-  if (!handlers || handlers.length === 0) {
-    return process.nextTick(gracefulExit);
+  /**
+   * Returns the list of transports and exceptionHandlers for this instance.
+   * @returns {Array} - List of transports and exceptionHandlers for this
+   * instance.
+   * @private
+   */
+  _getExceptionHandlers() {
+    // Remark (indexzero): since `logger.transports` returns all of the pipes
+    // from the _readableState of the stream we actually get the join of the
+    // explicit handlers and the implicit transports with
+    // `handleExceptions: true`
+    return this.logger.transports.filter(wrap => {
+      const transport = wrap.transport || wrap;
+      return transport.handleExceptions;
+    });
   }
-
-  //
-  // Log to all transports attempting to listen
-  // for when they are completed.
-  //
-  asyncForEach(handlers, function awaitLog(handler, next) {
-    //
-    // TODO: Change these to the correct WritableStream events
-    // so that we wait until exit.
-    //
-    var done = once(next);
-    var transport = handler.transport || handler;
-
-    //
-    // Debug wrapping so that we can inspect what's going on
-    // under the covers.
-    //
-    function onDone(event) {
-      return function () {
-        debug(event);
-        done();
-      };
-    }
-
-    transport.once('logged', onDone('logged'));
-    transport.once('error', onDone('error'));
-  }, gracefulExit);
-
-  this.logger.log(info);
-
-  //
-  // If exitOnError is true, then only allow the logging of
-  // exceptions to take up to `3000ms`.
-  //
-  if (doExit) {
-    timeout = setTimeout(gracefulExit, 3000);
-  }
-};
-
-/*
- * function _getExceptionHandlers ()
- *
- * Returns the list of transports and exceptionHandlers
- * for this instance.
- *
- * @api private
- */
-ExceptionHandler.prototype._getExceptionHandlers = function () {
-  //
-  // Remark (indexzero): since `logger.transports` returns all of the pipes
-  // from the _readableState of the stream we actually get the join of the
-  // explicit handlers and the implicit transports with `handleExceptions: true`
-  //
-  return this.logger.transports.filter(function (wrap) {
-    var transport = wrap.transport || wrap;
-    return transport.handleExceptions;
-  });
 };

--- a/lib/winston/exception-stream.js
+++ b/lib/winston/exception-stream.js
@@ -1,42 +1,56 @@
+/**
+ * exception-stream.js: TODO: add file header handler.
+ *
+ * (C) 2010 Charlie Robbins
+ * MIT LICENCE
+ */
+
 'use strict';
 
-const stream = require('stream');
-const util = require('util');
+const { Writable } = require('stream');
 
-/*
- * Constructor function for the ExceptionStream responsible for wrapping
- * a TransportStream; only allowing writes of `info` objects with `info.exception`
- * set to true.
- *
- * @param  {TransportStream} Stream to filter to exceptions
+/**
+ * TODO: add class description.
+ * @type {ExceptionStream}
+ * @extends {Writable}
  */
-var ExceptionStream = module.exports = function ExceptionStream(transport) {
-  if (!transport) {
-    throw new Error('ExceptionStream requires a TransportStream instance.');
+module.exports = class ExceptionStream extends Writable {
+  /**
+   * Constructor function for the ExceptionStream responsible for wrapping a
+   * TransportStream; only allowing writes of `info` objects with
+   * `info.exception` set to true.
+   * @param {!TransportStream} transport - Stream to filter to exceptions
+   */
+  constructor(transport) {
+    super({
+      objectMode: true
+    });
+
+    if (!transport) {
+      throw new Error('ExceptionStream requires a TransportStream instance.');
+    }
+
+    // Remark (indexzero): we set `handleExceptions` here because it's the
+    // predicate checked in ExceptionHandler.prototype.__getExceptionHandlers
+    this.handleExceptions = true;
+    this.transport = transport;
   }
 
-  stream.Writable.call(this, { objectMode: true });
+  /**
+   * Writes the info object to our transport instance if (and only if) the
+   * `exception` property is set on the info.
+   * @param {mixed} info - TODO: add param description.
+   * @param {mixed} enc - TODO: add param description.
+   * @param {mixed} callback - TODO: add param description.
+   * @returns {mixed} - TODO: add return description.
+   * @private
+   */
+  _write(info, enc, callback) {
+    if (info.exception) {
+      return this.transport.log(info, callback);
+    }
 
-  //
-  // Remark (indexzero): we set `handleExceptions` here because it's the
-  // predicate checked in ExceptionHandler.prototype.__getExceptionHandlers
-  //
-  this.handleExceptions = true;
-  this.transport = transport;
-};
-
-util.inherits(ExceptionStream, stream.Writable);
-
-/*
- * @private function _write(info)
- * Writes the info object to our transport instance if (and only if)
- * the `exception` property is set on the info.
- */
-ExceptionStream.prototype._write = function (info, enc, callback) {
-  if (info.exception) {
-    return this.transport.log(info, callback);
+    callback();
+    return true;
   }
-
-  callback();
-  return true;
 };

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -123,9 +123,11 @@ class Logger extends stream.Transform {
    *      meta: { thisIsMeta: true }
    *    });
    */
-  log(level, msg, meta) {
+  // log(level, msg, meta) {
+  log(...args) {
+    const [level, msg, meta] = args;
     // Optimize for the hotpath of logging JSON literals
-    if (arguments.length === 1) {
+    if (args.length === 1) {
       // Yo dawg, I heard you like levels ... seriously ...
       // In this context the LHS `level` here is actually the `info` so read
       // this as: info[LEVEL] = info.level;
@@ -135,7 +137,7 @@ class Logger extends stream.Transform {
     }
 
     // Slightly less hotpath, but worth optimizing for.
-    if (arguments.length === 2) {
+    if (args.length === 2) {
       if (msg && typeof msg === 'object') {
         msg[LEVEL] = msg.level = level;
         this.write(msg);
@@ -155,7 +157,7 @@ class Logger extends stream.Transform {
         [LEVEL]: level,
         level,
         message: msg
-      }, tokens, Array.prototype.slice.call(arguments, 2));
+      }, tokens, args.slice(2));
       return this;
     }
 
@@ -456,15 +458,14 @@ class Logger extends stream.Transform {
    * @param {string} id Unique id of the profiler
    * @returns {Logger} - TODO: add return description.
    */
-  profile(id) {
+  profile(id, ...args) {
     const time = Date.now();
     if (this.profilers[id]) {
       const timeEnd = this.profilers[id];
       delete this.profilers[id];
 
       // Attempt to be kind to users if they are still using older APIs.
-      const args = Array.prototype.slice.call(arguments, 1);
-      if (typeof args[args.length - 1] === 'function') {
+      if (typeof args[args.length - 2] === 'function') {
         // eslint-disable-next-line no-console
         console.warn('Callback function no longer supported as of winston@3.0.0');
         args.pop();
@@ -487,11 +488,10 @@ class Logger extends stream.Transform {
    * @returns {undefined}
    * @deprecated
    */
-  handleExceptions() {
+  handleExceptions(...args) {
     // eslint-disable-next-line no-console
     console.warn('Deprecated: .handleExceptions() will be removed in winston@4. Use .exceptions.handle()');
-    const args = Array.prototype.slice.call(arguments);
-    this.exceptions.handle.apply(this.exceptions, args);
+    this.exceptions.handle(this.exceptions, args);
   }
 
   /**
@@ -499,11 +499,10 @@ class Logger extends stream.Transform {
    * @returns {undefined}
    * @deprecated
    */
-  unhandleExceptions() {
+  unhandleExceptions(...args) {
     // eslint-disable-next-line no-console
     console.warn('Deprecated: .unhandleExceptions() will be removed in winston@4. Use .unexceptions.handle()');
-    const args = Array.prototype.slice.call(arguments);
-    this.exceptions.unhandle.apply(this.exceptions, args);
+    this.exceptions.unhandle(this.exceptions, args);
   }
 
   /**

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -43,19 +43,31 @@ class Logger extends stream.Transform {
    * @param {!Object} options - TODO: add param description.
    * @returns {undefined}
    */
-  configure(options) {
+  configure({
+    silent,
+    format,
+    levels,
+    level = 'info',
+    exitOnError = true,
+    transports,
+    colors,
+    emitErrs,
+    formatters,
+    padLevels,
+    rewriters,
+    stripColors,
+    exceptionHandlers
+  } = {}) {
     // Reset transports if we already have them
     if (this.transports.length) {
       this.clear();
     }
 
-    options = options || {};
-    this.silent = options.silent;
-    this.format = options.format || this.format || require('logform/json')();
+    this.silent = silent;
+    this.format = format || this.format || require('logform/json')();
 
-    const levels = options.levels || this.levels || config.npm.levels;
-    const maxLength = Math.max.apply(null, Object.keys(levels)
-      .map(lev => lev.length));
+    levels = levels || this.levels || config.npm.levels;
+    const maxLength = Math.max(...Object.keys(levels).map(lev => lev.length));
 
     this.paddings = Object.keys(levels).reduce((acc, lev) => {
       const pad = lev.length !== maxLength
@@ -68,26 +80,21 @@ class Logger extends stream.Transform {
 
     // Hoist other options onto this instance.
     this.levels = levels;
-    this.level = options.level || 'info';
+    this.level = level;
     this.exceptions = new ExceptionHandler(this);
     this.profilers = {};
-    this.exitOnError = typeof options.exitOnError !== 'undefined'
-      ? options.exitOnError
-      : true;
+    this.exitOnError = exitOnError;
 
     // Add all transports we have been provided.
-    if (options.transports) {
-      options.transports = Array.isArray(options.transports)
-        ? options.transports
-        : [options.transports];
-
-      options.transports.forEach(transport => {
-        this.add(transport);
-      });
+    if (transports) {
+      transports = Array.isArray(transports) ? transports : [transports];
+      transports.forEach(transport => this.add(transport));
     }
 
-    if (options.colors || options.emitErrs || options.formatters
-      || options.padLevels || options.rewriters || options.stripColors) {
+    if (
+      colors || emitErrs || formatters ||
+      padLevels || rewriters || stripColors
+    ) {
       throw new Error([
         '{ colors, emitErrs, formatters, padLevels, rewriters, stripColors } were removed in winston@3.0.0.',
         'Use a custom winston.format(function) instead.',
@@ -95,8 +102,8 @@ class Logger extends stream.Transform {
       ].join('\n'));
     }
 
-    if (options.exceptionHandlers) {
-      this.exceptions.handle(options.exceptionHandlers);
+    if (exceptionHandlers) {
+      this.exceptions.handle(exceptionHandlers);
     }
   }
 
@@ -267,7 +274,7 @@ class Logger extends stream.Transform {
     // transport. All NEW transports should inherit from
     // `winston.TransportStream`.
     const target = !isStream(transport)
-      ? new LegacyTransportStream({ transport: transport })
+      ? new LegacyTransportStream({ transport })
       : transport;
 
     if (!target._writableState || !target._writableState.objectMode) {

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -1,573 +1,552 @@
+/**
+ * logger.js: TODO: add file header description.
+ *
+ * (C) 2010 Charlie Robbins
+ * MIT LICENCE
+ */
+
 'use strict';
 
 const stream = require('stream');
-const util = require('util');
 const asyncForEach = require('async/forEach');
 const { LEVEL } = require('triple-beam');
 const isStream = require('is-stream');
 const ExceptionHandler = require('./exception-handler');
 const LegacyTransportStream = require('winston-transport/legacy');
 const Profiler = require('./profiler');
-const common = require('./common');
+const { clone, escapedPercent, formatRegExp, warn } = require('./common');
 const config = require('./config');
 
-const formatRegExp = common.formatRegExp;
-
-/*
- * Constructor function for the Logger object responsible
- * for persisting log messages and metadata to one or more transports.
+/**
+ * TODO: add class description.
+ * @type {Logger}
+ * @extends {stream.Transform}
  */
-var Logger = module.exports = function Logger(options) {
-  stream.Transform.call(this, { objectMode: true });
-  this.configure(options);
-};
+class Logger extends stream.Transform {
+  /**
+   * Constructor function for the Logger object responsible for persisting log
+   * messages and metadata to one or more transports.
+   * @param {!Object} options - foo
+   */
+  constructor(options) {
+    super({
+      objectMode: true
+    });
+    this.configure(options);
+  }
 
-//
-// Inherit from `stream.Transform`.
-//
-util.inherits(Logger, stream.Transform);
+  /**
+   * This will wholesale reconfigure this instance by:
+   * 1. Resetting all transports. Older transports will be removed implicitly.
+   * 2. Set all other options including levels, colors, rewriters, filters,
+   *    exceptionHandlers, etc.
+   * @param {!Object} options - TODO: add param description.
+   * @returns {undefined}
+   */
+  configure(options) {
+    // Reset transports if we already have them
+    if (this.transports.length) {
+      this.clear();
+    }
 
-/*
- * ### function configure (options)
- * This will wholesale reconfigure this instance by:
- * 1. Resetting all transports. Older transports will be removed implicitly.
- * 2. Set all other options including levels, colors, rewriters, filters,
- *    exceptionHandlers, etc.
- */
-Logger.prototype.configure = function (options) {
-  //
-  // Reset transports if we already have them
-  //
-  if (this.transports.length) {
+    options = options || {};
+    this.silent = options.silent;
+    this.format = options.format || this.format || require('logform/json')();
+
+    const levels = options.levels || this.levels || config.npm.levels;
+    const maxLength = Math.max.apply(null, Object.keys(levels)
+      .map(lev => lev.length));
+
+    this.paddings = Object.keys(levels).reduce(function (acc, lev) {
+      const pad = lev.length !== maxLength
+        ? new Array(maxLength - lev.length + 1).join(' ')
+        : '';
+
+      acc[lev] = pad;
+      return acc;
+    }, {});
+
+    // Hoist other options onto this instance.
+    this.levels = levels;
+    this.level = options.level || 'info';
+    this.exceptions = new ExceptionHandler(this);
+    this.profilers = {};
+    this.exitOnError = typeof options.exitOnError !== 'undefined'
+      ? options.exitOnError
+      : true;
+
+    // Add all transports we have been provided.
+    if (options.transports) {
+      options.transports = Array.isArray(options.transports)
+        ? options.transports
+        : [options.transports];
+
+      options.transports.forEach(function (transport) {
+        this.add(transport);
+      }, this);
+    }
+
+    if (options.colors || options.emitErrs || options.formatters
+      || options.padLevels || options.rewriters || options.stripColors) {
+      throw new Error([
+        '{ colors, emitErrs, formatters, padLevels, rewriters, stripColors } were removed in winston@3.0.0.',
+        'Use a custom winston.format(function) instead.',
+        'See: https://github.com/winstonjs/winston/tree/master/UPGRADE-3.0.md'
+      ].join('\n'));
+    }
+
+    if (options.exceptionHandlers) {
+      this.exceptions.handle(options.exceptionHandlers);
+    }
+  }
+
+  /**
+   * Ensure backwards compatibility with a `log` method
+   * @param {mixed} level - TODO: add param description.
+   * @param {mixed} msg - TODO: add param description.
+   * @param {mixed} meta - TODO: add param description.
+   * @returns {Logger} - TODO: add return description.
+   *
+   * @example
+   *    // Supports the existing API, which is now DEPRECATED:
+   *    logger.log('info', 'Hello world', { custom: true });
+   *    logger.log('info', new Error('Yo, it\'s on fire'));
+   *    logger.log('info', '%s %d%%', 'A string', 50, { thisIsMeta: true });
+   *
+   *    // And the new API with a single JSON literal:
+   *    logger.log({ level: 'info', message: 'Hello world', custom: true });
+   *    logger.log({ level: 'info', message: new Error('Yo, it\'s on fire') });
+   *    logger.log({
+   *      level: 'info',
+   *      message: '%s %d%%',
+   *      splat: ['A string', 50],
+   *      meta: { thisIsMeta: true }
+   *    });
+   */
+  log(level, msg, meta) {
+    // Optimize for the hotpath of logging JSON literals
+    if (arguments.length === 1) {
+      // Yo dawg, I heard you like levels ... seriously ...
+      // In this context the LHS `level` here is actually the `info` so read
+      // this as: info[LEVEL] = info.level;
+      level[LEVEL] = level.level;
+      this.write(level);
+      return this;
+    }
+
+    // Slightly less hotpath, but worth optimizing for.
+    if (arguments.length === 2) {
+      if (msg && typeof msg === 'object') {
+        msg[LEVEL] = msg.level = level;
+        this.write(msg);
+        return this;
+      }
+
+      this.write({ [LEVEL]: level, level, message: msg });
+      return this;
+    }
+
+    // Separation of the splat from { level, message, meta } must be done at
+    // this point in the objectMode stream since we only ever write a single
+    // object.
+    const tokens = msg && msg.match && msg.match(formatRegExp);
+    if (tokens) {
+      this._splat({
+        [LEVEL]: level,
+        level,
+        message: msg
+      }, tokens, Array.prototype.slice.call(arguments, 2));
+      return this;
+    }
+
+    const info = Object.assign({}, meta, {
+      [LEVEL]: level,
+      level,
+      message: msg
+    });
+    this.write(info);
+    return this;
+  }
+
+  /**
+   * Pushes data so that it can be picked up by all of our pipe targets.
+   * @param {mixed} info - TODO: add param description.
+   * @param {mixed} enc - TODO: add param description.
+   * @param {mixed} callback - TODO: add param description.
+   * @returns {undefined}
+   * @private
+   */
+  _transform(info, enc, callback) {
+    if (this.silent) {
+      return callback();
+    }
+
+    // [LEVEL] is only soft guaranteed to be set here since we are a proper
+    // stream. It is likely that `info` came in through `.log(info)` or
+    // `.info(info)`. If it is not defined, however, define it.
+    // This LEVEL symbol is provided by `triple-beam` and also used in:
+    // - logform
+    // - winston-transport
+    // - abstract-winston-transport
+    if (!info[LEVEL]) {
+      info[LEVEL] = info.level;
+    }
+
+    // Remark: really not sure what to do here, but this has been reported as
+    // very confusing by pre winston@2.0.0 users as quite confusing when using
+    // custom levels.
+    if (!this.levels[info[LEVEL]] && this.levels[info[LEVEL]] !== 0) {
+      // eslint-disable-next-line no-console
+      console.error('[winston] Unknown logger level: %s', info[LEVEL]);
+    }
+
+    // Remark: not sure if we should simply error here.
+    if (!this._readableState.pipes) {
+      // eslint-disable-next-line no-console
+      console.error('[winston] Attempt to write logs with no transports %j', info);
+    }
+
+    // Here we write to the `format` pipe-chain, which on `readable` above will
+    // push the formatted `info` Object onto the buffer for this instance.
+    this.push(this.format.transform(info, this.format.options));
+    callback();
+  }
+
+  /**
+   * Check to see if tokens <= splat.length, assign { splat, meta } into the
+   * `info` accordingly, and write to this instance.
+   * @param {mixed} info - TODO: add param description.
+   * @param {mixed} tokens - TODO: add param description.
+   * @param {mixed} splat - TODO: add param description.
+   * @returns {undefined}
+   * @private
+   */
+  _splat(info, tokens, splat) {
+    const percents = info.message.match(escapedPercent);
+    const escapes = percents && percents.length || 0;
+
+    // The expected splat is the number of tokens minus the number of escapes
+    // e.g.
+    // - { expectedSplat: 3 } '%d %s %j'
+    // - { expectedSplat: 5 } '[%s] %d%% %d%% %s %j'
+    //
+    // Any "meta" will be arugments in addition to the expected splat size
+    // regardless of type. e.g.
+    //
+    // logger.log('info', '%d%% %s %j', 100, 'wow', { such: 'js' }, { thisIsMeta: true });
+    // would result in splat of four (4), but only three (3) are expected. Therefore:
+    //
+    // extraSplat = 3 - 4 = -1
+    // metas = [100, 'wow', { such: 'js' }, { thisIsMeta: true }].splice(-1, -1 * -1);
+    // splat = [100, 'wow', { such: 'js' }]
+    const expectedSplat = tokens.length - escapes;
+    const extraSplat = expectedSplat - splat.length;
+    const metas = extraSplat < 0
+      ? splat.splice(extraSplat, -1 * extraSplat)
+      : [];
+
+    // Now that { splat } has been separated from any potential { meta }. we
+    // can assign this to the `info` object and write it to our format stream.
+    info.splat = splat;
+    if (metas.length) {
+      info.meta = metas[0];
+    }
+
+    this.write(info);
+  }
+
+  /**
+   * Adds the transport to this logger instance by piping to it.
+   * @param {mixed} transport - TODO: add param description.
+   * @returns {Logger} - TODO: add return description.
+   */
+  add(transport) {
+    // Support backwards compatibility with all existing `winston@1.x.x`
+    // transport. All NEW transports should inherit from
+    // `winston.TransportStream`.
+    const target = !isStream(transport)
+      ? new LegacyTransportStream({ transport: transport })
+      : transport;
+
+    if (!target._writableState || !target._writableState.objectMode) {
+      throw new Error('Transports must WritableStreams in objectMode. Set { objectMode: true }.');
+    }
+
+    // Listen for the `error` event on the new Transport.
+    this._onError(target);
+    this.pipe(target);
+
+    if (transport.handleExceptions) {
+      this.exceptions.handle();
+    }
+
+    return this;
+  }
+
+  /**
+   * Removes the transport from this logger instance by unpiping from it.
+   * @param {mixed} transport - TODO: add param description.
+   * @returns {Logger} - TODO: add return description.
+   */
+  remove(transport) {
+    let target = transport;
+    if (!isStream(transport)) {
+      target = this.transports.filter(function (match) {
+        return match.transport === transport;
+      })[0];
+    }
+
+    if (target) { this.unpipe(target); }
+    return this;
+  }
+
+  /**
+   * Removes all transports from this logger instance.
+   * @returns {Logger} - TODO: add return description.
+   */
+  clear() {
+    this.unpipe();
+    return this;
+  }
+
+  /**
+   * Cleans up resources (streams, event listeners) for all transports
+   * associated with this instance (if necessary).
+   * @returns {Logger} - TODO: add return description.
+   */
+  close() {
     this.clear();
+    this.emit('close');
+    return this;
   }
 
-  options = options || {};
-  this.silent = options.silent;
-  this.format = options.format || this.format || require('logform/json')();
-
-  var levels = options.levels || this.levels || config.npm.levels;
-  var maxLength = Math.max.apply(null, Object.keys(levels)
-    .map(function (lev) { return lev.length; }));
-
-  this.paddings = Object.keys(levels).reduce(function (acc, lev) {
-    var pad = lev.length !== maxLength
-      ? new Array(maxLength - lev.length + 1).join(' ')
-      : '';
-
-    acc[lev] = pad;
-    return acc;
-  }, {});
-
-  //
-  // Hoist other options onto this instance.
-  //
-  this.levels = levels;
-  this.level = options.level || 'info';
-  this.exceptions = new ExceptionHandler(this);
-  this.profilers = {};
-  this.exitOnError = typeof options.exitOnError !== 'undefined'
-    ? options.exitOnError
-    : true;
-
-  //
-  // Add all transports we have been provided.
-  //
-  if (options.transports) {
-    options.transports = Array.isArray(options.transports)
-      ? options.transports
-      : [options.transports];
-
-    options.transports.forEach(function (transport) {
-      this.add(transport);
-    }, this);
+  /**
+   * Sets the `target` levels specified on this instance.
+   * @param {Object} Target levels to use on this instance.
+   */
+  setLevels() {
+    warn.deprecated('setLevels');
   }
 
-  if (options.colors || options.emitErrs || options.formatters
-    || options.padLevels || options.rewriters || options.stripColors) {
+  /**
+   * Queries the all transports for this instance with the specified `options`.
+   * This will aggregate each transport's results into one object containing
+   * a property per transport.
+   * @param {Object} options - Query options for this instance.
+   * @param {function} callback - Continuation to respond to when complete.
+   * @retruns {mixed} - TODO: add return description.
+   */
+  query(options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    options = options || {};
+    const results = {};
+    const queryObject = clone(options.query) || {};
+
+    // Helper function to query a single transport
+    function queryTransport(transport, next) {
+      if (options.query) {
+        options.query = transport.formatQuery(queryObject);
+      }
+
+      transport.query(options, function (err, res) {
+        if (err) {
+          return next(err);
+        }
+
+        next(null, transport.formatResults(res, options.format));
+      });
+    }
+
+    // Helper function to accumulate the results from `queryTransport` into
+    // the `results`.
+    function addResults(transport, next) {
+      queryTransport(transport, function (err, result) {
+        // queryTransport could potentially invoke the callback multiple times
+        // since Transport code can be unpredictable.
+        if (next) {
+          result = err || result;
+          if (result) {
+            results[transport.name] = result;
+          }
+
+          // eslint-disable-next-line callback-return
+          next();
+        }
+
+        next = null;
+      });
+    }
+
+    // Iterate over the transports in parallel setting the appropriate key in
+    // the `results`.
+    asyncForEach(
+      this.transports.filter(transport => !!transport.query),
+      addResults,
+      () => callback(null, results)
+    );
+  }
+
+  /**
+   * Returns a log stream for all transports. Options object is optional.
+   * @param{Object} options={} - Stream options for this instance.
+   * @returns {Stream} - TODO: add return description.
+   */
+  stream(options = {}) {
+    const out = new stream.Stream();
+    const streams = [];
+
+    out._streams = streams;
+    out.destroy = function () {
+      var i = streams.length;
+      while (i--) streams[i].destroy();
+    };
+
+    // Create a list of all transports for this instance.
+    this.transports
+      .filter(transport => !!transport.stream)
+      .forEach(transport => {
+        const str = transport.stream(options);
+        if (!str) {
+          return;
+        }
+
+        streams.push(str);
+
+        str.on('log', log => {
+          log.transport = log.transport || [];
+          log.transport.push(transport.name);
+          out.emit('log', log);
+        });
+
+        str.on('error', err => {
+          err.transport = err.transport || [];
+          err.transport.push(transport.name);
+          out.emit('error', err);
+        });
+      });
+
+    return out;
+  }
+
+  /**
+   * Returns an object corresponding to a specific timing. When done is called
+   * the timer will finish and log the duration. e.g.:
+   * @returns {Profile} - TODO: add return description.
+   * @example
+   *    const timer = winston.startTimer()
+   *    setTimeout(() => {
+   *      timer.done({
+   *        message: 'Logging message'
+   *      });
+   *    }, 1000);
+   */
+  startTimer() {
+    return new Profiler(this);
+  }
+
+  /**
+   * Tracks the time inbetween subsequent calls to this method with the same
+   * `id` parameter. The second call to this method will log the difference in
+   * milliseconds along with the message.
+   * @param {string} id Unique id of the profiler
+   * @returns {Logger} - TODO: add return description.
+   */
+  profile(id) {
+    const time = Date.now();
+    if (this.profilers[id]) {
+      const timeEnd = this.profilers[id];
+      delete this.profilers[id];
+
+      // Attempt to be kind to users if they are still using older APIs.
+      const args = Array.prototype.slice.call(arguments, 1);
+      if (typeof args[args.length - 1] === 'function') {
+        // eslint-disable-next-line no-console
+        console.warn('Callback function no longer supported as of winston@3.0.0');
+        args.pop();
+      }
+
+      // Set the duration property of the metadata
+      const info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
+      info.level = info.level || 'info';
+      info.durationMs = time - timeEnd;
+      info.message = info.message || id;
+      return this.write(info);
+    }
+
+    this.profilers[id] = time;
+    return this;
+  }
+
+  /**
+   * Backwards compatibility to `exceptions.handle` in winston < 3.0.0.
+   * @returns {undefined}
+   * @deprecated
+   */
+  handleExceptions() {
+    // eslint-disable-next-line no-console
+    console.warn('Deprecated: .handleExceptions() will be removed in winston@4. Use .exceptions.handle()');
+    var args = Array.prototype.slice.call(arguments);
+    this.exceptions.handle.apply(this.exceptions, args);
+  }
+
+  /**
+   * Backwards compatibility to `exceptions.handle` in winston < 3.0.0.
+   * @returns {undefined}
+   * @deprecated
+   */
+  unhandleExceptions() {
+    // eslint-disable-next-line no-console
+    console.warn('Deprecated: .unhandleExceptions() will be removed in winston@4. Use .unexceptions.handle()');
+    var args = Array.prototype.slice.call(arguments);
+    this.exceptions.unhandle.apply(this.exceptions, args);
+  }
+
+  /**
+   * Throw a more meaningful deprecation notice
+   * @throws {Error} - TODO: add throws description.
+   */
+  cli() {
     throw new Error([
-      '{ colors, emitErrs, formatters, padLevels, rewriters, stripColors } were removed in winston@3.0.0.',
-      'Use a custom winston.format(function) instead.',
+      'Logger.cli() was removed in winston@3.0.0',
+      'Use a custom winston.formats.cli() instead.',
       'See: https://github.com/winstonjs/winston/tree/master/UPGRADE-3.0.md'
     ].join('\n'));
   }
 
-  if (options.exceptionHandlers) {
-    this.exceptions.handle(options.exceptionHandlers);
-  }
-};
+  /**
+   * Bubbles the error, `err`, that occured on the specified `transport` up
+   * from this instance if `emitErrs` has been set.
+   * @param {Object} transport - Transport on which the error occured
+   * @throws {Error} - Error that occurred on the transport
+   * @private
+   */
+  _onError(transport) {
+    function transportError(err) {
+      this.emit('error', err, transport);
+    }
 
-/*
- * @property {Array} Represents the current readableState
- * pipe targets for this Logger instance.
+    if (!transport.__winstonError) {
+      transport.__winstonError = transportError.bind(this);
+      transport.on('error', transport.__winstonError);
+    }
+  }
+}
+
+/**
+ * Represents the current readableState pipe targets for this Logger instance.
+ * @type {Array|Object}
  */
 Object.defineProperty(Logger.prototype, 'transports', {
   configurable: false,
   enumerable: true,
-  get: function () {
-    var pipes = this._readableState.pipes;
-    return !Array.isArray(pipes)
-      ? [pipes].filter(Boolean)
-      : pipes;
+  get() {
+    const { pipes } = this._readableState;
+    return !Array.isArray(pipes) ? [pipes].filter(Boolean) : pipes;
   }
 });
 
-/*
- * function log (level, msg, meta)
- * function log (info)
- * Ensure backwards compatibility with a `log` method
- *
- * Supports the existing API, which is now DEPRECATED:
- *
- *    logger.log('info', 'Hello world', { custom: true });
- *    logger.log('info', new Error('Yo, it's on fire'));
- *    logger.log('info', '%s %d%%', 'A string', 50, { thisIsMeta: true });
- *
- * And the new API with a single JSON literal:
- *
- *    logger.log({ level: 'info', message: 'Hello world', custom: true });
- *    logger.log({ level: 'info', message: new Error('Yo, it's on fire') });
- *    logger.log({
- *      level: 'info',
- *      message: '%s %d%%',
- *      splat: ['A string', 50],
- *      meta: { thisIsMeta: true }
- *    });
- *
- * @api public
- */
-Logger.prototype.log = function log(level, msg, meta) {
-  //
-  // Optimize for the hotpath of logging JSON literals
-  //
-  if (arguments.length === 1) {
-    //
-    // Yo dawg, I heard you like levels ... seriously ...
-    // In this context the LHS `level` here is actually
-    // the `info` so read this as:
-    // info[LEVEL] = info.level;
-    //
-    level[LEVEL] = level.level;
-    this.write(level);
-    return this;
-  }
-
-  //
-  // Slightly less hotpath, but worth optimizing for.
-  //
-  if (arguments.length === 2) {
-    if (msg && typeof msg === 'object') {
-      msg[LEVEL] = msg.level = level;
-      this.write(msg);
-      return this;
-    }
-
-    this.write({ [LEVEL]: level, level, message: msg });
-    return this;
-  }
-
-  //
-  // Separation of the splat from { level, message, meta } must be done
-  // at this point in the objectMode stream since we only ever write
-  // a single object.
-  //
-  const tokens = msg && msg.match && msg.match(formatRegExp);
-  if (tokens) {
-    this._splat({ [LEVEL]: level, level, message: msg }, tokens, Array.prototype.slice.call(arguments, 2));
-    return this;
-  }
-
-  const info = Object.assign({}, meta, { [LEVEL]: level, level, message: msg });
-  this.write(info);
-  return this;
-};
-
-/*
- * @private function _transform (obj)
- * Pushes data so that it can be picked up by all of
- * our pipe targets.
- */
-Logger.prototype._transform = function _transform(info, enc, callback) {
-  if (this.silent) {
-    return callback();
-  }
-
-  //
-  // [LEVEL] is only soft guaranteed to be set here since we are a proper
-  // stream. It is likely that `info` came in through `.log(info)` or
-  // `.info(info)`. If it is not defined, however, define it.
-  // This LEVEL symbol is provided by `triple-beam` and also used in:
-  // - logform
-  // - winston-transport
-  // - abstract-winston-transport
-  //
-  if (!info[LEVEL]) {
-    info[LEVEL] = info.level;
-  }
-
-  //
-  // Remark: really not sure what to do here, but this has been
-  // reported as very confusing by pre winston@2.0.0 users as
-  // quite confusing when using custom levels.
-  //
-  if (!this.levels[info[LEVEL]] && this.levels[info[LEVEL]] !== 0) {
-    console.error('[winston] Unknown logger level: %s', info[LEVEL]);
-  }
-
-  //
-  // Remark: not sure if we should simply error here.
-  //
-  if (!this._readableState.pipes) {
-    console.error('[winston] Attempt to write logs with no transports %j', info);
-  }
-
-  //
-  // Here we write to the `format` pipe-chain, which
-  // on `readable` above will push the formatted `info`
-  // Object onto the buffer for this instance.
-  //
-  this.push(this.format.transform(info, this.format.options));
-  callback();
-};
-
-/*
- * @private function _splat (info, tokens, splat)
- * Check to see if tokens <= splat.length, assign { splat, meta } into the `info`
- * accordingly, and write to this instance.
- */
-Logger.prototype._splat = function _splat(info, tokens, splat) {
-  const percents = info.message.match(common.escapedPercent);
-  const escapes = percents && percents.length || 0;
-
-  //
-  // The expected splat is the number of tokens minus the number of escapes. e.g.
-  //
-  // - { expectedSplat: 3 } '%d %s %j'
-  // - { expectedSplat: 5 } '[%s] %d%% %d%% %s %j'
-  //
-  // Any "meta" will be arugments in addition to the expected splat size
-  // regardless of type. e.g.
-  //
-  // logger.log('info', '%d%% %s %j', 100, 'wow', { such: 'js' }, { thisIsMeta: true });
-  // would result in splat of four (4), but only three (3) are expected. Therefore:
-  //
-  // extraSplat = 3 - 4 = -1
-  // metas = [100, 'wow', { such: 'js' }, { thisIsMeta: true }].splice(-1, -1 * -1);
-  // splat = [100, 'wow', { such: 'js' }]
-  //
-  const expectedSplat = tokens.length - escapes;
-  const extraSplat = expectedSplat - splat.length;
-  const metas = extraSplat < 0
-    ? splat.splice(extraSplat, -1 * extraSplat)
-    : [];
-
-  //
-  // Now that { splat } has been separated from any potential { meta }
-  // we can assign this to the `info` object and write it to our format stream.
-  //
-  info.splat = splat;
-  if (metas.length) {
-    info.meta = metas[0];
-  }
-
-  this.write(info);
-};
-
-/*
- * function add (transport)
- * Adds the transport to this logger instance by
- * piping to it.
- */
-Logger.prototype.add = function add(transport) {
-  //
-  // Support backwards compatibility with all existing
-  // `winston@1.x.x` transport. All NEW transports should
-  // inherit from `winston.TransportStream`.
-  //
-  var target = !isStream(transport)
-    ? new LegacyTransportStream({ transport: transport })
-    : transport;
-
-  if (!target._writableState || !target._writableState.objectMode) {
-    throw new Error('Transports must WritableStreams in objectMode. Set { objectMode: true }.');
-  }
-
-  //
-  // Listen for the `error` event on the new Transport
-  //
-  this._onError(target);
-  this.pipe(target);
-
-  if (transport.handleExceptions) {
-    this.exceptions.handle();
-  }
-
-  return this;
-};
-
-/*
- * function remove (transport)
- * Removes the transport from this logger instance by
- * unpiping from it.
- */
-Logger.prototype.remove = function remove(transport) {
-  var target = transport;
-  if (!isStream(transport)) {
-    target = this.transports.filter(function (match) {
-      return match.transport === transport;
-    })[0];
-  }
-
-  if (target) { this.unpipe(target); }
-  return this;
-};
-
-/*
- * function clear (transport)
- * Removes all transports from this logger instance.
- */
-Logger.prototype.clear = function clear() {
-  this.unpipe();
-  return this;
-};
-
-/*
- * ### function close ()
- * Cleans up resources (streams, event listeners) for all
- * transports associated with this instance (if necessary).
- */
-Logger.prototype.close = function close() {
-  this.clear();
-  this.emit('close');
-  return this;
-};
-
-/*
- * Sets the `target` levels specified on this instance.
- * @param {Object} Target levels to use on this instance.
- */
-Logger.prototype.setLevels = common.warn.deprecated('setLevels');
-
-//
-// ### function query (options, callback)
-// #### @options {Object} Query options for this instance.
-// #### @callback {function} Continuation to respond to when complete.
-// Queries the all transports for this instance with the specified `options`.
-// This will aggregate each transport's results into one object containing
-// a property per transport.
-//
-Logger.prototype.query = function query(options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-
-  options = options || {};
-  const results = {};
-  const queryObject = common.clone(options.query) || {};
-
-  //
-  // Helper function to query a single transport
-  //
-  function queryTransport(transport, next) {
-    if (options.query) {
-      options.query = transport.formatQuery(queryObject);
-    }
-
-    transport.query(options, function (err, results) {
-      if (err) {
-        return next(err);
-      }
-
-      next(null, transport.formatResults(results, options.format));
-    });
-  }
-
-  //
-  // Helper function to accumulate the results from
-  // `queryTransport` into the `results`.
-  //
-  function addResults(transport, next) {
-    queryTransport(transport, function (err, result) {
-      //
-      // queryTransport could potentially invoke the callback
-      // multiple times since Transport code can be unpredictable.
-      //
-      if (next) {
-        result = err || result;
-        if (result) {
-          results[transport.name] = result;
-        }
-
-        // eslint-disable-next-line callback-return
-        next();
-      }
-
-      next = null;
-    });
-  }
-
-  //
-  // Iterate over the transports in parallel setting the
-  // appropriate key in the `results`
-  //
-  asyncForEach(this.transports.filter(function (transport) {
-    return !!transport.query;
-  }), addResults, function () {
-    callback(null, results);
-  });
-};
-
-//
-// ### function stream (options)
-// #### @options {Object} Stream options for this instance.
-// Returns a log stream for all transports. Options object is optional.
-//
-Logger.prototype.stream = function _stream(options) {
-  options = options || {};
-
-  const out = new stream.Stream();
-  const streams = [];
-
-  out._streams = streams;
-  out.destroy = function () {
-    var i = streams.length;
-    while (i--) streams[i].destroy();
-  };
-
-  //
-  // Create a list of all transports for this instance.
-  //
-  this.transports.filter(function (transport) {
-    return !!transport.stream;
-  }).forEach(function (transport) {
-    var stream = transport.stream(options);
-    if (!stream) return;
-
-    streams.push(stream);
-
-    stream.on('log', function (log) {
-      log.transport = log.transport || [];
-      log.transport.push(transport.name);
-      out.emit('log', log);
-    });
-
-    stream.on('error', function (err) {
-      err.transport = err.transport || [];
-      err.transport.push(transport.name);
-      out.emit('error', err);
-    });
-  });
-
-  return out;
-};
-
-//
-// ### function startTimer ()
-// Returns an object corresponding to a specific timing. When done
-// is called the timer will finish and log the duration. e.g.:
-//
-//    timer = winston.startTimer()
-//    setTimeout(function(){
-//      timer.done({ message: 'Logging message' });
-//    }, 1000);
-//
-Logger.prototype.startTimer = function startTimer() {
-  return new Profiler(this);
-};
-
-//
-// ### function profile (id, [info])
-// @param {string} id Unique id of the profiler
-// Tracks the time inbetween subsequent calls to this method
-// with the same `id` parameter. The second call to this method
-// will log the difference in milliseconds along with the message.
-//
-Logger.prototype.profile = function profile(id) {
-  const time = Date.now();
-  let timeEnd;
-  let info;
-  let args;
-
-  if (this.profilers[id]) {
-    timeEnd = this.profilers[id];
-    delete this.profilers[id];
-
-    //
-    // Attempt to be kind to users if they are still
-    // using older APIs.
-    //
-    args = Array.prototype.slice.call(arguments, 1);
-    if (typeof args[args.length - 1] === 'function') {
-      console.warn('Callback function no longer supported as of winston@3.0.0');
-      args.pop();
-    }
-
-    //
-    // Set the duration property of the metadata
-    //
-    info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
-    info.level = info.level || 'info';
-    info.durationMs = time - timeEnd;
-    info.message = info.message || id;
-    return this.write(info);
-  }
-
-  this.profilers[id] = time;
-  return this;
-};
-
-/*
- * Backwards compatibility to `exceptions.handle`
- * in winston < 3.0.0.
- *
- * @api deprecated
- */
-Logger.prototype.handleExceptions = function handleExceptions() {
-  console.warn('Deprecated: .handleExceptions() will be removed in winston@4. Use .exceptions.handle()');
-  var args = Array.prototype.slice.call(arguments);
-  this.exceptions.handle.apply(this.exceptions, args);
-};
-
-/*
- * Backwards compatibility to `exceptions.handle`
- * in winston < 3.0.0.
- *
- * @api deprecated
- */
-Logger.prototype.unhandleExceptions = function unhandleExceptions() {
-  console.warn('Deprecated: .unhandleExceptions() will be removed in winston@4. Use .unexceptions.handle()');
-  var args = Array.prototype.slice.call(arguments);
-  this.exceptions.unhandle.apply(this.exceptions, args);
-};
-
-/*
- * Throw a more meaningful deprecation notice
- */
-Logger.prototype.cli = function cli() {
-  throw new Error([
-    'Logger.cli() was removed in winston@3.0.0',
-    'Use a custom winston.formats.cli() instead.',
-    'See: https://github.com/winstonjs/winston/tree/master/UPGRADE-3.0.md'
-  ].join('\n'));
-};
-
-//
-// ### @private function _onError (transport)
-// #### @transport {Object} Transport on which the error occured
-// #### @err {Error} Error that occurred on the transport
-// Bubbles the error, `err`, that occured on the specified `transport`
-// up from this instance if `emitErrs` has been set.
-//
-Logger.prototype._onError = function _onError(transport) {
-  var self = this;
-
-  function transportError(err) {
-    self.emit('error', err, transport);
-  }
-
-  if (!transport.__winstonError) {
-    transport.__winstonError = transportError;
-    transport.on('error', transport.__winstonError);
-  }
-};
+module.exports = Logger;

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -57,7 +57,7 @@ class Logger extends stream.Transform {
     const maxLength = Math.max.apply(null, Object.keys(levels)
       .map(lev => lev.length));
 
-    this.paddings = Object.keys(levels).reduce(function (acc, lev) {
+    this.paddings = Object.keys(levels).reduce((acc, lev) => {
       const pad = lev.length !== maxLength
         ? new Array(maxLength - lev.length + 1).join(' ')
         : '';
@@ -81,9 +81,9 @@ class Logger extends stream.Transform {
         ? options.transports
         : [options.transports];
 
-      options.transports.forEach(function (transport) {
+      options.transports.forEach(transport => {
         this.add(transport);
-      }, this);
+      });
     }
 
     if (options.colors || options.emitErrs || options.formatters
@@ -291,9 +291,8 @@ class Logger extends stream.Transform {
   remove(transport) {
     let target = transport;
     if (!isStream(transport)) {
-      target = this.transports.filter(function (match) {
-        return match.transport === transport;
-      })[0];
+      target = this.transports
+        .filter(match => match.transport === transport)[0];
     }
 
     if (target) { this.unpipe(target); }
@@ -352,7 +351,7 @@ class Logger extends stream.Transform {
         options.query = transport.formatQuery(queryObject);
       }
 
-      transport.query(options, function (err, res) {
+      transport.query(options, (err, res) => {
         if (err) {
           return next(err);
         }
@@ -364,7 +363,7 @@ class Logger extends stream.Transform {
     // Helper function to accumulate the results from `queryTransport` into
     // the `results`.
     function addResults(transport, next) {
-      queryTransport(transport, function (err, result) {
+      queryTransport(transport, (err, result) => {
         // queryTransport could potentially invoke the callback multiple times
         // since Transport code can be unpredictable.
         if (next) {
@@ -400,9 +399,11 @@ class Logger extends stream.Transform {
     const streams = [];
 
     out._streams = streams;
-    out.destroy = function () {
+    out.destroy = () => {
       let i = streams.length;
-      while (i--) streams[i].destroy();
+      while (i--) {
+        streams[i].destroy();
+      }
     };
 
     // Create a list of all transports for this instance.

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -401,7 +401,7 @@ class Logger extends stream.Transform {
 
     out._streams = streams;
     out.destroy = function () {
-      var i = streams.length;
+      let i = streams.length;
       while (i--) streams[i].destroy();
     };
 
@@ -489,7 +489,7 @@ class Logger extends stream.Transform {
   handleExceptions() {
     // eslint-disable-next-line no-console
     console.warn('Deprecated: .handleExceptions() will be removed in winston@4. Use .exceptions.handle()');
-    var args = Array.prototype.slice.call(arguments);
+    const args = Array.prototype.slice.call(arguments);
     this.exceptions.handle.apply(this.exceptions, args);
   }
 
@@ -501,7 +501,7 @@ class Logger extends stream.Transform {
   unhandleExceptions() {
     // eslint-disable-next-line no-console
     console.warn('Deprecated: .unhandleExceptions() will be removed in winston@4. Use .unexceptions.handle()');
-    var args = Array.prototype.slice.call(arguments);
+    const args = Array.prototype.slice.call(arguments);
     this.exceptions.unhandle.apply(this.exceptions, args);
   }
 

--- a/lib/winston/profiler.js
+++ b/lib/winston/profiler.js
@@ -35,8 +35,7 @@ module.exports = class Profiler {
    * @returns {mixed} - TODO: add return description.
    * @private
    */
-  done() {
-    const args = Array.prototype.slice.call(arguments);
+  done(...args) {
     if (typeof args[args.length - 1] === 'function') {
       // eslint-disable-next-line no-console
       console.warn('Callback function no longer supported as of winston@3.0.0');

--- a/lib/winston/profiler.js
+++ b/lib/winston/profiler.js
@@ -1,37 +1,52 @@
+/**
+ * profiler.js: TODO: add file header description.
+ *
+ * (C) 2010 Charlie Robbins
+ * MIT LICENCE
+ */
+
 'use strict';
 
-//
-// ### @private Profiler
-// Constructor function for the Profiler instance used by
-// `Logger.prototype.startTimer`. When done is called the timer
-// will finish and log the duration.
-//
-var Profiler = module.exports = function Profiler(logger) {
-  if (!logger) {
-    throw new Error('Logger is required for profiling.');
+/**
+ * TODO: add class description.
+ * @type {Profiler}
+ * @private
+ */
+module.exports = class Profiler {
+  /**
+   * Constructor function for the Profiler instance used by
+   * `Logger.prototype.startTimer`. When done is called the timer will finish
+   * and log the duration.
+   * @param {!Logger} logger - TODO: add param description.
+   * @private
+   */
+  constructor(logger) {
+    if (!logger) {
+      throw new Error('Logger is required for profiling.');
+    }
+
+    this.logger = logger;
+    this.start = Date.now();
   }
 
-  this.logger = logger;
-  this.start = Date.now();
-};
+  /**
+   * Ends the current timer (i.e. Profiler) instance and logs the `msg` along
+   * with the duration since creation.
+   * @returns {mixed} - TODO: add return description.
+   * @private
+   */
+  done() {
+    const args = Array.prototype.slice.call(arguments);
+    if (typeof args[args.length - 1] === 'function') {
+      // eslint-disable-next-line no-console
+      console.warn('Callback function no longer supported as of winston@3.0.0');
+      args.pop();
+    }
 
-//
-// ### function done (info)
-// Ends the current timer (i.e. Profiler) instance and
-// logs the `msg` along with the duration since creation.
-//
-Profiler.prototype.done = function () {
-  const args = Array.prototype.slice.call(arguments);
-  let info;
+    const info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
+    info.level = info.level || 'info';
+    info.durationMs = (Date.now()) - this.start;
 
-  if (typeof args[args.length - 1] === 'function') {
-    console.warn('Callback function no longer supported as of winston@3.0.0');
-    args.pop();
+    return this.logger.write(info);
   }
-
-  info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
-  info.level = info.level || 'info';
-  info.durationMs = (Date.now()) - this.start;
-
-  return this.logger.write(info);
 };

--- a/lib/winston/tail-file.js
+++ b/lib/winston/tail-file.js
@@ -1,17 +1,30 @@
+/**
+ * tail-file.js: TODO: add file header description.
+ *
+ * (C) 2010 Charlie Robbins
+ * MIT LICENCE
+ */
+
+'use strict';
+
 const fs = require('fs');
-const StringDecoder = require('string_decoder').StringDecoder;
-const Stream = require('stream').Stream;
+const { StringDecoder } = require('string_decoder');
+const { Stream } = require('stream');
 
-// Simple no-op function
-function nop() {}
+/**
+ * Simple no-op function.
+ * @returns {undefined}
+ */
+function noop() {}
 
-//
-// ### function tailFile (options, iter)
-// #### @options {Object} Options for tail.
-// #### @iter {function} Iterator function to execute on every line.
-// `tail -f` a file. Options must include file.
-//
-module.exports = function tailFile(options, iter) {
+/**
+ * TODO: add function description.
+ * @param {Object} options - Options for tail.
+ * @param {function} iter - Iterator function to execute on every line.
+* `tail -f` a file. Options must include file.
+ * @returns {mixed} - TODO: add return description.
+ */
+module.exports = (options, iter) => {
   const buffer = Buffer.alloc(64 * 1024);
   const decode = new StringDecoder('utf8');
   const stream = new Stream();
@@ -24,7 +37,7 @@ module.exports = function tailFile(options, iter) {
   }
 
   stream.readable = true;
-  stream.destroy = function () {
+  stream.destroy = () => {
     stream.destroyed = true;
     stream.emit('end');
     stream.emit('close');
@@ -43,7 +56,7 @@ module.exports = function tailFile(options, iter) {
 
     (function read() {
       if (stream.destroyed) {
-        fs.close(fd, nop);
+        fs.close(fd, noop);
         return;
       }
 
@@ -74,7 +87,7 @@ module.exports = function tailFile(options, iter) {
           return setTimeout(read, 1000);
         }
 
-        var data = decode.write(buffer.slice(0, bytes));
+        let data = decode.write(buffer.slice(0, bytes));
         if (!iter) {
           stream.emit('data', data);
         }

--- a/lib/winston/tail-file.js
+++ b/lib/winston/tail-file.js
@@ -43,7 +43,7 @@ module.exports = (options, iter) => {
     stream.emit('close');
   };
 
-  fs.open(options.file, 'a+', '0644', function (err, fd) {
+  fs.open(options.file, 'a+', '0644', (err, fd) => {
     if (err) {
       if (!iter) {
         stream.emit('error', err);
@@ -60,7 +60,7 @@ module.exports = (options, iter) => {
         return;
       }
 
-      return fs.read(fd, buffer, 0, buffer.length, pos, function (err, bytes) {
+      return fs.read(fd, buffer, 0, buffer.length, pos, (err, bytes) => {
         if (err) {
           if (!iter) {
             stream.emit('error', err);

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -48,7 +48,7 @@ module.exports = class Console extends TransportStream {
     if (this.stderrLevels[info[LEVEL]]) {
       if (console._stderr) {
         // Node.js maps `process.stderr` to `console._stderr`.
-        console._stderr.write(info[MESSAGE] + this.eol);
+        console._stderr.write(`${info[MESSAGE]}${this.eol}`);
       } else {
         // console.error adds a newline
         console.error(info[MESSAGE]);
@@ -62,7 +62,7 @@ module.exports = class Console extends TransportStream {
 
     if (console._stdout) {
       // Node.js maps `process.stdout` to `console._stdout`.
-      console._stdout.write(info[MESSAGE] + this.eol);
+      console._stdout.write(`${info[MESSAGE]}${this.eol}`);
     } else {
       // console.log adds a newline.
       console.log(info[MESSAGE]);

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -1,120 +1,127 @@
-/* eslint: no-console: 0 */
+/* eslint-disable no-console */
 /*
- * console.js: Transport for outputting to the console
+ * console.js: Transport for outputting to the console.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
+'use strict';
+
 const os = require('os');
-const util = require('util');
 const { LEVEL, MESSAGE } = require('triple-beam');
 const TransportStream = require('winston-transport');
 
-//
-// ### function Console (options)
-// #### @options {Object} Options for this instance.
-// Constructor function for the Console transport object responsible
-// for persisting log messages and metadata to a terminal or TTY.
-//
-var Console = module.exports = function (options) {
-  options = options || {};
-  TransportStream.call(this, options);
+/**
+ * Transport for outputting to the console.
+ * @type {Console}
+ * @extends {TransportStream}
+ */
+module.exports = class Console extends TransportStream {
+  /**
+   * Constructor function for the Console transport object responsible for
+   * persisting log messages and metadata to a terminal or TTY.
+   * @param {!Object} [options={}] - Options for this instance.
+   */
+  constructor(options = {}) {
+    super(options);
 
-  this.stderrLevels = getStderrLevels(options.stderrLevels, options.debugStdout);
-  this.eol = options.eol || os.EOL;
+    // Expose the name of this Transport on the prototype
+    this.name = 'console';
+    this.stderrLevels = this._getStderrLevels(
+      options.stderrLevels,
+      options.debugStdout
+    );
+    this.eol = options.eol || os.EOL;
+  }
 
-  //
-  // Convert stderrLevels into an Object for faster key-lookup times than an Array.
-  //
-  // For backwards compatibility, stderrLevels defaults to ['error', 'debug']
-  // or ['error'] depending on whether options.debugStdout is true.
-  //
-  function getStderrLevels(levels, debugStdout) {
-    var defaultMsg = 'Cannot have non-string elements in stderrLevels Array';
+  /**
+   * Core logging method exposed to Winston.
+   * @param {Object} info - TODO: add param description.
+   * @param {Function} callback - TODO: add param description.
+   * @returns {undefined}
+   */
+  log(info, callback) {
+    setImmediate(() => this.emit('logged', info));
+
+    // Remark: what if there is no raw...?
+    if (this.stderrLevels[info[LEVEL]]) {
+      if (console._stderr) {
+        // Node.js maps `process.stderr` to `console._stderr`.
+        console._stderr.write(info[MESSAGE] + this.eol);
+      } else {
+        // console.error adds a newline
+        console.error(info[MESSAGE]);
+      }
+
+      if (callback) {
+        callback(); // eslint-disable-line callback-return
+      }
+      return;
+    }
+
+    if (console._stdout) {
+      // Node.js maps `process.stdout` to `console._stdout`.
+      console._stdout.write(info[MESSAGE] + this.eol);
+    } else {
+      // console.log adds a newline.
+      console.log(info[MESSAGE]);
+    }
+
+    if (callback) {
+      callback(); // eslint-disable-line callback-return
+    }
+  }
+
+  /**
+   * Convert stderrLevels into an Object for faster key-lookup times than an
+   * Array. For backwards compatibility, stderrLevels defaults to
+   * ['error', 'debug'] or ['error'] depending on whether options.debugStdout
+   * is true.
+   * @param {mixed} levels - TODO: add param description.
+   * @param {mixed} debugStdout - TODO: add param description.
+   * @returns {mixed} - TODO: add return description.
+   * @private
+   */
+  _getStderrLevels(levels, debugStdout) {
+    const defaultMsg = 'Cannot have non-string elements in stderrLevels Array';
     if (debugStdout) {
       if (levels) {
-        //
         // Don't allow setting both debugStdout and stderrLevels together,
         // since this could cause behaviour a programmer might not expect.
-        //
         throw new Error('Cannot set debugStdout and stderrLevels together');
       }
 
-      return stringArrayToSet(['error'], defaultMsg);
+      return this._stringArrayToSet(['error'], defaultMsg);
     }
 
     if (!levels) {
-      return stringArrayToSet(['error', 'debug'], defaultMsg);
+      return this._stringArrayToSet(['error', 'debug'], defaultMsg);
     } else if (!(Array.isArray(levels))) {
       throw new Error('Cannot set stderrLevels to type other than Array');
     }
 
-    return stringArrayToSet(levels, defaultMsg);
+    return this._stringArrayToSet(levels, defaultMsg);
+  }
+
+  /**
+   * Returns a Set-like object with strArray's elements as keys (each with the
+   * value true).
+   * @param {Array} strArray - Array of Set-elements as strings.
+   * @param {?string} [errMsg] - Custom error message thrown on invalid input.
+   * @returns {Object} - TODO: add return description.
+   * @private
+   */
+  _stringArrayToSet(strArray, errMsg) {
+    errMsg = errMsg || 'Cannot make set from Array with non-string elements';
+
+    return strArray.reduce((set, el) =>  {
+      if (typeof el !== 'string') {
+        throw new Error(errMsg);
+      }
+      set[el] = true;
+
+      return set;
+    }, {});
   }
 };
-
-//
-// Inherit from `winston.Transport`.
-//
-util.inherits(Console, TransportStream);
-
-//
-// Expose the name of this Transport on the prototype
-//
-Console.prototype.name = 'console';
-
-//
-// ### function log (info)
-// #### @info {Object} **Optional** Additional metadata to attach
-// Core logging method exposed to Winston.
-//
-Console.prototype.log = function (info, callback) {
-  var self = this;
-  setImmediate(function () {
-    self.emit('logged', info);
-  });
-
-  //
-  // Remark: what if there is no raw...?
-  //
-  if (this.stderrLevels[info[LEVEL]]) {
-    if (console._stderr) {
-      // Node.js maps `process.stderr` to `console._stderr`.
-      console._stderr.write(info[MESSAGE] + this.eol);
-    } else {
-      // console.error adds a newline
-      console.error(info[MESSAGE]);
-    }
-
-    if (callback) { callback(); } // eslint-disable-line
-    return;
-  }
-
-  if (console._stdout) {
-    // Node.js maps `process.stdout` to `console._stdout`.
-    console._stdout.write(info[MESSAGE] + this.eol);
-  } else {
-    // console.log adds a newline.
-    console.log(info[MESSAGE]);
-  }
-
-  if (callback) { callback(); } // eslint-disable-line
-};
-
-//
-// ### function stringArrayToSet (array)
-// #### @strArray {Array} Array of Set-elements as strings.
-// #### @errMsg {string} **Optional** Custom error message thrown on invalid input.
-// Returns a Set-like object with strArray's elements as keys (each with the value true).
-//
-function stringArrayToSet(strArray, errMsg) {
-  errMsg = errMsg || 'Cannot make set from Array with non-string elements';
-
-  return strArray.reduce(function (set, el) {
-    if (typeof el !== 'string') { throw new Error(errMsg); }
-    set[el] = true;
-    return set;
-  }, {});
-}

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -47,7 +47,7 @@ module.exports = class File extends TransportStream {
     function throwIf(target) {
       Array.prototype.slice.call(arguments, 1).forEach(name => {
         if (options[name]) {
-          throw new Error('Cannot set ' + name + ' and ' + target + 'together');
+          throw new Error(`Cannot set ${name} and ${target} together`);
         }
       });
     }
@@ -113,7 +113,7 @@ module.exports = class File extends TransportStream {
     }
 
     // Grab the raw string and append the expected EOL.
-    const output = info[MESSAGE] + this.eol;
+    const output = `${info[MESSAGE]}${this.eol}`;
 
     // This gets called too early and does not depict when data has been flushed
     // to disk like I want it to.
@@ -349,7 +349,7 @@ module.exports = class File extends TransportStream {
       }
 
       if (err) {
-        debug('err ' + err.code, fullpath);
+        debug(`err ${err.code} ${fullpath}`);
         return callback(err);
       }
 
@@ -519,17 +519,19 @@ module.exports = class File extends TransportStream {
   _getFile() {
     const ext = path.extname(this._basename);
     const basename = path.basename(this._basename, ext);
+    const isRotation = this.rotationFormat
+      ? this.rotationFormat()
+      : this._created;
 
     // Caveat emptor (indexzero): rotationFormat() was broken by design When
     // combined with max files because the set of files to unlink is never
     // stored.
-    // TODO: refactor next line.
     const target = !this.tailable && this._created
-      ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
-      : basename + ext;
+      ? `${basename}${isRotation}${ext}`
+      : `${basename}${ext}`;
 
     return this.zippedArchive
-      ? target + '.gz'
+      ? `${target}.gz`
       : target;
   }
 
@@ -548,8 +550,10 @@ module.exports = class File extends TransportStream {
     }
 
     const oldest = this._created - this.maxFiles;
-    // TODO: refactor next line.
-    const target = path.join(this.dirname, basename + (oldest !== 0 ? oldest : '') + ext + (this.zippedArchive ? '.gz' : ''));
+    const isOldest = oldest !== 0 ? oldest : '';
+    const isZipped = this.zippedArchive ? '.gz' : '';
+    const filePath = `${basename}${isOldest}${ext}${isZipped}`;
+    const target = path.join(this.dirname, filePath);
 
     fs.unlink(target, callback);
   }
@@ -571,19 +575,21 @@ module.exports = class File extends TransportStream {
       return;
     }
 
+    // const isZipped = this.zippedArchive ? '.gz' : '';
+    const isZipped = this.zippedArchive ? '.gz' : '';
     for (let x = this.maxFiles - 1; x > 0; x--) {
       tasks.push(function (i) {
         return cb => {
-          // TODO: refactor next line.
-          const tmppath = path.join(this.dirname, basename + (i - 1) + ext + (this.zippedArchive ? '.gz' : ''));
+          let fileName = `${basename}${(i - 1)}${ext}${isZipped}`;
+          const tmppath = path.join(this.dirname, fileName);
 
           fs.exists(tmppath, exists => {
             if (!exists) {
               return cb(null);
             }
 
-            // TODO: refactor next line.
-            fs.rename(tmppath, path.join(this.dirname, basename + i + ext + (this.zippedArchive ? '.gz' : '')), cb);
+            fileName = `${basename}${i}${ext}${isZipped}`;
+            fs.rename(tmppath, path.join(this.dirname, fileName), cb);
           });
         };
       }.bind(this, x));
@@ -591,8 +597,8 @@ module.exports = class File extends TransportStream {
 
     asyncSeries(tasks, () => {
       fs.rename(
-        path.join(this.dirname, basename + ext),
-        path.join(this.dirname, basename + 1 + ext),
+        path.join(this.dirname, `${basename}${ext}`),
+        path.join(this.dirname, `${basename}1${ext}`),
         callback
       );
     });

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -42,10 +42,10 @@ module.exports = class File extends TransportStream {
     // Expose the name of this Transport on the prototype.
     this.name = 'file';
 
-    // Helper function which throws an `Error` in the event
-    // that any of the rest of the arguments is present in `options`.
-    function throwIf(target) {
-      Array.prototype.slice.call(arguments, 1).forEach(name => {
+    // Helper function which throws an `Error` in the event that any of the
+    // rest of the arguments is present in `options`.
+    function throwIf(target, ...args) {
+      args.slice(1).forEach(name => {
         if (options[name]) {
           throw new Error(`Cannot set ${name} and ${target} together`);
         }

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -1,14 +1,14 @@
-/*
- * file.js: Transport for outputting to a local log file
+/**
+ * file.js: Transport for outputting to a local log file.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
+
+'use strict';
 
 const fs = require('fs');
 const path = require('path');
-const util = require('util');
 const asyncSeries = require('async/series');
 const zlib = require('zlib');
 const { MESSAGE } = require('triple-beam');
@@ -19,541 +19,582 @@ const debug = require('diagnostics')('winston:file');
 const os = require('os');
 const tailFile = require('../tail-file');
 
-var noop = function () {};
+/**
+ * Simple no-op function.
+ * @returns {undefined}
+ */
+function noop() {}
 
-//
-// ### function File (options)
-// #### @options {Object} Options for this instance.
-// Constructor function for the File transport object responsible
-// for persisting log messages and metadata to one or more files.
-//
-var File = module.exports = function (options) {
-  options = options || {};
-  TransportStream.call(this, options);
+/**
+ * Transport for outputting to a local log file.
+ * @type {File}
+ * @extends {TransportStream}
+ */
+module.exports = class File extends TransportStream {
+  /**
+   * Constructor method for the File transport object responsible
+   * for persisting log messages and metadata to one or more files.
+   * @param {Object} options - Options for this instance.
+   */
+  constructor(options = {}) {
+    super(options);
 
-  //
-  // Helper function which throws an `Error` in the event
-  // that any of the rest of the arguments is present in `options`.
-  //
-  function throwIf(target /* , illegal... */) {
-    Array.prototype.slice.call(arguments, 1).forEach(function (name) {
-      if (options[name]) {
-        throw new Error('Cannot set ' + name + ' and ' + target + 'together');
+    // Expose the name of this Transport on the prototype.
+    this.name = 'file';
+
+    // Helper function which throws an `Error` in the event
+    // that any of the rest of the arguments is present in `options`.
+    function throwIf(target) {
+      Array.prototype.slice.call(arguments, 1).forEach(name => {
+        if (options[name]) {
+          throw new Error('Cannot set ' + name + ' and ' + target + 'together');
+        }
+      });
+    }
+
+    // Setup the base stream that always gets piped to to handle buffering.
+    this._stream = new PassThrough();
+    // Bind this context for listener methods.
+    this._onDrain = this._onDrain.bind(this);
+    this._onError = this._onError.bind(this);
+
+    if (options.filename || options.dirname) {
+      throwIf('filename or dirname', 'stream');
+      this._basename = this.filename = options.filename
+        ? path.basename(options.filename)
+        : 'winston.log';
+
+      this.dirname = options.dirname || path.dirname(options.filename);
+      this.options = options.options || {
+        flags: 'a'
+      };
+    } else if (options.stream) {
+      // eslint-disable-next-line no-console
+      console.warn('options.stream will be removed in winston@4. Use winston.transports.Stream');
+      throwIf('stream', 'filename', 'maxsize');
+      this._dest = this._stream.pipe(this._setupStream(options.stream));
+      // We need to listen for drain events when write() returns false. This
+      // can make node mad at times.
+    } else {
+      throw new Error('Cannot log to file without filename or stream.');
+    }
+
+    this.maxsize = options.maxsize || null;
+    this.rotationFormat = options.rotationFormat || false;
+    this.zippedArchive = options.zippedArchive || false;
+    this.maxFiles = options.maxFiles || null;
+    this.eol = options.eol || os.EOL;
+    this.tailable = options.tailable || false;
+
+    // Internal state variables representing the number of files this instance
+    // has created and the current size (in bytes) of the current logfile.
+    this._size = 0;
+    this._created = 0;
+    this._drains = 0;
+    this._next = noop;
+    this._opening = false;
+
+    this.open();
+  }
+
+  /**
+   * Core logging method exposed to Winston. Metadata is optional.
+   * @param {Object} info - TODO: add param description.
+   * @param {Function} callback - TODO: add param description.
+   * @returns {undefined}
+   */
+  log(info, callback = noop) {
+    // Remark: (jcrugzz) What is necessary about this callback(null, true) now
+    // when thinking about 3.x? Should silent be handled in the base
+    // TransportStream _write method?
+    if (this.silent) {
+      callback();
+      return true;
+    }
+
+    // Grab the raw string and append the expected EOL.
+    const output = info[MESSAGE] + this.eol;
+
+    // This gets called too early and does not depict when data has been flushed
+    // to disk like I want it to.
+    function logged() {
+      this._size += Buffer.byteLength(output);
+      this.emit('logged', info);
+
+      // Check to see if we need to end the stream and create a new one.
+      if (!this._needsNewFile()) {
+        return;
       }
+
+      // End the current stream, ensure it flushes and create a new one.
+      // TODO: This could probably be optimized to not run a stat call but its
+      // the safest way since we are supporting `maxFiles`. Remark: We could
+      // call `open` here but that would incur an extra unnecessary stat call.
+      this._endStream(() => this._nextFile());
+    }
+
+    const written = this._stream.write(output, logged.bind(this));
+    if (written === false) {
+      ++this._drains;
+    }
+
+    if (!this._drains) {
+      callback(); // eslint-disable-line callback-return
+    } else {
+      this._next = callback;
+    }
+
+    return written;
+  }
+
+  /**
+   * Query the transport. Options object is optional.
+   * @param {Object} options - Loggly-like query options for this instance.
+   * @param {function} callback - Continuation to respond to when complete.
+   * TODO: Refactor me.
+   */
+  query(options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    options = this.normalizeQuery(options);
+    const file = path.join(this.dirname, this.filename);
+    let buff = '';
+    let results = [];
+    let row = 0;
+
+    var stream = fs.createReadStream(file, {
+      encoding: 'utf8'
     });
-  }
 
-  //
-  // Setup the base stream that always gets piped to to handle buffering
-  //
-  this._stream = new PassThrough();
-
-  //
-  // Bind this context for listener functions
-  //
-  this._onDrain = this._onDrain.bind(this);
-  this._onError = this._onError.bind(this);
-
-  if (options.filename || options.dirname) {
-    throwIf('filename or dirname', 'stream');
-    this._basename = this.filename = options.filename
-      ? path.basename(options.filename)
-      : 'winston.log';
-
-    this.dirname = options.dirname || path.dirname(options.filename);
-    this.options = options.options || { flags: 'a' };
-  } else if (options.stream) {
-    console.warn('options.stream will be removed in winston@4. Use winston.transports.Stream');
-    throwIf('stream', 'filename', 'maxsize');
-    this._dest = this._stream.pipe(this._setupStream(options.stream));
-    //
-    // We need to listen for drain events when
-    // write() returns false. This can make node
-    // mad at times.
-    //
-  } else {
-    throw new Error('Cannot log to file without filename or stream.');
-  }
-
-  this.maxsize     = options.maxsize     || null;
-  this.rotationFormat = options.rotationFormat || false;
-  this.zippedArchive = options.zippedArchive || false;
-  this.maxFiles    = options.maxFiles    || null;
-  this.eol         = options.eol || os.EOL;
-  this.tailable    = options.tailable    || false;
-
-  //
-  // Internal state variables representing the number
-  // of files this instance has created and the current
-  // size (in bytes) of the current logfile.
-  //
-  this._size     = 0;
-  this._created  = 0;
-  this._drains   = 0;
-  this._next     = noop;
-  this._opening  = false;
-
-  this.open();
-};
-
-//
-// Inherit from `winston.Transport`.
-//
-util.inherits(File, TransportStream);
-
-//
-// Expose the name of this Transport on the prototype
-//
-File.prototype.name = 'file';
-
-//
-// function log (info)
-// @param {Object} info All relevant log information
-// Core logging method exposed to Winston. Metadata is optional.
-//
-File.prototype.log = function (info, callback) {
-  callback = callback || noop;
-
-  //
-  // Remark: (jcrugzz) What is necessary about this callback(null, true) now
-  // when thinking about 3.x? Should silent be handled in the base
-  // TransportStream _write method?
-  //
-  if (this.silent) {
-    callback();
-    return true;
-  }
-
-  //
-  // Grab the raw string and append the expected EOL
-  //
-  var self = this;
-  var output = info[MESSAGE] + this.eol;
-
-  //
-  // This gets called too early and does not depict when data has been flushed
-  // to disk like I want it to
-  //
-  function logged() {
-    self._size += Buffer.byteLength(output);
-    self.emit('logged', info);
-
-    //
-    // Check to see if we need to end the stream and create a new one
-    //
-    if (!self._needsNewFile()) { return; }
-
-    //
-    // End the current stream, ensure it flushes and create a new one.
-    // TODO: This could probably be optimized to not run a stat call but its
-    // the safest way since we are supporting `maxFiles`.
-    // Remark: We could call `open` here but that would incur an extra unnecessary stat call
-    //
-    self._endStream(function () { self._nextFile(); });
-  }
-
-  var written = this._stream.write(output, logged);
-  if (written === false) ++this._drains;
-  if (!this._drains) callback(); // eslint-disable-line
-  else this._next = callback;
-
-  return written;
-};
-
-//
-// ### function query (options, callback)
-// #### @options {Object} Loggly-like query options for this instance.
-// #### @callback {function} Continuation to respond to when complete.
-// Query the transport. Options object is optional.
-// TODO: Refactor me
-//
-File.prototype.query = function (options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-
-  options = this.normalizeQuery(options);
-  const file = path.join(this.dirname, this.filename);
-  let buff = '';
-  let results = [];
-  let row = 0;
-
-  var stream = fs.createReadStream(file, {
-    encoding: 'utf8'
-  });
-
-  stream.on('error', function (err) {
-    if (stream.readable) {
-      stream.destroy();
-    }
-    if (!callback) return;
-    return err.code !== 'ENOENT'
-      ? callback(err)
-      : callback(null, results);
-  });
-
-  stream.on('data', function (data) {
-    data = (buff + data).split(/\n+/);
-    const l = data.length - 1;
-    let i = 0;
-
-    for (; i < l; i++) {
-      if (!options.start || row >= options.start) {
-        add(data[i]);
-      }
-      row++;
-    }
-
-    buff = data[l];
-  });
-
-  stream.on('close', function () {
-    if (buff) add(buff, true);
-    if (options.order === 'desc') {
-      results = results.reverse();
-    }
-
-    // eslint-disable-next-line callback-return
-    if (callback) callback(null, results);
-  });
-
-  function add(buff, attempt) {
-    try {
-      var log = JSON.parse(buff);
-      if (check(log)) push(log);
-    } catch (e) {
-      if (!attempt) {
-        stream.emit('error', e);
-      }
-    }
-  }
-
-  function push(log) {
-    if (options.rows && results.length >= options.rows
-        && options.order !== 'desc') {
+    stream.on('error', err => {
       if (stream.readable) {
         stream.destroy();
       }
-      return;
-    }
-
-    if (options.fields) {
-      var obj = {};
-      options.fields.forEach(function (key) {
-        obj[key] = log[key];
-      });
-      log = obj;
-    }
-
-    if (options.order === 'desc') {
-      if (results.length >= options.rows) {
-        results.shift();
+      if (!callback) {
+        return;
       }
-    }
-    results.push(log);
-  }
 
-  function check(log) {
-    if (!log) return;
-
-    if (typeof log !== 'object') return;
-
-    var time = new Date(log.timestamp);
-    if ((options.from && time < options.from)
-        || (options.until && time > options.until)
-        || (options.level && options.level !== log.level)) {
-      return;
-    }
-
-    return true;
-  }
-};
-
-//
-// ### function stream (options)
-// #### @options {Object} Stream options for this instance.
-// Returns a log stream for this transport. Options object is optional.
-// TODO: Refactor me
-//
-File.prototype.stream = function (options) {
-  options = options || {};
-  const file = path.join(this.dirname, this.filename);
-  const stream = new Stream();
-
-  const tail = {
-    file: file,
-    start: options.start
-  };
-
-  stream.destroy = tailFile(tail, function (err, line) {
-    if (err) {
-      return stream.emit('error', err);
-    }
-
-    try {
-      stream.emit('data', line);
-      line = JSON.parse(line);
-      stream.emit('log', line);
-    } catch (e) {
-      stream.emit('error', e);
-    }
-  });
-
-  return stream;
-};
-
-//
-// ### function stat
-// Checks to see the filesize of
-//
-File.prototype.open = function open() {
-  var self = this;
-
-  //
-  // If we do not have a filename then we were passed a stream
-  // and dont need to keep track of size
-  //
-  if (!this.filename) { return; }
-  if (this.opening) { return; }
-  this.opening = true;
-
-  //
-  // Stat the target file to get the size and create the stream
-  //
-  this.stat(function (err, size) {
-    if (err) return self.emit('error', err);
-
-    debug('stat done', self.filename);
-    self._size = size;
-    self._createStream();
-    self.opening = false;
-  });
-};
-
-//
-// ### function stat
-// Stat the file and assess information in order to create the proper stream
-//
-File.prototype.stat = function stat(callback) {
-  var self = this;
-  var target = this._getFile();
-  var fullpath = path.join(this.dirname, target);
-
-  fs.stat(fullpath, function (err, stat) {
-    if (err && err.code === 'ENOENT') {
-      debug('err ENOENT', fullpath);
-      // Update internally tracked filename with the new target name
-      self.filename = target;
-      return callback(null, 0);
-    }
-
-    if (err) {
-      debug('err ' + err.code, fullpath);
-      return callback(err);
-    }
-
-    if (!stat || self._needsNewFile(stat.size)) {
-      //
-      // If `stats.size` is greater than the `maxsize` for
-      // this instance then try again
-      //
-      return self._incFile(function () { self.stat(callback); });
-    }
-    //
-    // Once we have figured out what the filename is, set it and return the
-    // size
-    //
-    self.filename = target;
-    callback(null, stat.size);
-  });
-};
-
-//
-// ### function close ()
-// Closes the stream associated with this instance.
-//
-File.prototype.close = function (cb) {
-  var self = this;
-
-  if (!this._stream) return;
-
-  this._stream.end(function () {
-    // eslint-disable-next-line callback-return
-    if (cb) cb();
-    self.emit('flush');
-    self.emit('closed');
-  });
-};
-
-File.prototype._needsNewFile = function (size) {
-  size = size || this._size;
-  return this.maxsize && size >= this.maxsize;
-};
-
-File.prototype._onDrain = function onDrain() {
-  if (--this._drains) return;
-  var next = this._next;
-  this._next = noop;
-  next();
-};
-
-File.prototype._onError = function onError(err) {
-  this.emit('error', err);
-};
-
-File.prototype._setupStream = function (stream) {
-  stream.on('error', this._onError);
-  stream.on('drain', this._onDrain);
-  return stream;
-};
-
-File.prototype._cleanupStream = function (stream) {
-  stream.removeListener('error', this._onError);
-  stream.removeListener('drain', this._onDrain);
-  return stream;
-};
-
-File.prototype._nextFile = function nextFile() {
-  var self = this;
-  return this._incFile(function () { self.open(); });
-};
-
-//
-// ### @private function endStream
-// #### @param {function} callback
-// Unpipe from the stream that has been marked as FULL
-// and end it so it flushes to disk
-//
-File.prototype._endStream = function endStream(callback) {
-  var self = this;
-  this._stream.unpipe(this._dest);
-
-  this._dest.end(function () {
-    self._cleanupStream(self._dest);
-    callback();
-  });
-};
-
-//
-// ### @private function _createStream ()
-//
-File.prototype._createStream = function () {
-  var self = this;
-  var fullpath = path.join(this.dirname, this.filename);
-
-  debug('create stream start', fullpath);
-  this._dest = fs.createWriteStream(fullpath, this.options)
-    .on('error', function (err) {
-      // TODO: what should we do with errors here?
-      debug(err);
-    })
-    .on('drain', this._onDrain)
-    .on('open', function () {
-      debug('file open ok', fullpath);
-      self.emit('open');
-      self._stream.pipe(self._dest);
+      return err.code !== 'ENOENT' ? callback(err) : callback(null, results);
     });
 
-  debug('create stream ok', fullpath);
-  if (this.zippedArchive) {
-    var gzip = zlib.createGzip();
-    gzip.pipe(this._dest);
-    this._dest = gzip;
-  }
-};
+    stream.on('data', data => {
+      data = (buff + data).split(/\n+/);
+      const l = data.length - 1;
+      let i = 0;
 
-File.prototype._incFile = function (callback) {
-  const ext = path.extname(this._basename);
-  const basename = path.basename(this._basename, ext);
+      for (; i < l; i++) {
+        if (!options.start || row >= options.start) {
+          add(data[i]);
+        }
+        row++;
+      }
 
-  if (!this.tailable) {
-    this._created += 1;
-    this._checkMaxFilesIncrementing(ext, basename, callback);
-  } else {
-    this._checkMaxFilesTailable(ext, basename, callback);
-  }
-};
+      buff = data[l];
+    });
 
-//
-// ### @private function _getFile ()
-// Gets the next filename to use for this instance
-// in the case that log filesizes are being capped.
-//
-File.prototype._getFile = function () {
-  const ext = path.extname(this._basename);
-  const basename = path.basename(this._basename, ext);
+    stream.on('close', () => {
+      if (buff) {
+        add(buff, true);
+      }
+      if (options.order === 'desc') {
+        results = results.reverse();
+      }
 
-  //
-  // Caveat emptor (indexzero): rotationFormat() was broken by design
-  // when combined with max files because the set of files to unlink
-  // is never stored.
-  //
-  var target = !this.tailable && this._created
-    ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
-    : basename + ext;
+      // eslint-disable-next-line callback-return
+      if (callback) callback(null, results);
+    });
 
-  return this.zippedArchive
-    ? target + '.gz'
-    : target;
-};
+    function add(buff, attempt) {
+      try {
+        const log = JSON.parse(buff);
+        if (check(log)) {
+          push(log);
+        }
+      } catch (e) {
+        if (!attempt) {
+          stream.emit('error', e);
+        }
+      }
+    }
 
-//
-// ### @private function _checkMaxFilesIncrementing ()
-// Increment the number of files created or
-// checked by this instance.
-//
-File.prototype._checkMaxFilesIncrementing = function (ext, basename, callback) {
-  // Check for maxFiles option and delete file
-  if (!this.maxFiles || this._created < this.maxFiles) {
-    return callback();
-  }
+    function push(log) {
+      if (
+        options.rows &&
+        results.length >= options.rows &&
+        options.order !== 'desc'
+      ) {
+        if (stream.readable) {
+          stream.destroy();
+        }
+        return;
+      }
 
-  const oldest = this._created - this.maxFiles;
-  const target = path.join(this.dirname, basename + (oldest !== 0 ? oldest : '') + ext +
-    (this.zippedArchive ? '.gz' : ''));
-
-  fs.unlink(target, callback);
-};
-
-//
-// ### @private function _checkMaxFilesTailable ()
-//
-// Roll files forward based on integer, up to maxFiles.
-// e.g. if base if file.log and it becomes oversized, roll
-//    to file1.log, and allow file.log to be re-used. If
-//    file is oversized again, roll file1.log to file2.log,
-//    roll file.log to file1.log, and so on.
-File.prototype._checkMaxFilesTailable = function (ext, basename, callback) {
-  const tasks = [];
-  const self = this;
-
-  if (!this.maxFiles) {
-    return;
-  }
-
-  for (var x = this.maxFiles - 1; x > 0; x--) {
-    tasks.push(function (i) {
-      return function (cb) {
-        var tmppath = path.join(self.dirname, basename + (i - 1) + ext +
-          (self.zippedArchive ? '.gz' : ''));
-        fs.exists(tmppath, function (exists) {
-          if (!exists) {
-            return cb(null);
-          }
-
-          fs.rename(tmppath, path.join(self.dirname, basename + i + ext +
-            (self.zippedArchive ? '.gz' : '')), cb);
+      if (options.fields) {
+        // TODO: refactor with reduce.
+        const obj = {};
+        options.fields.forEach(key => {
+          obj[key] = log[key];
         });
-      };
-    }(x));
+        log = obj;
+      }
+
+      if (options.order === 'desc') {
+        if (results.length >= options.rows) {
+          results.shift();
+        }
+      }
+      results.push(log);
+    }
+
+    function check(log) {
+      if (!log) {
+        return;
+      }
+
+      if (typeof log !== 'object') {
+        return;
+      }
+
+      const time = new Date(log.timestamp);
+      if (
+        (options.from && time < options.from) ||
+        (options.until && time > options.until) ||
+        (options.level && options.level !== log.level)
+      ) {
+        return;
+      }
+
+      return true;
+    }
   }
 
-  asyncSeries(tasks, function (err) { // eslint-disable-line
-    fs.rename(
-      path.join(self.dirname, basename + ext),
-      path.join(self.dirname, basename + 1 + ext),
-      callback
-    );
-  });
+  /**
+   * Returns a log stream for this transport. Options object is optional.
+   * @param {Object} options - Stream options for this instance.
+   * @returns {Stream} - TODO: add return description.
+   * TODO: Refactor me.
+   */
+  stream(options = {}) {
+    const file = path.join(this.dirname, this.filename);
+    const stream = new Stream();
+    const tail = {
+      file,
+      start: options.start
+    };
+
+    stream.destroy = tailFile(tail, (err, line) => {
+      if (err) {
+        return stream.emit('error', err);
+      }
+
+      try {
+        stream.emit('data', line);
+        line = JSON.parse(line);
+        stream.emit('log', line);
+      } catch (e) {
+        stream.emit('error', e);
+      }
+    });
+
+    return stream;
+  }
+
+  /**
+   * Checks to see the filesize of.
+   * @returns {undefined}
+   */
+  open() {
+    // If we do not have a filename then we were passed a stream and dont need
+    // to keep track of size.
+    if (!this.filename) {
+      return;
+    }
+    if (this.opening) {
+      return;
+    }
+
+    this.opening = true;
+
+    // Stat the target file to get the size and create the stream.
+    this.stat((err, size) => {
+      if (err) {
+        return this.emit('error', err);
+      }
+
+      debug('stat done', this.filename);
+      this._size = size;
+      this._createStream();
+      this.opening = false;
+    });
+  }
+
+  /**
+   * Stat the file and assess information in order to create the proper stream.
+   * @param {function} callback - TODO: add param description.
+   * @returns {undefined}
+   */
+  stat(callback) {
+    const target = this._getFile();
+    const fullpath = path.join(this.dirname, target);
+
+    fs.stat(fullpath, (err, stat) => {
+      if (err && err.code === 'ENOENT') {
+        debug('err ENOENT', fullpath);
+        // Update internally tracked filename with the new target name.
+        this.filename = target;
+        return callback(null, 0);
+      }
+
+      if (err) {
+        debug('err ' + err.code, fullpath);
+        return callback(err);
+      }
+
+      if (!stat || this._needsNewFile(stat.size)) {
+        // If `stats.size` is greater than the `maxsize` for this instance then
+        // try again.
+        return this._incFile(() => this.stat(callback));
+      }
+
+      // Once we have figured out what the filename is, set it and return the
+      // size.
+      this.filename = target;
+      callback(null, stat.size);
+    });
+  }
+
+  /**
+   * Closes the stream associated with this instance.
+   * @param {function} cb - TODO: add param description.
+   * @returns {undefined}
+   */
+  close(cb) {
+    if (!this._stream) {
+      return;
+    }
+
+    this._stream.end(() => {
+      if (cb) {
+        cb(); // eslint-disable-line callback-return
+      }
+      this.emit('flush');
+      this.emit('closed');
+    });
+  }
+
+  /**
+   * TODO: add method description.
+   * @param {number} size - TODO: add param description.
+   * @returns {undefined}
+   */
+  _needsNewFile(size) {
+    size = size || this._size;
+    return this.maxsize && size >= this.maxsize;
+  }
+
+  /**
+   * TODO: add method description.
+   * @returns {undefined}
+   */
+  _onDrain() {
+    if (--this._drains) {
+      return;
+    }
+
+    const next = this._next;
+    this._next = noop;
+
+    next();
+  }
+
+  /**
+   * TODO: add method description.
+   * @param {Error} err - TODO: add param description.
+   * @returns {undefined}
+   */
+  _onError(err) {
+    this.emit('error', err);
+  }
+
+  /**
+   * TODO: add method description.
+   * @param {Stream} stream - TODO: add param description.
+   * @returns {mixed} - TODO: add return description.
+   */
+  _setupStream(stream) {
+    stream.on('error', this._onError);
+    stream.on('drain', this._onDrain);
+
+    return stream;
+  }
+
+  /**
+   * TODO: add method description.
+   * @param {Stream} stream - TODO: add param description.
+   * @returns {mixed} - TODO: add return description.
+   */
+  _cleanupStream(stream) {
+    stream.removeListener('error', this._onError);
+    stream.removeListener('drain', this._onDrain);
+
+    return stream;
+  }
+
+  /**
+   * TODO: add method description.
+   * @returns {mixed} - TODO: add return description.
+   */
+  _nextFile() {
+    return this._incFile(() => {
+      this.open();
+    });
+  }
+
+  /**
+   * Unpipe from the stream that has been marked as full and end it so it
+   * flushes to disk.
+   * @param {function} callback - TODO: add param description.
+   * @private
+   */
+  _endStream(callback) {
+    this._stream.unpipe(this._dest);
+    this._dest.end(() => {
+      this._cleanupStream(this._dest);
+      callback();
+    });
+  }
+
+  /**
+   * TODO: add method description.
+   * @returns {undefined}
+   */
+  _createStream() {
+    const fullpath = path.join(this.dirname, this.filename);
+
+    debug('create stream start', fullpath);
+    this._dest = fs.createWriteStream(fullpath, this.options)
+      // TODO: What should we do with errors here?
+      .on('error', err => debug(err))
+      .on('drain', this._onDrain)
+      .on('open', () => {
+        debug('file open ok', fullpath);
+        this.emit('open');
+        this._stream.pipe(this._dest);
+      });
+
+    debug('create stream ok', fullpath);
+    if (this.zippedArchive) {
+      const gzip = zlib.createGzip();
+      gzip.pipe(this._dest);
+      this._dest = gzip;
+    }
+  }
+
+  /**
+   * TODO: add method description.
+   * @param {function} callback - TODO: add param description.
+   * @returns {undefined}
+   */
+  _incFile(callback) {
+    const ext = path.extname(this._basename);
+    const basename = path.basename(this._basename, ext);
+
+    if (!this.tailable) {
+      this._created += 1;
+      this._checkMaxFilesIncrementing(ext, basename, callback);
+    } else {
+      this._checkMaxFilesTailable(ext, basename, callback);
+    }
+  }
+
+  /**
+   * Gets the next filename to use for this instance in the case that log
+   * filesizes are being capped.
+   * @returns {string} - TODO: add return description.
+   * @private
+   */
+  _getFile() {
+    const ext = path.extname(this._basename);
+    const basename = path.basename(this._basename, ext);
+
+    // Caveat emptor (indexzero): rotationFormat() was broken by design When
+    // combined with max files because the set of files to unlink is never
+    // stored.
+    // TODO: refactor next line.
+    const target = !this.tailable && this._created
+      ? basename + (this.rotationFormat ? this.rotationFormat() : this._created) + ext
+      : basename + ext;
+
+    return this.zippedArchive
+      ? target + '.gz'
+      : target;
+  }
+
+  /**
+   * Increment the number of files created or checked by this instance.
+   * @param {mixed} ext - TODO: add param description.
+   * @param {mixed} basename - TODO: add param description.
+   * @param {mixed} callback - TODO: add param description.
+   * @returns {undefined}
+   * @private
+   */
+  _checkMaxFilesIncrementing(ext, basename, callback) {
+    // Check for maxFiles option and delete file.
+    if (!this.maxFiles || this._created < this.maxFiles) {
+      return callback();
+    }
+
+    const oldest = this._created - this.maxFiles;
+    // TODO: refactor next line.
+    const target = path.join(this.dirname, basename + (oldest !== 0 ? oldest : '') + ext + (this.zippedArchive ? '.gz' : ''));
+
+    fs.unlink(target, callback);
+  }
+
+  /**
+   * Roll files forward based on integer, up to maxFiles. e.g. if base if
+   * file.log and it becomes oversized, roll to file1.log, and allow file.log
+   * to be re-used. If file is oversized again, roll file1.log to file2.log,
+   * roll file.log to file1.log, and so on.
+   * @param {mixed} ext - TODO: add param description.
+   * @param {mixed} basename - TODO: add param description.
+   * @param {mixed} callback - TODO: add param description.
+   * @returns {undefined}
+   * @private
+   */
+  _checkMaxFilesTailable(ext, basename, callback) {
+    const tasks = [];
+    if (!this.maxFiles) {
+      return;
+    }
+
+    for (let x = this.maxFiles - 1; x > 0; x--) {
+      tasks.push(function (i) {
+        return cb => {
+          // TODO: refactor next line.
+          const tmppath = path.join(this.dirname, basename + (i - 1) + ext + (this.zippedArchive ? '.gz' : ''));
+
+          fs.exists(tmppath, exists => {
+            if (!exists) {
+              return cb(null);
+            }
+
+            // TODO: refactor next line.
+            fs.rename(tmppath, path.join(this.dirname, basename + i + ext + (this.zippedArchive ? '.gz' : '')), cb);
+          });
+        };
+      }.bind(this, x));
+    }
+
+    asyncSeries(tasks, () => {
+      fs.rename(
+        path.join(this.dirname, basename + ext),
+        path.join(this.dirname, basename + 1 + ext),
+        callback
+      );
+    });
+  }
 };

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -32,8 +32,8 @@ function noop() {}
  */
 module.exports = class File extends TransportStream {
   /**
-   * Constructor method for the File transport object responsible
-   * for persisting log messages and metadata to one or more files.
+   * Constructor function for the File transport object responsible for
+   * persisting log messages and metadata to one or more files.
    * @param {Object} options - Options for this instance.
    */
   constructor(options = {}) {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -165,7 +165,7 @@ module.exports = class File extends TransportStream {
     let results = [];
     let row = 0;
 
-    var stream = fs.createReadStream(file, {
+    const stream = fs.createReadStream(file, {
       encoding: 'utf8'
     });
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -233,12 +233,10 @@ module.exports = class File extends TransportStream {
       }
 
       if (options.fields) {
-        // TODO: refactor with reduce.
-        const obj = {};
-        options.fields.forEach(key => {
+        log = options.fields.reduce((obj, key) => {
           obj[key] = log[key];
-        });
-        log = obj;
+          return obj;
+        }, {});
       }
 
       if (options.order === 'desc') {

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -1,206 +1,196 @@
+/**
+ * http.js: Transport for outputting to a json-rpcserver.
+ *
+ * (C) 2010 Charlie Robbins
+ * MIT LICENCE
+ */
+
 'use strict';
 
-const util = require('util');
 const http = require('http');
 const https = require('https');
-const Stream = require('stream').Stream;
+const { Stream } = require('stream');
 const TransportStream = require('winston-transport');
 
-//
-// ### function Http (options)
-// #### @options {Object} Options for this instance.
-// Constructor function for the Http transport object responsible
-// for persisting log messages and metadata to a terminal or TTY.
-//
-var Http = module.exports = function (options) {
-  TransportStream.call(this, options);
-  options = options || {};
+/**
+ * Transport for outputting to a json-rpc server.
+ * @type {Stream}
+ * @extends {TransportStream}
+ */
+module.exports = class Http extends TransportStream {
+  /**
+   * Constructor function for the Http transport object responsible
+   * for persisting log messages and metadata to a terminal or TTY.
+   * @param {!Object} [options={}] - Options for this instance.
+   */
+  constructor(options = {}) {
+    super(options);
 
-  this.name = 'http';
-  this.ssl = !!options.ssl;
-  this.host = options.host || 'localhost';
-  this.port = options.port;
-  this.auth = options.auth;
-  this.path = options.path || '';
-  this.agent = options.agent;
-  this.headers = options.headers || {};
-  this.headers['content-type'] = 'application/json';
+    this.name = 'http';
+    this.ssl = !!options.ssl;
+    this.host = options.host || 'localhost';
+    this.port = options.port;
+    this.auth = options.auth;
+    this.path = options.path || '';
+    this.agent = options.agent;
+    this.headers = options.headers || {};
+    this.headers['content-type'] = 'application/json';
 
-  if (!this.port) {
-    this.port = this.ssl ? 443 : 80;
-  }
-};
-
-util.inherits(Http, TransportStream);
-
-//
-// Expose the name of this Transport on the prototype
-//
-Http.prototype.name = 'http';
-
-//
-// ### function log (meta)
-// #### @meta {Object} **Optional** Additional metadata to attach
-// Core logging method exposed to Winston.
-//
-Http.prototype.log = function (info, callback) {
-  var self = this;
-
-  this._request(info, function (err, res) {
-    if (res && res.statusCode !== 200) {
-      err = new Error('Invalid HTTP Status Code: ' + res.statusCode);
+    if (!this.port) {
+      this.port = this.ssl ? 443 : 80;
     }
-
-    if (err) {
-      self.emit('warn', err);
-    } else {
-      self.emit('logged', info);
-    }
-  });
-
-  //
-  // Remark: (jcrugzz) Fire and forget here so requests dont cause buffering
-  // and block more requests from happening?
-  //
-  if (callback) {
-    setImmediate(callback);
-  }
-};
-
-//
-// ### function query (options, callback)
-// #### @options {Object} Loggly-like query options for this instance.
-// #### @callback {function} Continuation to respond to when complete.
-// Query the transport. Options object is optional.
-//
-Http.prototype.query = function (options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
   }
 
-  options = this.normalizeQuery(options);
-  options = {
-    method: 'query',
-    params: options
-  };
-
-  if (options.params.path) {
-    options.path = options.params.path;
-    delete options.params.path;
-  }
-
-  if (options.params.auth) {
-    options.auth = options.params.auth;
-    delete options.params.auth;
-  }
-
-  this._request(options, function (err, res, body) {
-    if (res && res.statusCode !== 200) {
-      err = new Error('HTTP Status Code: ' + res.statusCode);
-    }
-
-    if (err) return callback(err);
-
-    if (typeof body === 'string') {
-      try {
-        body = JSON.parse(body);
-      } catch (e) {
-        return callback(e);
+  /**
+   * Core logging method exposed to Winston.
+   * @param {Object} info - TODO: add param description.
+   * @param {Function} callback - TODO: add param description.
+   * @returns {undefined}
+   */
+  log(info, callback) {
+    this._request(info, (err, res) => {
+      if (res && res.statusCode !== 200) {
+        err = new Error(`Invalid HTTP Status Code: ${res.statusCode}`);
       }
-    }
 
-    callback(null, body);
-  });
-};
-
-//
-// ### function stream (options)
-// #### @options {Object} Stream options for this instance.
-// Returns a log stream for this transport. Options object is optional.
-//
-Http.prototype.stream = function (options) {
-  options = options || {};
-
-  const stream = new Stream();
-
-  options = {
-    method: 'stream',
-    params: options
-  };
-
-  if (options.params.path) {
-    options.path = options.params.path;
-    delete options.params.path;
-  }
-
-  if (options.params.auth) {
-    options.auth = options.params.auth;
-    delete options.params.auth;
-  }
-
-  let buff = '';
-  const req = this._request(options);
-
-  stream.destroy = function () {
-    req.destroy();
-  };
-
-  req.on('data', function (data) {
-    data = (buff + data).split(/\n+/);
-    const l = data.length - 1;
-    let i = 0;
-
-    for (; i < l; i++) {
-      try {
-        stream.emit('log', JSON.parse(data[i]));
-      } catch (e) {
-        stream.emit('error', e);
+      if (err) {
+        this.emit('warn', err);
+      } else {
+        this.emit('logged', info);
       }
+    });
+
+    // Remark: (jcrugzz) Fire and forget here so requests dont cause buffering
+    // and block more requests from happening?
+    if (callback) {
+      setImmediate(callback);
+    }
+  }
+
+  /**
+   * Query the transport. Options object is optional.
+   * @param {Object} options -  Loggly-like query options for this instance.
+   * @param {function} callback - Continuation to respond to when complete.
+   * @returns {undefined}
+   */
+  query(options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
     }
 
-    buff = data[l];
-  });
+    options = {
+      method: 'query',
+      params: this.normalizeQuery(options)
+    };
 
-  req.on('error', function (err) {
-    stream.emit('error', err);
-  });
+    if (options.params.path) {
+      options.path = options.params.path;
+      delete options.params.path;
+    }
 
-  return stream;
-};
+    if (options.params.auth) {
+      options.auth = options.params.auth;
+      delete options.params.auth;
+    }
 
-//
-// ### function _request (options, callback)
-// #### @callback {function} Continuation to respond to when complete.
-// Make a request to a winstond server or any http server which can
-// handle json-rpc.
-//
-Http.prototype._request = function (options, callback) {
-  options = options || {};
+    this._request(options, (err, res, body) => {
+      if (res && res.statusCode !== 200) {
+        err = new Error(`Invalid HTTP Status Code: ${res.statusCode}`);
+      }
 
-  const auth = options.auth || this.auth;
-  const path = options.path || this.path || '';
+      if (err) {
+        return callback(err);
+      }
 
-  delete options.auth;
-  delete options.path;
+      if (typeof body === 'string') {
+        try {
+          body = JSON.parse(body);
+        } catch (e) {
+          return callback(e);
+        }
+      }
 
-  // Prepare options for outgoing HTTP request
-  const req = (this.ssl ? https : http).request({
-    method: 'POST',
-    host: this.host,
-    port: this.port,
-    path: '/' + path.replace(/^\//, ''),
-    headers: this.headers,
-    auth: auth ? (auth.username + ':' + auth.password) : '',
-    agent: this.agent
-  });
+      callback(null, body);
+    });
+  }
 
-  req.on('error', callback);
-  req.on('response', function (res) {
-    res.on('end', function () {
-      callback(null, res);
-    }).resume();
-  });
+  /**
+   * Returns a log stream for this transport. Options object is optional.
+   * @param {Object} options - Stream options for this instance.
+   * @returns {Stream} - TODO: add return description
+   */
+  stream(options = {}) {
+    const stream = new Stream();
+    options = {
+      method: 'stream',
+      params: options
+    };
 
-  req.end(Buffer.from(JSON.stringify(options), 'utf8'));
+    if (options.params.path) {
+      options.path = options.params.path;
+      delete options.params.path;
+    }
+
+    if (options.params.auth) {
+      options.auth = options.params.auth;
+      delete options.params.auth;
+    }
+
+    let buff = '';
+    const req = this._request(options);
+
+    stream.destroy = () => req.destroy();
+    req.on('data', data => {
+      data = (buff + data).split(/\n+/);
+      const l = data.length - 1;
+
+      let i = 0;
+      for (; i < l; i++) {
+        try {
+          stream.emit('log', JSON.parse(data[i]));
+        } catch (e) {
+          stream.emit('error', e);
+        }
+      }
+
+      buff = data[l];
+    });
+    req.on('error', err => stream.emit('error', err));
+
+    return stream;
+  }
+
+  /**
+   * Make a request to a winstond server or any http server which can
+   * handle json-rpc.
+   * @param {function} options - Options to sent the request.
+   * @param {function} callback - Continuation to respond to when complete.
+   */
+  _request(options, callback) {
+    options = options || {};
+
+    const auth = options.auth || this.auth;
+    const path = options.path || this.path || '';
+
+    delete options.auth;
+    delete options.path;
+
+    // Prepare options for outgoing HTTP request
+    const req = (this.ssl ? https : http).request({
+      method: 'POST',
+      host: this.host,
+      port: this.port,
+      path: '/' + path.replace(/^\//, ''),
+      headers: this.headers,
+      auth: auth ? (auth.username + ':' + auth.password) : '',
+      agent: this.agent
+    });
+
+    req.on('error', callback);
+    req.on('response', res => (
+      res.on('end', () => callback(null, res)).resume()
+    ));
+    req.end(Buffer.from(JSON.stringify(options), 'utf8'));
+  }
 };

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -44,7 +44,7 @@ module.exports = class Http extends TransportStream {
   /**
    * Core logging method exposed to Winston.
    * @param {Object} info - TODO: add param description.
-   * @param {Function} callback - TODO: add param description.
+   * @param {function} callback - TODO: add param description.
    * @returns {undefined}
    */
   log(info, callback) {

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -19,8 +19,8 @@ const TransportStream = require('winston-transport');
  */
 module.exports = class Http extends TransportStream {
   /**
-   * Constructor function for the Http transport object responsible
-   * for persisting log messages and metadata to a terminal or TTY.
+   * Constructor function for the Http transport object responsible for
+   * persisting log messages and metadata to a terminal or TTY.
    * @param {!Object} [options={}] - Options for this instance.
    */
   constructor(options = {}) {

--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -181,9 +181,9 @@ module.exports = class Http extends TransportStream {
       method: 'POST',
       host: this.host,
       port: this.port,
-      path: '/' + path.replace(/^\//, ''),
+      path: `/${path.replace(/^\//, '')}`,
       headers: this.headers,
-      auth: auth ? (auth.username + ':' + auth.password) : '',
+      auth: auth ? (`${auth.username}:${auth.password}`) : '',
       agent: this.agent
     });
 

--- a/lib/winston/transports/index.js
+++ b/lib/winston/transports/index.js
@@ -1,39 +1,56 @@
-/*
- * transports.js: Set of all transports Winston knows about
+/**
+ * transports.js: Set of all transports Winston knows about.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
+'use strict';
+
+/**
+ * TODO: add property description.
+ * @type {Console}
+ */
 Object.defineProperty(exports, 'Console', {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     return require('./console');
   }
 });
 
+/**
+ * TODO: add property description.
+ * @type {File}
+ */
 Object.defineProperty(exports, 'File', {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     return require('./file');
   }
 });
 
+/**
+ * TODO: add property description.
+ * @type {Http}
+ */
 Object.defineProperty(exports, 'Http', {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     return require('./http');
   }
 });
 
+/**
+ * TODO: add property description.
+ * @type {Stream}
+ */
 Object.defineProperty(exports, 'Stream', {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     return require('./stream');
   }
 });

--- a/lib/winston/transports/stream.js
+++ b/lib/winston/transports/stream.js
@@ -1,63 +1,61 @@
-/*
- * stream.js: Transport for outputting to any arbitrary stream
+/**
+ * stream.js: Transport for outputting to any arbitrary stream.
  *
  * (C) 2010 Charlie Robbins
  * MIT LICENCE
- *
  */
 
-const util = require('util');
+'use strict';
+
 const isStream = require('is-stream');
 const { MESSAGE } = require('triple-beam');
 const TransportStream = require('winston-transport');
 
-//
-// ### function Console (options)
-// #### @options {Object} Options for this instance.
-// Constructor function for the Console transport object responsible
-// for persisting log messages and metadata to a terminal or TTY.
-//
-var Stream = module.exports = function (options) {
-  TransportStream.call(this, options);
-  options = options || {};
+/**
+ * Transport for outputting to any arbitrary stream.
+ * @type {Stream}
+ * @extends {TransportStream}
+ */
+module.exports = class Stream extends TransportStream {
+  /**
+   * Constructor function for the Console transport object responsible for
+   * persisting log messages and metadata to a terminal or TTY.
+   * @param {!Object} [options={}] - Options for this instance.
+   */
+  constructor(options = {}) {
+    super(options);
 
-  if (!options.stream || !isStream(options.stream)) {
-    throw new Error('options.stream is required.');
+    if (!options.stream || !isStream(options.stream)) {
+      throw new Error('options.stream is required.');
+    }
+
+    // We need to listen for drain events when write() returns false. This can
+    // make node mad at times.
+    this._stream = options.stream;
+    this._stream.setMaxListeners(Infinity);
+    this.isObjectMode = options.stream._writableState.objectMode;
   }
 
-  //
-  // We need to listen for drain events when
-  // write() returns false. This can make node
-  // mad at times.
-  //
-  this._stream = options.stream;
-  this._stream.setMaxListeners(Infinity);
-  this.isObjectMode = options.stream._writableState.objectMode;
-};
+  /**
+   * Core logging method exposed to Winston.
+   * @param {Object} info - TODO: add param description.
+   * @param {Function} callback - TODO: add param description.
+   * @returns {undefined}
+   */
+  log(info, callback) {
+    setImmediate(() => this.emit('logged', info));
+    if (this.isObjectMode) {
+      this._stream.write(info);
+      if (callback) {
+        callback(); // eslint-disable-line callback-return
+      }
+      return;
+    }
 
-//
-// Inherit from `winston.Transport`.
-//
-util.inherits(Stream, TransportStream);
-
-//
-// ### function log (meta)
-// #### @meta {Object} Additional metadata to attach
-// Core logging method exposed to Winston.
-//
-Stream.prototype.log = function (info, callback) {
-  var self = this;
-  setImmediate(function () {
-    self.emit('logged', info);
-  });
-
-  if (this.isObjectMode) {
-    this._stream.write(info);
-    if (callback) { callback(); } // eslint-disable-line
+    this._stream.write(info[MESSAGE]);
+    if (callback) {
+      callback(); // eslint-disable-line callback-return
+    }
     return;
   }
-
-  this._stream.write(info[MESSAGE]);
-  if (callback) { callback(); } // eslint-disable-line
-  return;
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "report": "nyc report --reporter=lcov"
   },
   "engines": {
-    "node": ">= 4.2.2"
+    "node": ">= 6.4.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Some of the things I did to the code in the `./lib` folder:
 - Source code uses es6 `classes` in stead of `prototypes`.
 - Most of the `functions` have been replaced with `arrow-functions` (not all of them are, or can be converted).
 - Methods have tags to generate API documentation (not everything is documented, there are still a lot of `TODO`'s.
 - Prettified the code for the most part; keep lines under 80 characters, make `if`-statements more readable, etc.
 - Replaced `var` for `const` and `let` (think I got them all, not sure).

 - [x] Use template strings instead of concatenating strings.
 - [x] `Container.js` can make use of the `Map` object.
 - [x] Use destruturing and property shorthand's.
 - [x] Replace usage of `arguments` for rest properties 
 - [x] Check if `var` is never used.

P.S.: I've joined the gitter chat if you need me.
