### PR TITLE
Fix file tailrolling failure

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -112,6 +112,13 @@ module.exports = class File extends TransportStream {
       });
       return;
     }
+    if (this._rotate) {
+      this._stream.once('rotate', () => {
+        this._rotate = false;
+        this.log(info, callback);
+      });
+      return;
+    }
 
     // Grab the raw string and append the expected EOL.
     const output = `${info[MESSAGE]}${this.eol}`;
@@ -142,6 +149,7 @@ module.exports = class File extends TransportStream {
       // End the current stream, ensure it flushes and create a new one.
       // This could potentially be optimized to not run a stat call but its
       // the safest way since we are supporting `maxFiles`.
+      this._rotate = true;
       this._endStream(() => this._rotateFile());
     }
 
@@ -341,11 +349,15 @@ module.exports = class File extends TransportStream {
       if (err) {
         return this.emit('error', err);
       }
-
       debug('stat done: %s { size: %s }', this.filename, size);
       this._size = size;
       this._dest = this._createStream(this._stream);
       this._opening = false;
+      if (this._stream.eventNames().includes('rotate')) {
+        this._stream.emit('rotate');
+      } else {
+        this._rotate = false;
+      }
     });
   }
 

--- a/test/transports/file-tailrolling.test.js
+++ b/test/transports/file-tailrolling.test.js
@@ -1,16 +1,11 @@
-var assert = require('assert'),
-    rimraf = require('rimraf'),
-    fs = require('fs'),
-    path = require('path'),
-    winston = require('../../lib/winston'),
-    helpers = require('../helpers');
-const asyncSeries = require('async/series');
+/* eslint-disable no-sync */
+const assert = require('assert');
+const rimraf = require('rimraf');
+const fs = require('fs');
+const path = require('path');
+const winston = require('../../lib/winston');
 
-
-
-const { MESSAGE, LEVEL } = require('triple-beam');
-
-
+const { MESSAGE } = require('triple-beam');
 
 //
 // Remove all log fixtures
@@ -23,78 +18,76 @@ function removeFixtures(done) {
 
 let tailrollTransport = null;
 
-describe('winston/transports/file/tailrolling', function(){
-  describe("An instance of the File Transport", function(){
+describe('winston/transports/file/tailrolling', function () {
+  describe('An instance of the File Transport', function () {
     before(removeFixtures);
     after(removeFixtures);
 
-    it('init logger AFTER cleaning up old files', function(){
-	tailrollTransport = new winston.transports.File({
-	  timestamp: false,
-	  json: false,
-	  filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testtailrollingfiles.log'),
-	  maxsize: 4096,
-	  maxFiles: 3,
-	  tailable: true
-	})
-        .on('open', console.log)
+    it('init logger AFTER cleaning up old files', function () {
+      tailrollTransport = new winston.transports.File({
+        timestamp: false,
+        json: false,
+        filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testtailrollingfiles.log'),
+        maxsize: 4096,
+        maxFiles: 3,
+        tailable: true
+      })
+        .on('open', console.log); // eslint-disable-line no-console
     });
 
-    it("and when passed more files than the maxFiles", function(done){
-          let created = 0;
-          let loggedTotal = 0;
-   
-          function data(ch, kb) {
-            return String.fromCharCode(65 + ch).repeat(kb*1024 - 1);
-          };
+    it('and when passed more files than the maxFiles', function (done) {
+      let created = 0;
+      let loggedTotal = 0;
 
-          function logKbytes(kbytes, txt) {
-            const toLog = {};
-	    toLog[MESSAGE] = data(txt, kbytes)
-            tailrollTransport.log(toLog);
-          }
+      function data(ch, kb) {
+        return String.fromCharCode(65 + ch).repeat(kb * 1024 - 1);
+      }
 
-          tailrollTransport.on('logged', function (info) {
-            loggedTotal += info[MESSAGE].length + 1
-            if (loggedTotal >= 14*1024) { // just over 3 x 4kb files
-              return done();
-            }
+      function logKbytes(kbytes, txt) {
+        const toLog = {};
+	      toLog[MESSAGE] = data(txt, kbytes);
+        tailrollTransport.log(toLog);
+      }
 
-            if(loggedTotal % 4096 === 0) {
-              created ++;
-            }
-            setTimeout(() => logKbytes(1, created), 100);
-          });
+      tailrollTransport.on('logged', function (info) {
+        loggedTotal += info[MESSAGE].length + 1;
+        if (loggedTotal >= 14 * 1024) { // just over 3 x 4kb files
+          return done();
+        }
 
-          logKbytes(1, created);
-       });
+        if (loggedTotal % 4096 === 0) {
+          created++;
+        }
+        // eslint-disable-next-line max-nested-callbacks
+        setTimeout(() => logKbytes(1, created), 100);
+      });
 
-       it("should be 3 log files, base to maxFiles - 1", function () {
-          var file, fullpath;
-          for (var num = 0; num < 4; num++) {
-            file = !num ? 'testtailrollingfiles.log' : 'testtailrollingfiles' + num + '.log';
-            fullpath = path.join(__dirname, '..', 'fixtures', 'logs', file);
+      logKbytes(1, created);
+    });
 
-            if (num == 3) {
-              return assert.ok(!fs.existsSync(fullpath));
-            }
+    it('should be 3 log files, base to maxFiles - 1', function () {
+      for (var num = 0; num < 4; num++) {
+        const file = !num ? 'testtailrollingfiles.log' : 'testtailrollingfiles' + num + '.log';
+        const fullpath = path.join(__dirname, '..', 'fixtures', 'logs', file);
 
-            assert.ok(fs.existsSync(fullpath));
-          }
-          
-          return false;
-        });
+        if (num === 3) {
+          return assert.ok(!fs.existsSync(fullpath));
+        }
 
-        it("should have files in correct order", function () {
-          var file, fullpath, content;
-          ['D', 'C', 'B'].forEach(function (letter, i) {
-            file = !i ? 'testtailrollingfiles.log' : 'testtailrollingfiles' + i + '.log';
-            content = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'logs', file), 'ascii');
-            content = content.replace(/\s+/g, '');
+        assert.ok(fs.existsSync(fullpath));
+      }
 
-            assert(content.match(new RegExp(letter, 'g'))[0].length, content.length);
-          });
-        });
-    })
-})
+      return false;
+    });
 
+    it('should have files in correct order', function () {
+      ['D', 'C', 'B'].forEach(function (letter, i) {
+        const file = !i ? 'testtailrollingfiles.log' : 'testtailrollingfiles' + i + '.log';
+        let content = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'logs', file), 'ascii');
+        content = content.replace(/\s+/g, '');
+
+        assert(content.match(new RegExp(letter, 'g'))[0].length, content.length);
+      });
+    });
+  });
+});

--- a/test/transports/file-tailrolling.test.js
+++ b/test/transports/file-tailrolling.test.js
@@ -59,7 +59,7 @@ describe('winston/transports/file/tailrolling', function () {
           created++;
         }
         // eslint-disable-next-line max-nested-callbacks
-        setTimeout(() => logKbytes(1, created), 100);
+        setTimeout(() => logKbytes(1, created), 1);
       });
 
       logKbytes(1, created);


### PR DESCRIPTION
This fixes #1464. The log files are now rotated correctly.

The test now always passes with a 1 millisecond timeout (at least on my machine).