### PR TITLE
Check log.length when evaluating "legacyness" of transports

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -270,10 +270,12 @@ class Logger extends stream.Transform {
    * @returns {Logger} - TODO: add return description.
    */
   add(transport) {
-    // Support backwards compatibility with all existing `winston@1.x.x`
-    // transport. All NEW transports should inherit from
-    // `winston.TransportStream`.
-    const target = !isStream(transport)
+    // Support backwards compatibility with all existing `winston < 3.x.x`
+    // transports which meet one of two criteria:
+    // 1. They inherit from winston.Transport in  < 3.x.x which is NOT a stream.
+    // 2. They expose a log method which has a length greater than 2 (i.e. more then
+    //    just `log(info, callback)`.
+    const target = !isStream(transport) || transport.log.length > 2
       ? new LegacyTransportStream({ transport })
       : transport;
 
@@ -299,7 +301,7 @@ class Logger extends stream.Transform {
    */
   remove(transport) {
     let target = transport;
-    if (!isStream(transport)) {
+    if (!isStream(transport) || transport.log.length > 2) {
       target = this.transports
         .filter(match => match.transport === transport)[0];
     }

--- a/test/helpers/mocks/legacy-mixed-transport.js
+++ b/test/helpers/mocks/legacy-mixed-transport.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const events = require('events');
+const util = require('util')
+const Transport = require('../../../').Transport;
+
+//
+// ### function LegacyMixed (options)
+// #### @options {Object} Options for this instance.
+// Constructor function for the LegacyMixed transport object responsible
+// for persisting log messages and metadata to a memory array of messages
+// and conforming to the old winston transport API, **BUT** INHERITS FROM
+// THE MODERN WINSTON TRANSPORT.
+//
+module.exports = class LegacyMixed extends Transport {
+  constructor(options = {}) {
+    super(options);
+
+    //
+    // Expose the name of this Transport on the prototype
+    //
+    module.exports.prototype.name = 'legacy-mixed-test';
+
+    this.silent = options.silent;
+    this.output = { error: [], write: [] };
+  }
+
+  //
+  // ### function log (level, msg, [meta], callback)
+  // #### @level {string} Level at which to log the message.
+  // #### @msg {string} Message to log
+  // #### @meta {Object} **Optional** Additional metadata to attach
+  // #### @callback {function} Continuation to respond to when complete.
+  // Core logging method exposed to Winston. Metadata is optional.
+  //
+  log(level, msg, meta, callback) {
+    if (this.silent) {
+      return callback(null, true);
+    }
+
+    var output = 'I AM BACKWARDS COMPATIBLE WITH LEGACY';
+
+    if (level === 'error' || level === 'debug') {
+      this.errorOutput.push(output);
+    } else {
+      this.writeOutput.push(output);
+    }
+
+    this.emit('logged');
+    callback(null, true);
+  }
+};

--- a/test/helpers/mocks/legacy-transport.js
+++ b/test/helpers/mocks/legacy-transport.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var events = require('events'),
-    util = require('util'),
-    Transport = require('winston-compat').Transport;
+const events = require('events');
+const util = require('util')
+const Transport = require('winston-compat').Transport;
 
 //
 // ### function Legacy (options)
@@ -11,7 +11,7 @@ var events = require('events'),
 // for persisting log messages and metadata to a memory array of messages
 // and conforming to the old winston transport API.
 //
-var Legacy = module.exports = function (options) {
+const Legacy = module.exports = function Legacy(options) {
   options = options || {};
   Transport.call(this, options);
 

--- a/test/logger-legacy.test.js
+++ b/test/logger-legacy.test.js
@@ -21,6 +21,10 @@ const LegacyMixedTransport = require('./helpers/mocks/legacy-mixed-transport');
 const TransportStream = require('winston-transport');
 const helpers = require('./helpers');
 
+/*
+ * Assumes that the `TransportClass` with the given { name, displayName }
+ * are properly handled by a winston Logger.
+ */
 function assumeAcceptsLegacy({ displayName, name, TransportClass }) {
   return function () {
     it(`.add(${name})`, function () {
@@ -34,7 +38,7 @@ function assumeAcceptsLegacy({ displayName, name, TransportClass }) {
       assume(logger._readableState.pipesCount).equals(1);
       assume(logger._readableState.pipes.transport).is.an('object');
       assume(logger._readableState.pipes.transport).equals(transport);
-      assume(output.stderr.join('')).to.include('legacy-test is a legacy winston transport. Consider upgrading');
+      assume(output.stderr.join('')).to.include(`${name} is a legacy winston transport. Consider upgrading`);
     });
 
     it(`.add(${name}) multiple`, function () {
@@ -51,7 +55,7 @@ function assumeAcceptsLegacy({ displayName, name, TransportClass }) {
       var output = stdMocks.flush();
 
       assume(logger._readableState.pipesCount).equals(3);
-      var errorMsg = 'legacy-test is a legacy winston transport. Consider upgrading';
+      var errorMsg = `${name} is a legacy winston transport. Consider upgrading`;
       assume(output.stderr.join('')).to.include(errorMsg);
     });
 
@@ -61,8 +65,7 @@ function assumeAcceptsLegacy({ displayName, name, TransportClass }) {
         new TransportClass()
       ];
 
-      var logger = winston.createLogger({ transports: transports });
-
+      const logger = winston.createLogger({ transports: transports });
       assume(logger.transports.length).equals(2);
       logger.remove(transports[1]);
       assume(logger.transports.length).equals(1);

--- a/test/logger-legacy.test.js
+++ b/test/logger-legacy.test.js
@@ -17,8 +17,59 @@ const stdMocks = require('std-mocks');
 const { MESSAGE } = require('triple-beam');
 const winston = require('../lib/winston');
 const LegacyTransport = require('./helpers/mocks/legacy-transport');
+const LegacyMixedTransport = require('./helpers/mocks/legacy-mixed-transport');
 const TransportStream = require('winston-transport');
 const helpers = require('./helpers');
+
+function assumeAcceptsLegacy({ displayName, name, TransportClass }) {
+  return function () {
+    it(`.add(${name})`, function () {
+      stdMocks.use();
+      var logger = winston.createLogger();
+      var transport = new TransportClass();
+      logger.add(transport);
+      stdMocks.restore();
+      var output = stdMocks.flush();
+
+      assume(logger._readableState.pipesCount).equals(1);
+      assume(logger._readableState.pipes.transport).is.an('object');
+      assume(logger._readableState.pipes.transport).equals(transport);
+      assume(output.stderr.join('')).to.include('legacy-test is a legacy winston transport. Consider upgrading');
+    });
+
+    it(`.add(${name}) multiple`, function () {
+      stdMocks.use();
+      var logger = winston.createLogger({
+        transports: [
+          new TransportClass(),
+          new TransportClass(),
+          new TransportClass()
+        ]
+      });
+
+      stdMocks.restore();
+      var output = stdMocks.flush();
+
+      assume(logger._readableState.pipesCount).equals(3);
+      var errorMsg = 'legacy-test is a legacy winston transport. Consider upgrading';
+      assume(output.stderr.join('')).to.include(errorMsg);
+    });
+
+    it('.remove() [LegacyTransportStream]', function () {
+      var transports = [
+        new winston.transports.Console(),
+        new TransportClass()
+      ];
+
+      var logger = winston.createLogger({ transports: transports });
+
+      assume(logger.transports.length).equals(2);
+      logger.remove(transports[1]);
+      assume(logger.transports.length).equals(1);
+      assume(logger.transports[0]).equals(transports[0]);
+    });
+  };
+}
 
 describe('Logger (legacy API)', function () {
   it('new Logger({ DEPRECATED })', function () {
@@ -38,51 +89,23 @@ describe('Logger (legacy API)', function () {
     });
   });
 
-  it('.add(LegacyTransport)', function () {
-    stdMocks.use();
-    var logger = winston.createLogger();
-    var transport = new LegacyTransport();
-    logger.add(transport);
-    stdMocks.restore();
-    var output = stdMocks.flush();
+  describe(
+    'LegacyTransport (inherits from winston@2 Transport)',
+    assumeAcceptsLegacy({
+      displayName: 'LegacyTransport',
+      TransportClass: LegacyTransport,
+      name: 'legacy-test'
+    })
+  );
 
-    assume(logger._readableState.pipesCount).equals(1);
-    assume(logger._readableState.pipes.transport).is.an('object');
-    assume(logger._readableState.pipes.transport).equals(transport);
-    assume(output.stderr.join('')).to.include('legacy-test is a legacy winston transport. Consider upgrading');
-  });
-
-  it('.add(LegacyTransport) multiple', function () {
-    stdMocks.use();
-    var logger = winston.createLogger({
-      transports: [
-        new LegacyTransport(),
-        new LegacyTransport(),
-        new LegacyTransport()
-      ]
-    });
-
-    stdMocks.restore();
-    var output = stdMocks.flush();
-
-    assume(logger._readableState.pipesCount).equals(3);
-    var errorMsg = 'legacy-test is a legacy winston transport. Consider upgrading';
-    assume(output.stderr.join('')).to.include(errorMsg);
-  });
-
-  it('.remove() [LegacyTransportStream]', function () {
-    var transports = [
-      new winston.transports.Console(),
-      new (LegacyTransport)()
-    ];
-
-    var logger = winston.createLogger({ transports: transports });
-
-    assume(logger.transports.length).equals(2);
-    logger.remove(transports[1]);
-    assume(logger.transports.length).equals(1);
-    assume(logger.transports[0]).equals(transports[0]);
-  });
+  describe(
+    'LegacyMixedTransport (inherits from winston@3 Transport)',
+    assumeAcceptsLegacy({
+      displayName: 'LegacyMixedTransport',
+      TransportClass: LegacyMixedTransport,
+      name: 'legacy-mixed-test'
+    })
+  );
 
   it('.log(level, message)', function (done) {
     var logger = helpers.createLogger(function (info) {


### PR DESCRIPTION
In `winston@3` [this code](https://github.com/rapid7/le_node/blob/master/src/logger.js#L713-L717) in `le_node` would not result in the `LogentriesTransport` being wrapped in a `LegacyTransportStream` because `winston.Transport` will be `require('winston-transport')` and not `require('winston-compat').Transport` as we expect.

To work around this we now also check the function `length` of the `log` function to ensure a length of two. This is not a perfect check, but it should handle the 80% case. 

Related: https://github.com/winstonjs/winston/issues/1280, https://github.com/winstonjs/winston-transport/pull/23