### PR TITLE
Fix Profiler done() method typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ declare namespace winston {
   interface Profiler {
     logger: Logger;
     start: Date;
-    done(): boolean;
+    done(info?: any): boolean;
   }
 
   type LogCallback = (error?: any, level?: string, message?: string, meta?: any) => void;


### PR DESCRIPTION
Hi there!

A quick fix for the `Profiler.done` method TypeScript typing. It wasn't allowing any parameter, but actually, it does.

Best regards,

François Voron
