### PR TITLE
[fix] Correctly refactor handleExceptions and unhandleExceptions

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -98,7 +98,7 @@ Object.keys(winston.config.npm.levels).concat([
   'unhandleExceptions',
   'configure'
 ]).forEach(method => (
-  winston[method] = args => defaultLogger[method](...args)
+  winston[method] = (...args) => defaultLogger[method](...args)
 ));
 
 /**

--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -38,24 +38,12 @@ module.exports = class ExceptionHandler {
    * @returns {undefined}
    */
   handle(...args) {
-    const self = this;
-
-    // Helper function
-    function add(handler) {
-      if (!self.handlers.has(handler)) {
-        handler.handleExceptions = true;
-        const wrapper = new ExceptionStream(handler);
-        self.handlers.set(handler, wrapper);
-        self.logger.pipe(wrapper);
-      }
-    }
-
     args.forEach(arg => {
       if (Array.isArray(arg)) {
-        return arg.forEach(add);
+        return arg.forEach(handler => this._addHandler(handler));
       }
 
-      add(arg);
+      this._addHandler(arg);
     });
 
     if (!this.catcher) {
@@ -152,6 +140,20 @@ module.exports = class ExceptionHandler {
         native: site.isNative()
       };
     });
+  }
+
+  /**
+   * Helper method to add a transport as an exception handler.
+   * @param {Transport} handler - The transport to add as an exception handler.
+   * @returns {void}
+   */
+  _addHandler(handler) {
+    if (!this.handlers.has(handler)) {
+      handler.handleExceptions = true;
+      const wrapper = new ExceptionStream(handler);
+      this.handlers.set(handler, wrapper);
+      this.logger.pipe(wrapper);
+    }
   }
 
   /**

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -498,7 +498,7 @@ class Logger extends stream.Transform {
   handleExceptions(...args) {
     // eslint-disable-next-line no-console
     console.warn('Deprecated: .handleExceptions() will be removed in winston@4. Use .exceptions.handle()');
-    this.exceptions.handle(this.exceptions, args);
+    this.exceptions.handle(...args);
   }
 
   /**
@@ -509,7 +509,7 @@ class Logger extends stream.Transform {
   unhandleExceptions(...args) {
     // eslint-disable-next-line no-console
     console.warn('Deprecated: .unhandleExceptions() will be removed in winston@4. Use .unexceptions.handle()');
-    this.exceptions.unhandle(this.exceptions, args);
+    this.exceptions.unhandle(...args);
   }
 
   /**


### PR DESCRIPTION
The `handleExceptions` and `unhandleExceptions` methods where not refactored correctly to ES6 in #1286. The [`exit-on-error.js`](https://github.com/winstonjs/winston/blob/master/test/helpers/scripts/exit-on-error.js) script will throw the following `TypeError`. This PR should fix this `TypeError`.

```
Ignore this error.../lib/winston/exception-handler.js:215
      transport.once('logged', onDone('logged'));
                ^
TypeError: transport.once is not a function

```