### PR TITLE
[fix] Fix streams not draining properly

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -142,6 +142,7 @@ module.exports = class File extends TransportStream {
       callback(); // eslint-disable-line callback-return
     } else {
       this._next = callback;
+      this._dest.emit('drain');
     }
 
     return written;


### PR DESCRIPTION
A possible fix for #1144. It seems like the `_stream` is not draining properly, but by draining the `_dest` stream we also drain the `_stream` because they are piped together? I'm not sure about this, because it did fix the script provided by @juanda99. This doesn't fix the script of  @kramer65, possible because the `while (true) { }` loop is blocking the NodeJS event-loop.