### PR TITLE
fix: assign log levels to un bound functions

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -45,7 +45,8 @@ class DerivedLogger extends Logger {
 
       // Define prototype methods for each log level
       // e.g. logger.log('info', msg) <––> logger.info(msg) & logger.isInfoEnabled()
-      this[level] = (...args) => {
+      // this is not an arrow function so it'll always be called on the instance not at a fixed place in the prototype chain.
+      this[level] = function(...args){
         // Optimize the hot-path which is the single object.
         if (args.length === 1) {
           const [msg] = args;

--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -45,8 +45,8 @@ class DerivedLogger extends Logger {
 
       // Define prototype methods for each log level
       // e.g. logger.log('info', msg) <––> logger.info(msg) & logger.isInfoEnabled()
-      // this is not an arrow function so it'll always be called on the instance not at a fixed place in the prototype chain.
-      this[level] = function(...args){
+      // this is not an arrow function so it'll always be called on the instance instead of a fixed place in the prototype chain.
+      this[level] = function (...args) {
         // Optimize the hot-path which is the single object.
         if (args.length === 1) {
           const [msg] = args;

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -66,6 +66,33 @@ describe('Logger', function () {
     })
   });
 
+  it('new Logger({ levels }) custom methods are not bound to instance', function () {
+
+    var logger = winston.createLogger({
+      level: 'error',
+      exitOnError: false,
+      transports: []
+    });
+
+    let logs = []
+
+    let extendedLogger = Object.create(logger,{
+      write:{
+        value:function(...args){
+          logs.push(args)
+        }
+      }
+    })
+
+    extendedLogger.log({test:1})
+    extendedLogger.warn({test:2})
+
+    assume(logs[0]||[]).is.eql([{test:1}])
+    assume(logs[1]||[]).is.eql([{message:{test:2},level:'warn'}])
+
+
+  });
+
   it('.add({ invalid Transport })', function () {
     var logger = winston.createLogger();
     assume(function () {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -67,30 +67,27 @@ describe('Logger', function () {
   });
 
   it('new Logger({ levels }) custom methods are not bound to instance', function () {
-
     var logger = winston.createLogger({
       level: 'error',
       exitOnError: false,
       transports: []
     });
 
-    let logs = []
+    let logs = [];
 
     let extendedLogger = Object.create(logger,{
       write:{
         value:function(...args){
-          logs.push(args)
+          logs.push(args);
         }
       }
-    })
+    });
 
-    extendedLogger.log({test:1})
-    extendedLogger.warn({test:2})
+    extendedLogger.log({test:1});
+    extendedLogger.warn({test:2});
 
-    assume(logs[0]||[]).is.eql([{test:1}])
-    assume(logs[1]||[]).is.eql([{message:{test:2},level:'warn'}])
-
-
+    assume(logs[0]||[]).is.eql([{test:1}]);
+    assume(logs[1]||[]).is.eql([{message:{test:2},level:'warn'}]);
   });
 
   it('.add({ invalid Transport })', function () {


### PR DESCRIPTION
binding custom log level functions to `this` with arrow functions causes unintentional behavior. 
the expectation is that they should be callable the same way as logger.log

if you extend a logger instance `logger.log` will be called with `logger` being `this` whereas `logger.warn` can only be called with `logger.prototype` as this.

this fixes #1482 but I believe it should be treated as a bug. I doubt blocking extension of only part of the surface area of the logger instance was intended. 

this sets the base for efficient child loggers that only extend write to add attributes.

attn @DABH 

~//todo tests =)~