### PR TITLE
Attempt at fixing the issues with ExceptionHandler in #1289

### DIFF
--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -201,8 +201,6 @@ module.exports = class ExceptionHandler {
 
     // Log to all transports attempting to listen for when they are completed.
     asyncForEach(handlers, (handler, next) => {
-      // TODO: Change these to the correct WritableStream events so that we
-      // wait until exit.
       const done = once(next);
       const transport = handler.transport || handler;
 
@@ -214,9 +212,10 @@ module.exports = class ExceptionHandler {
         };
       }
 
-      transport.once('logged', onDone('logged'));
+      transport._ending = true;
+      transport.once('finish', onDone('finished'));
       transport.once('error', onDone('error'));
-    }, gracefulExit);
+    }, () => doExit && gracefulExit());
 
     this.logger.log(info);
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -85,9 +85,25 @@ module.exports = class File extends TransportStream {
     this._created = 0;
     this._drain = false;
     this._opening = false;
+    this._ending = false;
 
     this.open();
   }
+
+  finishIfEnding() {
+    if (this._ending) {
+      if (this._opening) {
+        this.once('open', () => {
+          this._stream.once('finish', () => this.emit('finish'));
+          setImmediate(() => this._stream.end());
+        });
+      } else {
+        this._stream.once('finish', () => this.emit('finish'));
+        setImmediate(() => this._stream.end());
+      }
+    }
+  }
+
 
   /**
    * Core logging method exposed to Winston. Metadata is optional.
@@ -167,6 +183,8 @@ module.exports = class File extends TransportStream {
     }
 
     debug('written', written, this._drain);
+
+    this.finishIfEnding();
 
     return written;
   }
@@ -458,12 +476,16 @@ module.exports = class File extends TransportStream {
    * @param {function} callback - Callback for when the current file has closed.
    * @private
    */
-  _endStream(callback) {
-    this._stream.unpipe(this._dest);
-    this._dest.end(() => {
-      this._cleanupStream(this._dest);
-      callback();
-    });
+  _endStream(callback = () => {}) {
+    if (this._dest) {
+      this._stream.unpipe(this._dest);
+      this._dest.end(() => {
+        this._cleanupStream(this._dest);
+        callback();
+      });
+    } else {
+      callback(); // eslint-disable-line callback-return
+    }
   }
 
   /**


### PR DESCRIPTION
#1289 observed that the ExceptionHandler was broken, at least with the File transport, because the File transport emits the `logged` event before content is flushed to disk (and the handler exits upon seeing `logged` events from the handling transports).

This is one potential way to get the desired behavior.  We add an `_ending` flag to the File transport, which is set to true on an unhandled exception in ExceptionHandler.  The File transport's `log()` checks if `_ending` is true when logging, and if so, ends the stream and passes up the stream's `finish` event (when stuff is flushed) to the exception handler.  There is also a check to wait for the file to open first, if it's opening (otherwise you end before the file opens and so nothing is logged still).

This does appear to fix the test case provided by the OP in #1289 but this is also near the limit of my stream skills so feel free to just use it as inspiration if there is a better approach.