### PR TITLE
Add node 11 and disallow failures on node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "11"
 
 before_install:
   - travis_retry npm install
@@ -15,7 +16,7 @@ script:
 
 matrix:
   allow_failures:
-  - node_js: "10"
+  - node_js: "11"
 
 notifications:
   email:


### PR DESCRIPTION
This adds Node 11 to Travis Ci and disallows test failures on Node 10 since it will enter active LTS soon.
