### PR TITLE
Add coverage to ignored npm files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,5 @@ docs
 docs/*
 .nyc_output/
 .nyc_output/*
+coverage/
+coverage/*


### PR DESCRIPTION
Looks like coverage got added to recent npm packages. It doesn't need to be installed

$ find node_modules/winston -type d
node_modules/winston
node_modules/winston/coverage
node_modules/winston/coverage/lcov-report
node_modules/winston/coverage/lcov-report/lib
node_modules/winston/coverage/lcov-report/lib/winston
node_modules/winston/coverage/lcov-report/lib/winston/config
node_modules/winston/coverage/lcov-report/lib/winston/transports
node_modules/winston/lib
node_modules/winston/lib/winston
node_modules/winston/lib/winston/config
node_modules/winston/lib/winston/transports
node_modules/winston/scratch
node_modules/winston/scratch/1144
node_modules/winston/test
node_modules/winston/test/transports

(Should scratch be there too?)