### PR TITLE
fix(exceptionhandler): prevent debug throws

### DIFF
--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -9,10 +9,16 @@
 
 const os = require('os');
 const asyncForEach = require('async/forEach');
-const debug = require('diagnostics')('winston:exception');
 const once = require('one-time');
 const stackTrace = require('stack-trace');
 const ExceptionStream = require('./exception-stream');
+
+let debug = () => {};
+try {
+  debug = require('diagnostics')('winston:exception');
+} catch (e) {
+  //loading debug fails, let debug fallback to noop
+}
 
 /**
  * Object for handling uncaughtException events.


### PR DESCRIPTION
This PR intends to add small guards around `debug` in `exception-handler`. In Electron codebase we use, we are experiencing below exception thrown when load winston: 

```
 Error: Failed to read the 'localStorage' property from 'Window': Storage is disabled inside 'data:' URLs.
    at env (/Users/xxxx/node_modules/env-variable/index.js:24:16)
    at enabled (/Users/xxxx/node_modules/enabled/index.js:14:14)
    at factory (/Users/xxxx/node_modules/diagnostics/index.js:40:8)
    at Object.<anonymous> (/Users/xxxx/node_modules/winston/lib/winston/exception-handler.js:12:37)
    at Object.<anonymous> (/Users/xxxx/node_modules/winston/lib/winston/exception-handler.js:248:3)
```

as `diagnostics` module trying to be isomorphic and while trying to check env, doesn't guard exceptions around non-allowed environement. It is some sort of edge cases probably node / browser won't hit easily.

Still this might not be desired fix - may better way is to use modules like `https://github.com/visionmedia/debug` instead, or some other approach I couldn't think of. Open PR for discussion / proceed further since it isn't easily able to workaround in consumer code of winston.