### PR TITLE
3.0.0-rc6 pre-release and final items for 3.0.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## v3.0.0-rc6 / 2018-05-24
-### T-MINUS 5-DAYS TO WINSTON@3 EDITION
+## v3.0.0-rc6 / 2018-05-30
+### T-MINUS 6-DAY TO WINSTON@3 EDITION
 
+  - **Document that we are pushing for a June 5th, 2018 release of `winston@3.0.0`**
 - [#1287], (@DABH) Added types for Typescript.
 - [#1286], (@ChrisAlderson) Migrate codebase to ES6
   - [#1324], (@ChrisAlderson) Fix regression introduced by ES6 migration for
@@ -14,6 +15,9 @@
   for backwards compatibility.
 - [#1320], (@ChrisAlderson) Enhance tests to run on Windows.
 - Internal project maintenance
+  - Bump to `winston-transport@4.0.0` which may cause incompatibilities if
+    your custom transport does not explicitly require `winston-transport`
+    itself. 
   - [#1292], (@ChrisAlderson) Add node v10 to TravisCI build matrix.
   - [#1296], (@indexzero) Improve `UPGRADE-3.0.md`. Add Github Issue Template.
   - Remove "npm run report" in favor of reports being automatically generate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## v3.0.0-rc6 / 2018-05-24
+### T-MINUS 5-DAYS TO WINSTON@3 EDITION
+
+- [#1287], (@DABH) Added types for Typescript.
+- [#1286], (@ChrisAlderson) Migrate codebase to ES6
+  - [#1324], (@ChrisAlderson) Fix regression introduced by ES6 migration for
+    exception handling.
+- [#1291], [#1294], [#1318], (@indexzero, @ChrisAlderson, @mempf) Improvements
+  to `File` transport core functionality. Fixes [#1194].
+- [#1311], (@ChrisAlderson) Add `eol` option to `Stream` transport.
+- [#1297], (@ChrisAlderson) Move `winston.config` to `triple-beam`. Expose
+  for backwards compatibility.
+- [#1320], (@ChrisAlderson) Enhance tests to run on Windows.
+- Internal project maintenance
+  - [#1292], (@ChrisAlderson) Add node v10 to TravisCI build matrix.
+  - [#1296], (@indexzero) Improve `UPGRADE-3.0.md`. Add Github Issue Template.
+  - Remove "npm run report" in favor of reports being automatically generate.
+  - Update `logform`, `triple-beam`, and `winston-transport` to latest.
+
+> Special thanks to our newest `winston` core team member – @ChrisAlderson for 
+> helping make `winston@3.0.0` a reality next week!
+
 ## v3.0.0-rc5 / 2018-04-20
 ### UNOFFICIAL NATIONAL HOLIDAY EDITION
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CONTRIBUTING
 
-TL;DR? The `winston` project is actively working towards getting `3.0.0` out of RC (currently `3.0.0-rc5`). 
+TL;DR? The `winston` project is actively working towards getting `3.0.0` out of RC (currently `3.0.0-rc6`). 
 
 - [Be kind & actively empathetic to one another](CODE_OF_CONDUCT.md)
 - [What makes up `winston@3.0.0`?](#what-makes-up-winston-3.0.0)
@@ -51,7 +51,7 @@ const logger = createLogger({
 You will commonly see this closing `winston@2.x` issues:
 
 ```
-Development `winston@2.x` has ceased. Please consider upgrading to `winston@3.0.0-rc5`. If you feel strongly about this bug please open a PR against the `2.x` branch. Thank you for using `winston`!
+Development `winston@2.x` has ceased. Please consider upgrading to `winston@3.0.0-rc6`. If you feel strongly about this bug please open a PR against the `2.x` branch. Thank you for using `winston`!
 ```
 
 ## Could this be implemented as a format?

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A logger for just about everything.
 
 [![Join the chat at https://gitter.im/winstonjs/winston](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/winstonjs/winston?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-## winston@3.0.0-rc5
+## winston@3.0.0-rc6
 
-**We are pushing for a May 29th, 2018 release of `winston@3.0.0`**, currently
-`winston@3.0.0-rc5`.
+**We are pushing for a June 5th, 2018 release of `winston@3.0.0`**, currently
+`winston@3.0.0-rc6`.
 
 ```
 npm i winston@next --save


### PR DESCRIPTION
@jcrugzz @ChrisAlderson @DABH – less than a week until `winston@3.0.0`. The new bug count has been low and assuming there aren't any major hiccups after `rc6` gets released today we are on-track for next Tuesday. 

There are a few "must do" things before then, so if you've got time these are the places to focus your efforts:

- [#1024]: logger.debug is sent to stderr 
- [#1191]: Logger level doesn't update transports level 
- [#1250]: logging methods no longer take a callback, can't reliably use it in some environments (AWS Lambda) 
- [#1261]: [3.0.0-rc] Exception during formatting kills logging 
- [#1280]: le_node (Logentries) doesn't work with Winston RC3 
- [#1289]: ExceptionHandler silences printing of console errors?

Getting to this point has been a marathon, not a sprint – appreciate any and all time you can lend to the project. I'll be in Berlin next week for JSConf.eu and will be releasing a blog post on the new version. Exciting!