### PR TITLE
Fix/export logger class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ declare namespace winston {
     exceptionHandlers?: any;
   }
 
-  interface Logger extends NodeJSStream.Transform {
+  class Logger extends NodeJSStream.Transform {
     silent: boolean;
     format: logform.Format;
     levels: Config.AbstractConfigSetLevels;
@@ -124,7 +124,7 @@ declare namespace winston {
 
     configure(options: LoggerOptions): void;
 
-    new(options?: LoggerOptions): Logger;
+    constructor (options?: LoggerOptions);
   }
 
   interface Container {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="node" />
 
-import * as stream from "stream";
+import * as NodeJSStream from "stream";
 
 import * as logform from 'logform';
 import * as Transport from 'winston-transport';
@@ -80,7 +80,7 @@ declare namespace winston {
     exceptionHandlers?: any;
   }
 
-  interface Logger extends stream.Transform {
+  interface Logger extends NodeJSStream.Transform {
     silent: boolean;
     format: logform.Format;
     levels: Config.AbstractConfigSetLevels;


### PR DESCRIPTION
The `Logger` is exposed as a proper class under `winston.Logger`.  However, the in the typescript declaration, `Logger` is only listed as an `interface` and not a `class`.  This correctly exports the `Logger` as a class.

Note: Depends on #1474 