### PR TITLE
fix: set max listeners for Console transport

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -32,7 +32,7 @@ module.exports = class Console extends TransportStream {
     this.consoleWarnLevels = this._stringArrayToSet(options.consoleWarnLevels);
     this.eol = options.eol || os.EOL;
 
-    this.setMaxListeners(30)
+    this.setMaxListeners(30);
   }
 
   /**

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -31,6 +31,8 @@ module.exports = class Console extends TransportStream {
     this.stderrLevels = this._stringArrayToSet(options.stderrLevels);
     this.consoleWarnLevels = this._stringArrayToSet(options.consoleWarnLevels);
     this.eol = options.eol || os.EOL;
+
+    this.setMaxListeners(30)
   }
 
   /**


### PR DESCRIPTION
Suppresses warning provided by Node concerning max event listeners. No functionality change, but silences warnings.

issue #1334 discussion details the warning from Node concerning max event listeners. This was resolved for the file transport in pull #1344, but the warning is also provided for Console transports. This sets the max event listener for the console transport also to 30