### PR TITLE
fix a bug

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -523,7 +523,7 @@ File.prototype._createStream = function () {
     }
 
     function compressFile() {
-      if (self._archive) {
+      if (self._archive && fs.existsSync(self._archive)) {
         var gzip = zlib.createGzip();
 
         var inp = fs.createReadStream(String(self._archive));


### PR DESCRIPTION
* fix: `fs.createReadStream` may throw error `ENOENT: no such file or directory`, when multi process handle same log file
