### PR TITLE
Transports streams emit 'finish' event, not 'finished'

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ by `winston` see the [`winston` Transports](docs/transports.md) document.
 
 Often it is useful to wait for your logs to be written before exiting the
 process. Each instance of `winston.Logger` is also a [Node.js stream]. A
-`finished` event will be raised when all logs have flushed to all transports
+`finish` event will be raised when all logs have flushed to all transports
 after the stream has been ended.
 
 ``` js


### PR DESCRIPTION
Per my tests I had to listen to the `finish` event as `finished` was never called.

I believe this is inline per this issue: https://github.com/winstonjs/winston/issues/1250