### PR TITLE
Add 3.0 notes for logger.add. Add ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,63 @@
+<!--
+  ✋📓❓ **NOTE:** for support questions, please use StackOverflow. This
+  repository's issues are reserved for feature requests and bug reports.
+-->
+
+### Please tell us about your environment:
+  
+- _`winston` version?_
+   - [ ] `winston@2`
+   - [ ] `winston@3` 
+- _`node -v` outputs:_
+- _Operating System?_ (Windows, macOS, or Linux)
+- _Language?_ (all | TypeScript X.X | ES6/7 | ES5 | Dart)
+
+### What is the problem? 
+<!--
+  Please describe how to reproduce the problem including a minimum working
+  code example.
+-->
+
+### What do you expect to happen instead?
+<!--
+  Please explain how you would expect your code to function. 
+-->
+
+### Other information
+<!--
+  e.g. stacktraces, related Github issues, suggestions on how to fix, 
+  links for us to have more context (e.g. stackoverflow, gitter, etc).
+  If nothing please remove this section.
+-->
+
+<!--
+  Thank you for contributing to winston! Please review this checklist
+  before submitting your issue.
+
+  - Please ensure that your new issue conforms to our contribution guidelines:
+  https://github.com/winstonjs/winston/blob/master/CONTRIBUTING.md
+  
+  - Participation in this open source project is subject to the our CoC
+  https://github.com/winstonjs/winston/blob/master/CODE_OF_CONDUCT.md
+
+  - For feature requests, delete the above and uncomment the section following
+  this one. But first, review the existing feature requests and make sure
+  there isn't one that already describes the feature you'd like to see added:
+  https://github.com/winstonjs/winston/issues?q=is%3Aopen+is%3Aissue+label%3A%22feature+request%22
+-->
+
+<!--
+### What's the feature?
+
+If this is a NEW feature request please include a description of the feature,
+a short code sample of the API, and the motivation / use case for changing
+the behavior?
+
+### What problem is the feature intended to solve?
+
+### Is the absence of this feature blocking you or your team? If so, how?
+
+### Is this feature similar to an existing feature in another tool?
+
+### Is this a feature you're prepared to implement, with support from us?
+-->

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -32,12 +32,28 @@
 - `winston.Container.prototype.add` no longer does crazy options parsing. Implementation inspired by [segmentio/winston-logger](https://github.com/segmentio/winston-logger/blob/master/lib/index.js#L20-L43)
 
 ### `winston.Logger`
-- `winston.Logger` will no longer respond with an error when logging with no transports
-- `winston.Logger` will no longer respond with an error if the same transports are added twice.
+
+- `winston.Logger.add` no longer accepts prototypes / classes. Pass **an instance of our transport instead.**
+
+**Don't do this**
+``` js
+// DON'T DO THIS. It will no longer work
+logger.add(winston.transports.Console);
+
+// Do this instead.
+logger.add(new winston.transports.Console());
+```
+
+- `winston.Logger` will no longer respond with an error when logging with no
+  transports
+- `winston.Logger` will no longer respond with an error if the same transports
+  are added twice.
 - `Logger.prototype.stream`
-  - `options.transport` is removed. Use the transport instance on the logger directly.
+  - `options.transport` is removed. Use the transport instance on the logger
+    directly.
 - `Logger.prototype.query`
-  - `options.transport` is removed. Use the transport instance on the logger directly.
+  - `options.transport` is removed. Use the transport instance on the logger 
+    directly.
 
 ### Exceptions & exception handling
 - `winston.exception` has been removed. Use:


### PR DESCRIPTION
Worked on these a bit with @DABH this morning. Hopefully the `ISSUE_TEMPLATE.md` helps reduce the number of inbound duplicate issues and helps discern between `winston@3` and `winston@2` problems. 