### PR TITLE
Mention possibility to set log level for profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,11 +820,8 @@ on:
  }, 1000);
 ```
 
-All profile messages are set to 'info' level by default and both message and
-metadata are optional. There are no plans in the Roadmap to make this
-configurable, but we are open to suggestions through new issues!
-
-For individual profile messages you can set the log level by supplying an object with a `level` property:
+All profile messages are set to 'info' level by default, and both message and
+metadata are optional.  For individual profile messages, you can override the default log level by supplying a metadata object with a `level` property:
 
 ```js
 logger.profile('test', { level: 'debug' });

--- a/README.md
+++ b/README.md
@@ -824,6 +824,12 @@ All profile messages are set to 'info' level by default and both message and
 metadata are optional. There are no plans in the Roadmap to make this
 configurable, but we are open to suggestions through new issues!
 
+For individual profile messages you can set the log level by supplying an object with a `level` property:
+
+```js
+logger.profile('test', { level: 'debug' });
+```
+
 ## Querying Logs
 
 `winston` supports querying of logs with Loggly-like options. [See Loggly


### PR DESCRIPTION
I found out that it is indeed possible to set the log level for profiling logs by supplying an object with a `level` property. This should be mentioned in the docs.