### PR TITLE
Added `isLevelEnabled(string)` & `isXXXEnabled()`

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -44,7 +44,7 @@ class DerivedLogger extends Logger {
       }
 
       // Define prototype methods for each log level
-      // e.g. logger.log('info', msg) <––> logger.info(msg)
+      // e.g. logger.log('info', msg) <––> logger.info(msg) & logger.isInfoEnabled()
       this[level] = (...args) => {
         // Optimize the hot-path which is the single object.
         if (args.length === 1) {
@@ -61,8 +61,14 @@ class DerivedLogger extends Logger {
         // 2. v1/v2 API: log(level, msg, ... [string interpolate], [{metadata}], [callback])
         return this.log(level, ...args);
       };
+
+      this[isLevelEnabledFunctionName(level)] = () => this.isLevelEnabled(level);
     });
   }
+}
+
+function isLevelEnabledFunctionName(level) {
+  return 'is' + level.charAt(0).toUpperCase() + level.slice(1) + 'Enabled';
 }
 
 /**

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -95,6 +95,31 @@ class Logger extends stream.Transform {
     }
   }
 
+  isLevelEnabled(level) {
+    const givenLevelValue = getLevelValue(this.levels, level);
+    if (givenLevelValue === null) {
+      return false;
+    }
+
+    const configuredLevelValue = getLevelValue(this.levels, this.level);
+    if (configuredLevelValue === null) {
+      return false;
+    }
+
+    if (!this.transports || this.transports.length === 0) {
+      return configuredLevelValue >= givenLevelValue;
+    }
+
+    const index = this.transports.findIndex(transport => {
+      let transportLevelValue = getLevelValue(this.levels, transport.level);
+      if (transportLevelValue === null) {
+        transportLevelValue = configuredLevelValue;
+      }
+      return transportLevelValue >= givenLevelValue;
+    });
+    return index !== -1;
+  }
+
   /* eslint-disable valid-jsdoc */
   /**
    * Ensure backwards compatibility with a `log` method
@@ -509,6 +534,14 @@ class Logger extends stream.Transform {
       transport.on('error', transport.__winstonError);
     }
   }
+}
+
+function getLevelValue(levels, level) {
+  const value = levels[level];
+  if (!value && value !== 0) {
+    return null;
+  }
+  return value;
 }
 
 /**

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -359,6 +359,185 @@ describe('Logger (levels)', function () {
   });
 });
 
+describe('Logger (level enabled/disabled)', function () {
+  it('default levels', function () {
+    var logger = winston.createLogger({
+      level: 'verbose',
+      levels: winston.config.npm.levels,
+      transports: [new winston.transports.Console()]
+    });
+
+    assume(logger.isLevelEnabled).is.a('function');
+
+    assume(logger.isErrorEnabled).is.a('function');
+    assume(logger.isWarnEnabled).is.a('function');
+    assume(logger.isInfoEnabled).is.a('function');
+    assume(logger.isVerboseEnabled).is.a('function');
+    assume(logger.isDebugEnabled).is.a('function');
+    assume(logger.isSillyEnabled).is.a('function');
+
+    assume(logger.isLevelEnabled('error')).true();
+    assume(logger.isLevelEnabled('warn')).true();
+    assume(logger.isLevelEnabled('info')).true();
+    assume(logger.isLevelEnabled('verbose')).true();
+    assume(logger.isLevelEnabled('debug')).false();
+    assume(logger.isLevelEnabled('silly')).false();
+
+    assume(logger.isErrorEnabled()).true();
+    assume(logger.isWarnEnabled()).true();
+    assume(logger.isInfoEnabled()).true();
+    assume(logger.isVerboseEnabled()).true();
+    assume(logger.isDebugEnabled()).false();
+    assume(logger.isSillyEnabled()).false();
+  });
+
+  it('default levels, transport override', function () {
+    var transport = new winston.transports.Console();
+    transport.level = 'debug';
+
+    var logger = winston.createLogger({
+      level: 'info',
+      levels: winston.config.npm.levels,
+      transports: [transport]
+    });
+
+    assume(logger.isLevelEnabled).is.a('function');
+
+    assume(logger.isErrorEnabled).is.a('function');
+    assume(logger.isWarnEnabled).is.a('function');
+    assume(logger.isInfoEnabled).is.a('function');
+    assume(logger.isVerboseEnabled).is.a('function');
+    assume(logger.isDebugEnabled).is.a('function');
+    assume(logger.isSillyEnabled).is.a('function');
+
+    assume(logger.isLevelEnabled('error')).true();
+    assume(logger.isLevelEnabled('warn')).true();
+    assume(logger.isLevelEnabled('info')).true();
+    assume(logger.isLevelEnabled('verbose')).true();
+    assume(logger.isLevelEnabled('debug')).true();
+    assume(logger.isLevelEnabled('silly')).false();
+
+    assume(logger.isErrorEnabled()).true();
+    assume(logger.isWarnEnabled()).true();
+    assume(logger.isInfoEnabled()).true();
+    assume(logger.isVerboseEnabled()).true();
+    assume(logger.isDebugEnabled()).true();
+    assume(logger.isSillyEnabled()).false();
+  });
+
+  it('default levels, no transports', function () {
+    var logger = winston.createLogger({
+      level: 'verbose',
+      levels: winston.config.npm.levels,
+      transports: []
+    });
+
+    assume(logger.isLevelEnabled).is.a('function');
+
+    assume(logger.isErrorEnabled).is.a('function');
+    assume(logger.isWarnEnabled).is.a('function');
+    assume(logger.isInfoEnabled).is.a('function');
+    assume(logger.isVerboseEnabled).is.a('function');
+    assume(logger.isDebugEnabled).is.a('function');
+    assume(logger.isSillyEnabled).is.a('function');
+
+    assume(logger.isLevelEnabled('error')).true();
+    assume(logger.isLevelEnabled('warn')).true();
+    assume(logger.isLevelEnabled('info')).true();
+    assume(logger.isLevelEnabled('verbose')).true();
+    assume(logger.isLevelEnabled('debug')).false();
+    assume(logger.isLevelEnabled('silly')).false();
+
+    assume(logger.isErrorEnabled()).true();
+    assume(logger.isWarnEnabled()).true();
+    assume(logger.isInfoEnabled()).true();
+    assume(logger.isVerboseEnabled()).true();
+    assume(logger.isDebugEnabled()).false();
+    assume(logger.isSillyEnabled()).false();
+  });
+
+  it('custom levels', function () {
+    var logger = winston.createLogger({
+      level: 'test',
+      levels: {
+        bad: 0,
+        test: 1,
+        ok: 2
+      },
+      transports: [new winston.transports.Console()]
+    });
+
+    assume(logger.isLevelEnabled).is.a('function');
+
+    assume(logger.isBadEnabled).is.a('function');
+    assume(logger.isTestEnabled).is.a('function');
+    assume(logger.isOkEnabled).is.a('function');
+
+    assume(logger.isLevelEnabled('bad')).true();
+    assume(logger.isLevelEnabled('test')).true();
+    assume(logger.isLevelEnabled('ok')).false();
+
+    assume(logger.isBadEnabled()).true();
+    assume(logger.isTestEnabled()).true();
+    assume(logger.isOkEnabled()).false();
+  });
+
+  it('custom levels, no transports', function () {
+    var logger = winston.createLogger({
+      level: 'test',
+      levels: {
+        bad: 0,
+        test: 1,
+        ok: 2
+      },
+      transports: []
+    });
+
+    assume(logger.isLevelEnabled).is.a('function');
+
+    assume(logger.isBadEnabled).is.a('function');
+    assume(logger.isTestEnabled).is.a('function');
+    assume(logger.isOkEnabled).is.a('function');
+
+    assume(logger.isLevelEnabled('bad')).true();
+    assume(logger.isLevelEnabled('test')).true();
+    assume(logger.isLevelEnabled('ok')).false();
+
+    assume(logger.isBadEnabled()).true();
+    assume(logger.isTestEnabled()).true();
+    assume(logger.isOkEnabled()).false();
+  });
+
+  it('custom levels, transport override', function () {
+    var transport = new winston.transports.Console();
+    transport.level = 'ok';
+
+    var logger = winston.createLogger({
+      level: 'bad',
+      levels: {
+        bad: 0,
+        test: 1,
+        ok: 2
+      },
+      transports: [transport]
+    });
+
+    assume(logger.isLevelEnabled).is.a('function');
+
+    assume(logger.isBadEnabled).is.a('function');
+    assume(logger.isTestEnabled).is.a('function');
+    assume(logger.isOkEnabled).is.a('function');
+
+    assume(logger.isLevelEnabled('bad')).true();
+    assume(logger.isLevelEnabled('test')).true();
+    assume(logger.isLevelEnabled('ok')).true();
+
+    assume(logger.isBadEnabled()).true();
+    assume(logger.isTestEnabled()).true();
+    assume(logger.isOkEnabled()).true();
+  });
+});
+
 describe('Logger (stream semantics)', function () {
   it(`'finish' event awaits transports to emit 'finish'`, function (done) {
     const transports = [


### PR DESCRIPTION
Make logger expose functions to check if a particular level is enabled. This could be useful if either message or parameter creation is an expensive operation, which should be avoided when log level is disabled.

Logger will contain `isLevelEnabled(level: string)` function and multiple `isXXXEnabled()` where "XXX" is the capitalized name of the configured log level. E.g. `isDebugEnabled()`, `isInfoEnabled()`, etc.

Resolves https://github.com/winstonjs/winston/issues/905