### PR TITLE
Add types entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston",
   "description": "A logger for just about everything.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "maintainers": [
     "Jarrett Cruger <jcrugzz@gmail.com>",
@@ -53,6 +53,7 @@
     "winston-compat": "^0.1.1"
   },
   "main": "./lib/winston",
+  "types": "./index.d.ts",
   "scripts": {
     "lint": "populist lib/*.js lib/winston/*.js lib/winston/**/*.js",
     "pretest": "npm run lint",


### PR DESCRIPTION
`index.d.ts` is not in `package.json`, so types are not accessible from outside 