### PR TITLE
Allowing use of both meta and splat in same call to log()

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -173,7 +173,7 @@ class Logger extends stream.Transform {
     if (typeof meta === 'object' && meta !== null) {
       this.write(Object.assign({}, meta, {
         [LEVEL]: level,
-        [SPLAT]: splat.slice(0),
+        [SPLAT]: splat.slice(1),
         level,
         message: msg
       }));


### PR DESCRIPTION
The `arguments.length` > 2 section in `log()` examines the first item in the `splat` param to see if it's a `meta` object. Problem is, a subsequent call to `splat.slice()` still includes that `meta` object in the `splat`, accidentally calling `slice(0)` instead of `slice(1)`.

Here's an example that breaks under the merge target but works when using the merge source:

```js
const winston = require('winston');

let transports = {
  console: new winston.transports.Console({level: 'info'})
};

let {format} = winston;
let logger = winston.createLogger({
  format: format.combine(
    format.splat(),
    format.printf(info => `[${info.label}]: ${info.message}`)
  ),
  transports: [transports.console]
});

logger.log(
  'info',
  'let\'s %s some %s',
  {label: 'label!'},
  'interpolate',
  'splat parameters'
);
```