### PR TITLE
Documentation - Update winlog2 link in transports.md

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -578,7 +578,7 @@ Options:
 
 ### Winlog2 Transport
 
-[winston-winlog2][19] is a Windows Event log transport:
+[winston-winlog2][33] is a Windows Event log transport:
 
 ``` js
 const winston = require('winston');
@@ -724,3 +724,4 @@ That's why we say it's a logger for just about everything
 [30]: https://cloud.google.com/logging/
 [31]: https://github.com/joelee/winston-spark
 [32]: https://github.com/avens19/winston-sumologic-transport
+[33]: https://github.com/peteward44/winston-winlog2


### PR DESCRIPTION
Fix link to winlog2, it was previously linking to graylog2