### PR TITLE
console transport: send all levels to stdout not stderr by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/*
 .nyc_output/*
 *.log
 .idea
+*.sw*

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -26,6 +26,7 @@
 ### Transports
 - `winston.transports.Memory` was removed. Use any Node.js `stream.Writeable` with a large `highWaterMark` instance instead.
 - When writing transports use `winston-transport` instead of `winston.Transport`
+- In `winston.transports.Console`, log level 'debug' ouptut is now sent to stdout by default rather than stderr (controlled by `debugStdout` option)
 
 ### `winston.Container` and `winston.loggers`
 - `winston.Container` instances no longer have default `Console` transports

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -25,8 +25,10 @@
 
 ### Transports
 - `winston.transports.Memory` was removed. Use any Node.js `stream.Writeable` with a large `highWaterMark` instance instead.
-- When writing transports use `winston-transport` instead of `winston.Transport`
-- In `winston.transports.Console`, log level 'debug' ouptut is now sent to stdout by default rather than stderr (controlled by `debugStdout` option)
+- When writing transports use `winston-transport` instead of `winston.Transport`.
+- In `winston.transports.Console`, output for all log levels is now sent to stdout by default.
+    - `debugStdout` option has been removed.
+    - `stderrLevels` now defaults to `[]`.
 
 ### `winston.Container` and `winston.loggers`
 - `winston.Container` instances no longer have default `Console` transports

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -78,30 +78,29 @@ module.exports = class Console extends TransportStream {
    * Array. For backwards compatibility, stderrLevels defaults to
    * ['error', 'debug'] or ['error'] depending on whether options.debugStdout
    * is true.
-   * @param {mixed} levels - TODO: add param description.
-   * @param {mixed} debugStdout - TODO: add param description.
-   * @returns {mixed} - TODO: add return description.
+   * @param {mixed} levels - An Array of string names of levels whose output
+   *                         should go to stderr
+   * @param {mixed} debugStdout - Whether the 'debug' level should be sent to
+   *                              stdout (default true as of `winston@3`).
+   * @returns {mixed} - An Object containing the levels to send to stderr.
    * @private
    */
   _getStderrLevels(levels, debugStdout) {
     const defaultMsg = 'Cannot have non-string elements in stderrLevels Array';
-    if (debugStdout) {
-      if (levels) {
-        // Don't allow setting both debugStdout and stderrLevels together,
-        // since this could cause behaviour a programmer might not expect.
-        throw new Error('Cannot set debugStdout and stderrLevels together');
+    if (debugStdout && levels) {
+      // Don't allow setting both debugStdout and stderrLevels together,
+      // since this could cause behaviour a programmer might not expect.
+      throw new Error('Cannot set debugStdout and stderrLevels together');
+    } else if (levels) {
+        if (!(Array.isArray(levels))) {
+        throw new Error('Cannot set stderrLevels to type other than Array');
       }
-
-      return this._stringArrayToSet(['error'], defaultMsg);
-    }
-
-    if (!levels) {
+      return this._stringArrayToSet(levels, defaultMsg);
+    } else if (debugStdout === false) {
       return this._stringArrayToSet(['error', 'debug'], defaultMsg);
-    } else if (!(Array.isArray(levels))) {
-      throw new Error('Cannot set stderrLevels to type other than Array');
     }
 
-    return this._stringArrayToSet(levels, defaultMsg);
+    return this._stringArrayToSet(['error'], defaultMsg);
   }
 
   /**

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -92,7 +92,7 @@ module.exports = class Console extends TransportStream {
       // since this could cause behaviour a programmer might not expect.
       throw new Error('Cannot set debugStdout and stderrLevels together');
     } else if (levels) {
-        if (!(Array.isArray(levels))) {
+      if (!(Array.isArray(levels))) {
         throw new Error('Cannot set stderrLevels to type other than Array');
       }
       return this._stringArrayToSet(levels, defaultMsg);

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -28,10 +28,7 @@ module.exports = class Console extends TransportStream {
 
     // Expose the name of this Transport on the prototype
     this.name = 'console';
-    this.stderrLevels = this._getStderrLevels(
-      options.stderrLevels,
-      options.debugStdout
-    );
+    this.stderrLevels = this._stringArrayToSet(options.stderrLevels);
     this.eol = options.eol || os.EOL;
   }
 
@@ -74,36 +71,6 @@ module.exports = class Console extends TransportStream {
   }
 
   /**
-   * Convert stderrLevels into an Object for faster key-lookup times than an
-   * Array. For backwards compatibility, stderrLevels defaults to
-   * ['error', 'debug'] or ['error'] depending on whether options.debugStdout
-   * is true.
-   * @param {mixed} levels - An Array of string names of levels whose output
-   *                         should go to stderr
-   * @param {mixed} debugStdout - Whether the 'debug' level should be sent to
-   *                              stdout (default true as of `winston@3`).
-   * @returns {mixed} - An Object containing the levels to send to stderr.
-   * @private
-   */
-  _getStderrLevels(levels, debugStdout) {
-    const defaultMsg = 'Cannot have non-string elements in stderrLevels Array';
-    if (debugStdout && levels) {
-      // Don't allow setting both debugStdout and stderrLevels together,
-      // since this could cause behaviour a programmer might not expect.
-      throw new Error('Cannot set debugStdout and stderrLevels together');
-    } else if (levels) {
-      if (!(Array.isArray(levels))) {
-        throw new Error('Cannot set stderrLevels to type other than Array');
-      }
-      return this._stringArrayToSet(levels, defaultMsg);
-    } else if (debugStdout === false) {
-      return this._stringArrayToSet(['error', 'debug'], defaultMsg);
-    }
-
-    return this._stringArrayToSet(['error'], defaultMsg);
-  }
-
-  /**
    * Returns a Set-like object with strArray's elements as keys (each with the
    * value true).
    * @param {Array} strArray - Array of Set-elements as strings.
@@ -112,7 +79,14 @@ module.exports = class Console extends TransportStream {
    * @private
    */
   _stringArrayToSet(strArray, errMsg) {
-    errMsg = errMsg || 'Cannot make set from Array with non-string elements';
+    if (!strArray)
+      return {};
+
+    errMsg = errMsg || 'Cannot make set from type other than Array of string elements';
+
+    if (!Array.isArray(strArray)) {
+      throw new Error(errMsg);
+    }
 
     return strArray.reduce((set, el) =>  {
       if (typeof el !== 'string') {

--- a/test/transports/console.test.js
+++ b/test/transports/console.test.js
@@ -19,7 +19,6 @@ const defaultLevels = winston.config.npm.levels;
 const transports = {
   defaults: new winston.transports.Console(),
   noStderr: new winston.transports.Console({ stderrLevels: [] }),
-  debugStdout: new winston.transports.Console({ debugStdout: true }),
   stderrLevels: new winston.transports.Console({
     stderrLevels: ['info', 'warn']
   }),
@@ -56,7 +55,7 @@ function assertStderrLevels(transport, stderrLevels) {
 
 describe('Console transport', function () {
   describe('with defaults', function () {
-    it('logs all levels (EXCEPT error) to stdout', function () {
+    it('logs all levels to stdout', function () {
       stdMocks.use();
       transports.defaults.levels = defaultLevels;
       Object.keys(defaultLevels)
@@ -74,43 +73,32 @@ describe('Console transport', function () {
       stdMocks.restore();
       var output = stdMocks.flush();
       assume(output.stderr).is.an('array');
-      assume(output.stderr).length(1);
+      assume(output.stderr).length(0);
       assume(output.stdout).is.an('array');
-      assume(output.stdout).length(6);
+      assume(output.stdout).length(7);
     });
 
-    it("should set stderrLevels to ['error'] by default", assertStderrLevels(
+    it("should set stderrLevels to [] by default", assertStderrLevels(
       transports.defaults,
-      ['error']
+      []
     ));
   });
 
   describe('throws an appropriate error when', function () {
-    it('if both debugStdout and stderrLevels are set { debugStdout, stderrLevels }', function () {
-      assume(function () {
-        let throwing = new winston.transports.Console({
-          stderrLevels: ['foo', 'bar'],
-          debugStdout: true
-        })
-      }).throws(/Cannot set debugStdout and stderrLevels/);
-    });
-
     it("if stderrLevels is set, but not an Array { stderrLevels: 'Not an Array' }", function () {
       assume(function () {
         let throwing = new winston.transports.Console({
-          stderrLevels: 'Not an Array',
-          debugStdout: false
+          stderrLevels: 'Not an Array'
         })
-      }).throws(/Cannot set stderrLevels to type other than Array/);
+      }).throws(/Cannot make set from type other than Array of string elements/);
     });
 
     it("if stderrLevels contains non-string elements { stderrLevels: ['good', /^invalid$/, 'valid']", function () {
       assume(function () {
         let throwing = new winston.transports.Console({
-          stderrLevels: ['good', /^invalid$/, 'valid'],
-          debugStdout: false
+          stderrLevels: ['good', /^invalid$/, 'valid']
         })
-      }).throws(/Cannot have non-string elements in stderrLevels Array/);
+      }).throws(/Cannot make set from type other than Array of string elements/);
     });
   });
 

--- a/test/transports/console.test.js
+++ b/test/transports/console.test.js
@@ -56,7 +56,7 @@ function assertStderrLevels(transport, stderrLevels) {
 
 describe('Console transport', function () {
   describe('with defaults', function () {
-    it('logs all levels (EXCEPT error and debug) to stdout', function () {
+    it('logs all levels (EXCEPT error) to stdout', function () {
       stdMocks.use();
       transports.defaults.levels = defaultLevels;
       Object.keys(defaultLevels)
@@ -74,14 +74,14 @@ describe('Console transport', function () {
       stdMocks.restore();
       var output = stdMocks.flush();
       assume(output.stderr).is.an('array');
-      assume(output.stderr).length(2);
+      assume(output.stderr).length(1);
       assume(output.stdout).is.an('array');
-      assume(output.stdout).length(5);
+      assume(output.stdout).length(6);
     });
 
-    it("should set stderrLevels to ['error', 'debug'] by default", assertStderrLevels(
+    it("should set stderrLevels to ['error'] by default", assertStderrLevels(
       transports.defaults,
-      ['error', 'debug']
+      ['error']
     ));
   });
 


### PR DESCRIPTION
This addresses the common points brought up in #927 and #1024 .  This change makes 'debug' level output go to stdout not stderr by default for the console transport.  The behavior is still controllable by specifying the `debugStdout` option for the transport or by passing a `levels` array, just as before.  Tests updated to reflect new default and line added to upgrade guide to mention this since it's a breaking change.