### PR TITLE
Add arguments for exceptions.(un)handle in TS defs; prefer non-deprec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,14 +717,14 @@ If you want to use this feature with the default logger, simply call
 
 ``` js
 //
-// You can add a separate exception logger by passing it to `.handleExceptions`
+// You can add a separate exception logger by passing it to `.exceptions.handle`
 //
 winston.exceptions.handle(
   new winston.transports.File({ filename: 'path/to/exceptions.log' })
 );
 
 //
-// Alternatively you can set `.handleExceptions` to true when adding transports
+// Alternatively you can set `handleExceptions` to true when adding transports
 // to winston. You can use the `.humanReadableUnhandledException` option to 
 // get more readable exceptions.
 //

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,8 +22,8 @@ declare namespace winston {
     handlers: Map<any, any>;
     catcher: Function | boolean;
 
-    handle(): void;
-    unhandle(): void;
+    handle(...transports: Transport[]): void;
+    unhandle(...transports: Transport[]): void;
     getAllInfo(err: string | Error): object;
     getProcessInfo(): object;
     getOsInfo(): object;

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -16,3 +16,5 @@ logger.log({ level: 'info', message: 'hey dude', meta: { foo: 'bar' } });
 // Default logger
 winston.http('New incoming connection')
 winston.error('The error was: ', err)
+
+winston.exceptions.handle(new winston.transports.File({ filename: 'exceptions.log' }));


### PR DESCRIPTION
…ated syntax in readme

- I am intentionally leaving out `winston.(un)handleException` from the TS defs since it's deprecated; folks who are picking up the library to use with Typescript should be modern enough to not rely on legacy/deprecated interfaces.  But if there is a strong desire to add those in there, I definitely can.