### PR TITLE
build: add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "winston-compat": "^0.1.1"
   },
   "main": "./lib/winston",
+  "types": "./index.d.ts",
   "scripts": {
     "lint": "populist lib/*.js lib/winston/*.js lib/winston/**/*.js",
     "pretest": "npm run lint",


### PR DESCRIPTION
The `types` entry need in the `package.json` to publish the root index.d.ts file and this entry will use by the typescript compiler to find typings