### PR TITLE
[Winston 2.x] Decycle circular `Error` instances

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -80,12 +80,13 @@ exports.clone = function (obj) {
   if (obj instanceof Error) {
     // With potential custom Error objects, this might not be exactly correct,
     // but probably close-enough for purposes of this lib.
+
     var copy = { message: obj.message };
     Object.getOwnPropertyNames(obj).forEach(function (key) {
       copy[key] = obj[key];
     });
 
-    return copy;
+    return cycle.decycle(copy);
   }
   else if (!(obj instanceof Object)) {
     return obj;
@@ -145,7 +146,7 @@ exports.log = function (options) {
         : exports.timestamp,
       timestamp   = options.timestamp ? timestampFn() : null,
       showLevel   = options.showLevel === undefined ? true : options.showLevel,
-      meta        = options.meta !== null && options.meta !== undefined && !(options.meta instanceof Error)
+      meta        = options.meta !== null && options.meta !== undefined
         ? exports.clone(options.meta)
         : options.meta || null,
       output;
@@ -244,10 +245,6 @@ exports.log = function (options) {
     : options.message;
 
   if (meta !== null && meta !== undefined) {
-    if (meta && meta instanceof Error && meta.stack) {
-      meta = meta.stack;
-    }
-
     if (typeof meta !== 'object') {
       output += ' ' + meta;
     }

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -80,7 +80,6 @@ exports.clone = function (obj) {
   if (obj instanceof Error) {
     // With potential custom Error objects, this might not be exactly correct,
     // but probably close-enough for purposes of this lib.
-
     var copy = { message: obj.message };
     Object.getOwnPropertyNames(obj).forEach(function (key) {
       copy[key] = obj[key];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston",
   "description": "A multi-transport async logging library for Node.js",
-  "version": "2.5.0",
+  "version": "2.4.2",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "maintainers": [
     "Jarrett Cruger <jcrugzz@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston",
   "description": "A multi-transport async logging library for Node.js",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "maintainers": [
     "Jarrett Cruger <jcrugzz@gmail.com>",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -194,6 +194,23 @@ helpers.testLevels = function (levels, transport, assertMsg, assertFn) {
   circmetadatatest[assertMsg] = assertFn;
   tests['when passed circular metadata'] = circmetadatatest;
 
+  var circerror = new Error("message!");
+  var foo = {};
+  var circerrordatatest;
+
+  foo.bar = foo;
+  circerror.foo = foo;
+  circerror.stack = 'Some stacktrace';
+
+  circerrordatatest = {
+    topic: function () {
+      transport.log('info', 'test message', circerror, this.callback.bind(this, null));
+    }
+  };
+
+  circerrordatatest[assertMsg] = assertFn;
+  tests['when passed circular error as metadata'] = circerrordatatest;
+
   return tests;
 };
 


### PR DESCRIPTION
Hey there!

I understand that work on Winston 2 has ceased, so we can continue to use our own fork if this isn't worth pursuing for you. That said, it would be better for us to depend upon an official version of 2.x if possible.

We use Winston 2 on a legacy project at News UK and were encountering `TypeError: Converting circular structure to JSON` when logging cycling `Error` instances. It turns out that, in HEAD of 2.x:

* `exports.clone` in `lib/winston/common.js` [converts `Error`s to plain `Object`s, but doesn't decycle them](https://github.com/winstonjs/winston/blob/2.x/lib/winston/common.js#L80)
* `exports.clone` won't be called at the beginning of `exports.log` if `options.meta instanceof Error`

This PR fixes both of those behaviours. I have also added a test to the helpers to assert that `Error`s are decycled correctly across transports, and the existing ones still pass. Nonetheless, please let me know if this behaviour impacts legacy functionality or is nonetheless undesirable for any other reason.

Thanks!