### PR TITLE
Set max listeners to 30 to silence node warnings

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -47,7 +47,7 @@ module.exports = class File extends TransportStream {
 
     // Setup the base stream that always gets piped to to handle buffering.
     this._stream = new PassThrough();
-    this._stream.setMaxListeners(Infinity);
+    this._stream.setMaxListeners(30);
 
     // Bind this context for listener methods.
     this._onError = this._onError.bind(this);

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -47,6 +47,7 @@ module.exports = class File extends TransportStream {
 
     // Setup the base stream that always gets piped to to handle buffering.
     this._stream = new PassThrough();
+    this._stream.setMaxListeners(Infinity);
 
     // Bind this context for listener methods.
     this._onError = this._onError.bind(this);


### PR DESCRIPTION
Addresses the discussion in #1334 -- no functionality change, but silences warnings.  This is likely a reasonable strategy, the only risk being some users might be more likely to use anti-patterns like in #1334 where many loggers are created all sharing the same transport (it would be less likely to get the max listener warning in that case now).  However, since one of the file stress tests was also hitting the (low I think) default limit in Node, I think it's pretty reasonable to bump up the limit to 30 for the time being.