### PR TITLE
[feat] Add eol option to Stream transport

### DIFF
--- a/examples/simple-stream.js
+++ b/examples/simple-stream.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const winston = require('../lib/winston');
+
+const filePath = path.join(__dirname, 'winston.log');
+const stream = fs.createWriteStream(filePath);
+
+const logger = winston.createLogger({
+  transports: [
+    new winston.transports.Stream({ stream })
+  ]
+});
+
+setTimeout(() => {
+  logger.log({ level: 'info', message: 'foo' });
+  logger.log({ level: 'info', message: 'bar' });
+}, 1000);
+
+setTimeout(() => {
+  try {
+    fs.unlinkSync(filePath); // eslint-disable-line no-sync
+  } catch (ex) {} // eslint-disable-line no-empty
+});

--- a/examples/simple-stream.js
+++ b/examples/simple-stream.js
@@ -22,4 +22,4 @@ setTimeout(() => {
   try {
     fs.unlinkSync(filePath); // eslint-disable-line no-sync
   } catch (ex) {} // eslint-disable-line no-empty
-});
+}, 2000);

--- a/lib/winston/transports/index.d.ts
+++ b/lib/winston/transports/index.d.ts
@@ -74,9 +74,12 @@ declare namespace winston {
 
   interface StreamTransportOptions extends Transport.TransportStreamOptions {
     stream: NodeJS.WritableStream;
+    eol?: string;
   }
 
   interface StreamTransportInstance extends Transport {
+    eol: string;
+
     new(options?: StreamTransportOptions): StreamTransportInstance;
   }
 

--- a/lib/winston/transports/stream.js
+++ b/lib/winston/transports/stream.js
@@ -9,6 +9,7 @@
 
 const isStream = require('is-stream');
 const { MESSAGE } = require('triple-beam');
+const os = require('os');
 const TransportStream = require('winston-transport');
 
 /**
@@ -34,6 +35,7 @@ module.exports = class Stream extends TransportStream {
     this._stream = options.stream;
     this._stream.setMaxListeners(Infinity);
     this.isObjectMode = options.stream._writableState.objectMode;
+    this.eol = options.eol || os.EOL;
   }
 
   /**
@@ -52,7 +54,7 @@ module.exports = class Stream extends TransportStream {
       return;
     }
 
-    this._stream.write(info[MESSAGE]);
+    this._stream.write(`${info[MESSAGE]}${this.eol}`);
     if (callback) {
       callback(); // eslint-disable-line callback-return
     }

--- a/test/transports/stream.test.js
+++ b/test/transports/stream.test.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const writeable = require('../helpers').writeable;
 const { MESSAGE } = require('triple-beam');
+const os = require('os');
 const winston = require('../../');
 const split = require('split2');
 const assume = require('assume');
@@ -31,7 +32,7 @@ describe('Stream({ stream })', function () {
     };
 
     const stream = writeable(function (raw) {
-      assume(raw.toString()).equals(expected[MESSAGE]);
+      assume(raw.toString()).equals(`${expected[MESSAGE]}${os.EOL}`);
       done();
     }, false);
 


### PR DESCRIPTION
Adds `options.eol` to the `Stream` transport the same way it is implemented in `Console` and `File` transports. Also added an example to show this fixes #1304.