### PR TITLE
[fix] File transport under stress hangs logger

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -495,6 +495,7 @@ module.exports = class File extends TransportStream {
     const dest = fs.createWriteStream(fullpath, this.options)
       // TODO: What should we do with errors here?
       .on('error', err => debug(err))
+      .on('drain', this._onDrain)
       .on('close', () => debug('close', dest.path, dest.bytesWritten))
       .on('open', () => {
         debug('file open ok', fullpath);

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -415,7 +415,8 @@ module.exports = class File extends TransportStream {
    * @returns {undefined}
    */
   _onDrain() {
-    if (--this._drains) {
+    if (this._drains > 0) {
+      --this._drains
       return;
     }
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -55,7 +55,6 @@ module.exports = class File extends TransportStream {
     this._stream = new PassThrough();
 
     // Bind this context for listener methods.
-    this._onDrain = this._onDrain.bind(this);
     this._onError = this._onError.bind(this);
 
     if (options.filename || options.dirname) {
@@ -89,7 +88,7 @@ module.exports = class File extends TransportStream {
     this._size = 0;
     this._pendingSize = 0;
     this._created = 0;
-    this._drains = 0;
+    this._drain = false;
     this._next = noop;
     this._opening = false;
 
@@ -143,9 +142,22 @@ module.exports = class File extends TransportStream {
       this._endStream(() => this._rotateFile());
     }
 
+    if (this._drain) {
+      this._stream.once('drain', () => {
+        this._drain = false;
+        this.log(info, callback);
+      });
+      return;
+    }
+
     const written = this._stream.write(output, logged.bind(this));
     if (written === false) {
-      ++this._drains;
+      this._drain = true;
+      this._stream.once('drain', () => {
+        this._drain = false;
+        callback();
+      });
+      return;
     }
 
     // Keep track of the pending bytes being written while files are opening
@@ -158,11 +170,9 @@ module.exports = class File extends TransportStream {
       this.rotatedWhileOpening = true;
     }
 
-    debug('written', written, this._drains);
-    if (!this._drains) {
+    debug('written', written, this._drain);
+    if (written) {
       callback(); // eslint-disable-line callback-return
-    } else {
-      this._next = callback;
     }
 
     return written;
@@ -412,22 +422,6 @@ module.exports = class File extends TransportStream {
 
   /**
    * TODO: add method description.
-   * @returns {undefined}
-   */
-  _onDrain() {
-    if (this._drains > 0) {
-      --this._drains
-      return;
-    }
-
-    const next = this._next;
-    this._next = noop;
-
-    next();
-  }
-
-  /**
-   * TODO: add method description.
    * @param {Error} err - TODO: add param description.
    * @returns {undefined}
    */
@@ -442,7 +436,6 @@ module.exports = class File extends TransportStream {
    */
   _setupStream(stream) {
     stream.on('error', this._onError);
-    stream.on('drain', this._onDrain);
 
     return stream;
   }
@@ -454,7 +447,6 @@ module.exports = class File extends TransportStream {
    */
   _cleanupStream(stream) {
     stream.removeListener('error', this._onError);
-    stream.removeListener('drain', this._onDrain);
 
     return stream;
   }
@@ -495,7 +487,6 @@ module.exports = class File extends TransportStream {
     const dest = fs.createWriteStream(fullpath, this.options)
       // TODO: What should we do with errors here?
       .on('error', err => debug(err))
-      .on('drain', this._onDrain)
       .on('close', () => debug('close', dest.path, dest.bytesWritten))
       .on('open', () => {
         debug('file open ok', fullpath);

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -163,7 +163,6 @@ module.exports = class File extends TransportStream {
       callback(); // eslint-disable-line callback-return
     } else {
       this._next = callback;
-      this._dest.emit('drain');
     }
 
     return written;


### PR DESCRIPTION
I noticed in one of our project using winston3 that all our logging would stop after a few large (sometimes very large) log messages. The use of the file transport was the cause and it seemed like it was not draining correctly. Upon investigation I found that the drain mechanism seemed flawed by using a drain counter and not resetting it to zero when the drain event occurs.

Additionally the file transport would attempt to write to the stream after receiving the indicator to stop and wait for a drain event.

I have tested this against the examples provided by @juanda99 and @kramer65 mentioned in #1144 and they both seem to work although the @kramer65 code had to by slightly modified to allow the while(true) loop to give the event loop some time to breathe.

I know this transport has been particularly tricky to get right and I hope this helps but unfortunately as it stands now, winston3 rc5 still can get the file transport stuck leading to all logging getting stuck. I am trying to create an isolated test case although my attempts so far have not gone well.  