### PR TITLE
Typescript: silent is boolean

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,7 +72,7 @@ declare namespace winston {
 
   interface LoggerOptions {
     levels?: Config.AbstractConfigSetLevels;
-    silent?: string;
+    silent?: boolean;
     format?: logform.Format;
     level?: string;
     exitOnError?: Function | boolean;


### PR DESCRIPTION
Just noticed a small error in Typescript. In Logger, the silent option is boolean (as it should be), but in LoggerOptions, it is declared as string. This small PR corrects the problem.