### PR TITLE
[fix] Allow transports with no 'log' function at all.

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -17,6 +17,17 @@ const Profiler = require('./profiler');
 const { clone, warn } = require('./common');
 const config = require('./config');
 
+function isLegacyTransport(transport) {
+  // Support backwards compatibility with all existing `winston < 3.x.x`
+  // transports which meet one of two criteria:
+  // 1. They inherit from winston.Transport in  < 3.x.x which is NOT a stream.
+  // 2. They expose a log method which has a length greater than 2 (i.e. more then
+  //    just `log(info, callback)`.  (Note that transports without a `log`
+  //    function are assumed to be 3.x.x transports - just regular
+  //    writable streams.
+  return !isStream(transport) || (transport.log && transport.log.length > 2);
+}
+
 /**
  * TODO: add class description.
  * @type {Logger}
@@ -236,12 +247,7 @@ class Logger extends stream.Transform {
    * @returns {Logger} - TODO: add return description.
    */
   add(transport) {
-    // Support backwards compatibility with all existing `winston < 3.x.x`
-    // transports which meet one of two criteria:
-    // 1. They inherit from winston.Transport in  < 3.x.x which is NOT a stream.
-    // 2. They expose a log method which has a length greater than 2 (i.e. more then
-    //    just `log(info, callback)`.
-    const target = !isStream(transport) || transport.log.length > 2
+    const target = isLegacyTransport(transport)
       ? new LegacyTransportStream({ transport })
       : transport;
 
@@ -267,7 +273,7 @@ class Logger extends stream.Transform {
    */
   remove(transport) {
     let target = transport;
-    if (!isStream(transport) || transport.log.length > 2) {
+    if (isLegacyTransport(transport)) {
       target = this.transports
         .filter(match => match.transport === transport)[0];
     }


### PR DESCRIPTION
This fixes a minor issue in logger.  Transports are essentially just writable streams in Winston 3.0.0, but there's [this check](https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js#L244-L246) for legacy loggers which checks to see if `transport.log.length > 2`.

First of all, if nothing else, in winston-transport, the [log function is declared as optional in the typescript definition](https://github.com/winstonjs/winston-transport/blob/master/index.d.ts#L19), so assuming `transport.log` exists is "bad".

Second, (and the motivation for this PR) I'm trying to write a "deferred transport".  I want to go query Consul and find out where my Elasticsearch server is before I create an Elasticsearch transport, but while I'm waiting for Consul, things could be logged, and I want to buffer those somewhere until my ES transport shows up.  So I want to do:

```js
const futureEsTransport = new DeferedSink({objectMode: true});

const logger = winston.createLogger({
    level: 'info',
    transports: [
        futureEsTransport
    ]
});

consul.findElasticsearch()
.then(esAddress =>
    futureEsTransport.resolve(new Elasticsearch({...}))
);
```

`DeferedSink` here can be just a general purpose Writable stream - it doesn't actually need any Winston specific code in it, so it could be used in other settings.  But to make it work right now, I need to add a dummy "log() {}" function to it.  :P