### PR TITLE
Fixes logger.query() broken by winston 3.0.0

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -14,7 +14,7 @@ const isStream = require('is-stream');
 const ExceptionHandler = require('./exception-handler');
 const LegacyTransportStream = require('winston-transport/legacy');
 const Profiler = require('./profiler');
-const { clone, warn } = require('./common');
+const { warn } = require('./common');
 const config = require('./config');
 
 /**
@@ -310,7 +310,6 @@ class Logger extends stream.Transform {
    * a property per transport.
    * @param {Object} options - Query options for this instance.
    * @param {function} callback - Continuation to respond to when complete.
-   * @retruns {mixed} - TODO: add return description.
    */
   query(options, callback) {
     if (typeof options === 'function') {
@@ -320,11 +319,11 @@ class Logger extends stream.Transform {
 
     options = options || {};
     const results = {};
-    const queryObject = clone(options.query) || {};
+    const queryObject = Object.assign({}, options.query || {});
 
     // Helper function to query a single transport
     function queryTransport(transport, next) {
-      if (options.query) {
+      if (options.query && typeof transport.formatQuery === 'function') {
         options.query = transport.formatQuery(queryObject);
       }
 
@@ -333,7 +332,11 @@ class Logger extends stream.Transform {
           return next(err);
         }
 
-        next(null, transport.formatResults(res, options.format));
+        if (typeof transport.formatResults === 'function') {
+          res = transport.formatResults(res, options.format);
+        }
+
+        next(null, res);
       });
     }
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -183,7 +183,7 @@ module.exports = class File extends TransportStream {
       options = {};
     }
 
-    options = this.normalizeQuery(options);
+    options = normalizeQuery(options);
     const file = path.join(this.dirname, this.filename);
     let buff = '';
     let results = [];
@@ -290,6 +290,36 @@ module.exports = class File extends TransportStream {
       }
 
       return true;
+    }
+
+    function normalizeQuery(options) {
+      options = options || {};
+
+      // limit
+      options.rows = options.rows || options.limit || 10;
+
+      // starting row offset
+      options.start = options.start || 0;
+
+      // now
+      options.until = options.until || new Date();
+      if (typeof options.until !== 'object') {
+        options.until = new Date(options.until);
+      }
+
+      // now - 24
+      options.from = options.from || (options.until - (24 * 60 * 60 * 1000));
+      if (typeof options.from !== 'object') {
+        options.from = new Date(options.from);
+      }
+
+      // 'asc' or 'desc'
+      options.order = options.order || 'desc';
+
+      // which fields to select
+      options.fields = options.fields;
+
+      return options;
     }
   }
 


### PR DESCRIPTION
Winston 3.0.0 broke the logger.query() and transport.query() methods (#1130 #1181) by removing some methods from TransportStream while moving to winston-transport and removing the common.clone() method.

This pull request aims to simply fix the current query() implementation, until Winston 3.3.0 comes around with a query rework.