### PR TITLE
Approach to fixing #1174

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ before_install:
 script:
   - npm test
 
+matrix:
+  allow_failures:
+  - node_js: "10"
+
 notifications:
   email:
     - travis@nodejitsu.com

--- a/examples/file-maxsize.js
+++ b/examples/file-maxsize.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const { MESSAGE } = require('triple-beam');
+const winston = require('../');
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.printf(info => `${info.message}`),
+  transports: [
+    new winston.transports.File({
+      filename: path.join(__dirname, 'error.log'),
+      level: 'info',
+      maxsize: 500
+    })
+  ]
+});
+
+// Write 750 characters
+logger.info(`test=${'a'.repeat(245)}`);
+logger.info(`test=${'b'.repeat(245)}`);
+logger.info(`test=${'c'.repeat(245)}`);
+
+setTimeout(() => {
+  logger.info(`test=${'d'.repeat(245)}`);
+  logger.info(`test=${'e'.repeat(245)}`);
+  logger.info(`test=${'f'.repeat(245)}`);
+}, 2000);

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -308,14 +308,10 @@ module.exports = class File extends TransportStream {
    * @returns {undefined}
    */
   open() {
-    // If we do not have a filename then we were passed a stream and dont need
-    // to keep track of size.
-    if (!this.filename) {
-      return;
-    }
-    if (this.opening) {
-      return;
-    }
+    // If we do not have a filename then we were passed a stream and
+    // don't need to keep track of size.
+    if (!this.filename) return;
+    if (this.opening) return;
 
     this.opening = true;
 
@@ -355,8 +351,8 @@ module.exports = class File extends TransportStream {
       }
 
       if (!stat || this._needsNewFile(stat.size)) {
-        // If `stats.size` is greater than the `maxsize` for this instance then
-        // try again.
+        // If `stats.size` is greater than the `maxsize` for this
+        // instance then try again.
         return this._incFile(() => this.stat(callback));
       }
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -88,6 +88,7 @@ module.exports = class File extends TransportStream {
     // Internal state variables representing the number of files this instance
     // has created and the current size (in bytes) of the current logfile.
     this._size = 0;
+    this._pendingSize = 0;
     this._created = 0;
     this._drains = 0;
     this._next = noop;
@@ -113,14 +114,24 @@ module.exports = class File extends TransportStream {
 
     // Grab the raw string and append the expected EOL.
     const output = `${info[MESSAGE]}${this.eol}`;
+    const bytes = Buffer.byteLength(output);
 
-    // This gets called too early and does not depict when data has been flushed
-    // to disk like I want it to.
+    // After we have written to the PassThrough check to see if we need
+    // to rotate to the next file.
+    //
+    // Remark: This gets called too early and does not depict when data
+    // has been actually flushed to disk.
     function logged() {
-      this._size += Buffer.byteLength(output);
+      this._size += bytes;
+      this._pendingSize -= bytes;
 
       debug('logged %s %s', this._size, output);
       this.emit('logged', info);
+
+      // Do not attempt to rotate files while opening
+      if (this.opening) {
+        return;
+      }
 
       // Check to see if we need to end the stream and create a new one.
       if (!this._needsNewFile()) {
@@ -128,15 +139,24 @@ module.exports = class File extends TransportStream {
       }
 
       // End the current stream, ensure it flushes and create a new one.
-      // TODO: This could probably be optimized to not run a stat call but its
-      // the safest way since we are supporting `maxFiles`. Remark: We could
-      // call `open` here but that would incur an extra unnecessary stat call.
-      this._endStream(() => this._nextFile());
+      // This could potentially be optimized to not run a stat call but its
+      // the safest way since we are supporting `maxFiles`.
+      this._endStream(() => this._rotateFile());
     }
 
     const written = this._stream.write(output, logged.bind(this));
     if (written === false) {
       ++this._drains;
+    }
+
+    // Keep track of the pending bytes being written while files are opening
+    // in order to properly rotate the PassThrough this._stream when the file
+    // eventually does open.
+    this._pendingSize += bytes;
+    if (this.opening
+      && !this.rotatedWhileOpening
+      && this._needsNewFile(this._size + this._pendingSize)) {
+      this.rotatedWhileOpening = true;
     }
 
     debug('written', written, this._drains);
@@ -323,7 +343,7 @@ module.exports = class File extends TransportStream {
 
       debug('stat done: %s { size: %s }', this.filename, size);
       this._size = size;
-      this._createStream();
+      this._dest = this._createStream(this._stream);
       this.opening = false;
     });
   }
@@ -444,16 +464,15 @@ module.exports = class File extends TransportStream {
    * TODO: add method description.
    * @returns {mixed} - TODO: add return description.
    */
-  _nextFile() {
-    return this._incFile(() => {
-      this.open();
-    });
+  _rotateFile() {
+    this._incFile(() => this.open());
   }
 
   /**
    * Unpipe from the stream that has been marked as full and end it so it
    * flushes to disk.
-   * @param {function} callback - TODO: add param description.
+   *
+   * @param {function} callback - Callback for when the current file has closed.
    * @private
    */
   _endStream(callback) {
@@ -465,29 +484,45 @@ module.exports = class File extends TransportStream {
   }
 
   /**
-   * TODO: add method description.
-   * @returns {undefined}
+   * Returns the WritableStream for the active file on this instance. If we
+   * should gzip the file then a zlib stream is returned.
+   *
+   * @param {ReadableStream} source – PassThrough to pipe to the file when open.
+   * @returns {WritableStream} Stream that writes to disk for the active file.
    */
-  _createStream() {
+  _createStream(source) {
     const fullpath = path.join(this.dirname, this.filename);
 
     debug('create stream start', fullpath, this.options);
-    this._dest = fs.createWriteStream(fullpath, this.options)
+    const dest = fs.createWriteStream(fullpath, this.options)
       // TODO: What should we do with errors here?
       .on('error', err => debug(err))
-      .on('close', () => debug('close', this._dest.path, this._dest.bytesWritten))
+      .on('close', () => debug('close', dest.path, dest.bytesWritten))
       .on('open', () => {
         debug('file open ok', fullpath);
         this.emit('open', fullpath);
-        this._stream.pipe(this._dest);
+        source.pipe(dest);
+
+        // If rotation occured during the open operation then we immediately
+        // start writing to a new PassThrough, begin opening the next file
+        // and cleanup the previous source and dest once the source has drained.
+        if (this.rotatedWhileOpening) {
+          this._stream = new PassThrough();
+          this._rotateFile();
+          this.rotatedWhileOpening = false;
+          this._cleanupStream(dest);
+          source.end();
+        }
       });
 
     debug('create stream ok', fullpath);
     if (this.zippedArchive) {
       const gzip = zlib.createGzip();
-      gzip.pipe(this._dest);
-      this._dest = gzip;
+      gzip.pipe(dest);
+      return gzip;
     }
+
+    return dest;
   }
 
   /**
@@ -496,6 +531,7 @@ module.exports = class File extends TransportStream {
    * @returns {undefined}
    */
   _incFile(callback) {
+    debug('_incFile', this.filename);
     const ext = path.extname(this._basename);
     const basename = path.basename(this._basename, ext);
 
@@ -543,7 +579,7 @@ module.exports = class File extends TransportStream {
   _checkMaxFilesIncrementing(ext, basename, callback) {
     // Check for maxFiles option and delete file.
     if (!this.maxFiles || this._created < this.maxFiles) {
-      return callback();
+      return setImmediate(callback);
     }
 
     const oldest = this._created - this.maxFiles;

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -462,7 +462,6 @@ module.exports = class File extends TransportStream {
 
   /**
    * TODO: add method description.
-   * @returns {mixed} - TODO: add return description.
    */
   _rotateFile() {
     this._incFile(() => this.open());

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -129,7 +129,7 @@ module.exports = class File extends TransportStream {
       this.emit('logged', info);
 
       // Do not attempt to rotate files while opening
-      if (this.opening) {
+      if (this._opening) {
         return;
       }
 
@@ -153,7 +153,7 @@ module.exports = class File extends TransportStream {
     // in order to properly rotate the PassThrough this._stream when the file
     // eventually does open.
     this._pendingSize += bytes;
-    if (this.opening
+    if (this._opening
       && !this.rotatedWhileOpening
       && this._needsNewFile(this._size + this._pendingSize)) {
       this.rotatedWhileOpening = true;
@@ -331,9 +331,9 @@ module.exports = class File extends TransportStream {
     // If we do not have a filename then we were passed a stream and
     // don't need to keep track of size.
     if (!this.filename) return;
-    if (this.opening) return;
+    if (this._opening) return;
 
-    this.opening = true;
+    this._opening = true;
 
     // Stat the target file to get the size and create the stream.
     this.stat((err, size) => {
@@ -344,7 +344,7 @@ module.exports = class File extends TransportStream {
       debug('stat done: %s { size: %s }', this.filename, size);
       this._size = size;
       this._dest = this._createStream(this._stream);
-      this.opening = false;
+      this._opening = false;
     });
   }
 


### PR DESCRIPTION
In this approach we track a new bit of state within the File transport: `rotatedWhileOpening` which indicates that enough data was written while no files were open to cause rotation. 

When this flag is set we trigger the rotation in `_createStream`. Not 100% sure this is the right approach, but it does solve the problem at hand. Going to sleep on it and decide the right path forward.