### PR TITLE
Bubble transport warn events to logger

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -274,8 +274,9 @@ class Logger extends stream.Transform {
       throw new Error('Transports must WritableStreams in objectMode. Set { objectMode: true }.');
     }
 
-    // Listen for the `error` event on the new Transport.
-    this._onError(target);
+    // Listen for the `error` event and the `warn` event on the new Transport.
+    this._onEvent('error', target);
+    this._onEvent('warn', target);
     this.pipe(target);
 
     if (transport.handleExceptions) {
@@ -518,20 +519,20 @@ class Logger extends stream.Transform {
   }
 
   /**
-   * Bubbles the error, `err`, that occured on the specified `transport` up
-   * from this instance if `emitErrs` has been set.
-   * @param {Object} transport - Transport on which the error occured
-   * @throws {Error} - Error that occurred on the transport
+   * Bubbles the `event` that occured on the specified `transport` up
+   * from this instance.
+   * @param {string} event - The event that occured
+   * @param {Object} transport - Transport on which the event occured
    * @private
    */
-  _onError(transport) {
-    function transportError(err) {
-      this.emit('error', err, transport);
+  _onEvent(event, transport) {
+    function transportEvent(err) {
+      this.emit(event, err, transport);
     }
 
-    if (!transport.__winstonError) {
-      transport.__winstonError = transportError.bind(this);
-      transport.on('error', transport.__winstonError);
+    if (!transport['__winston' + event]) {
+      transport['__winston' + event] = transportEvent.bind(this);
+      transport.on(event, transport['__winston' + event]);
     }
   }
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -838,3 +838,33 @@ describe('Logger (profile, startTimer)', function (done) {
     }, 100);
   });
 });
+
+describe('Should bubble transport events', () => {
+  it('error', (done) => {
+    const consoleTransport = new winston.transports.Console();
+    const logger = winston.createLogger({
+      transports: [consoleTransport]
+    });
+
+    logger.on('error', (err, transport) => {
+      assume(err).instanceOf(Error);
+      assume(transport).is.an('object');
+      done();
+    });
+    consoleTransport.emit('error', new Error());
+  });
+
+  it('warn', (done) => {
+    const consoleTransport = new winston.transports.Console();
+    const logger = winston.createLogger({
+      transports: [consoleTransport]
+    });
+
+    logger.on('warn', (err, transport) => {
+      assume(err).instanceOf(Error);
+      assume(transport).is.an('object');
+      done();
+    });
+    consoleTransport.emit('warn', new Error());
+  });
+});


### PR DESCRIPTION
This ensures that `warn` events from transports are bubbled up to the logger and adds a test case for it. 
I also added a test case for the `error` event.

Closes #1457.