### PR TITLE
Fix file tailrolling test failure #2

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity,max-statements */
 /**
  * file.js: Transport for outputting to a local log file.
  *
@@ -353,11 +354,13 @@ module.exports = class File extends TransportStream {
       this._size = size;
       this._dest = this._createStream(this._stream);
       this._opening = false;
-      if (this._stream.eventNames().includes('rotate')) {
-        this._stream.emit('rotate');
-      } else {
-        this._rotate = false;
-      }
+      this.once('open', () => {
+        if (this._stream.eventNames().includes('rotate')) {
+          this._stream.emit('rotate');
+        } else {
+          this._rotate = false;
+        }
+      });
     });
   }
 

--- a/test/log-exception.test.js
+++ b/test/log-exception.test.js
@@ -40,7 +40,7 @@ describe('Logger, ExceptionHandler', function () {
       var logger = winston.createLogger({
         exceptionHandlers: [
           new winston.transports.Console(),
-          new winston.transports.File({ filename: path.join(__dirname, 'fixtures', 'logs', 'filelog.log' )})
+          new winston.transports.File({ filename: path.join(__dirname, 'fixtures', 'logs', 'filelog.log') })
         ]
       });
 
@@ -53,9 +53,9 @@ describe('Logger, ExceptionHandler', function () {
   });
 
   it('Custom exitOnError function does not exit', function (done) {
-    var scriptDir = path.join(__dirname, 'helpers', 'scripts'),
-        child = spawn('node', [path.join(scriptDir, 'exit-on-error.js')]),
-        stdout = [];
+    const scriptDir = path.join(__dirname, 'helpers', 'scripts');
+    const child = spawn('node', [path.join(scriptDir, 'exit-on-error.js')]);
+    const stdout = [];
 
     child.stdout.setEncoding('utf8');
     child.stdout.on('data', function (line) {


### PR DESCRIPTION
Second attempt to fix the file tailrolling test failure.

I wasn't able to reproduce the failure on one of my maschines, but on travic ci in my fork it occured on approximately every third build. 
With the fix I didn't have failures on travic ci anymore. I ran the build about ten times with the fix.

Relates to #1480 and #1464.