### PR TITLE
Fix Transform from `readable-stream` using create-react-app

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { Transform } = require('readable-stream');
+const { Stream, Transform } = require('readable-stream');
 const asyncForEach = require('async/forEach');
 const { LEVEL, SPLAT } = require('triple-beam');
 const isStream = require('is-stream');
@@ -398,7 +398,7 @@ class Logger extends Transform {
    * @returns {Stream} - TODO: add return description.
    */
   stream(options = {}) {
-    const out = new stream.Stream();
+    const out = new Stream();
     const streams = [];
 
     out._streams = streams;

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const stream = require('readable-stream');
+const { Transform } = require('readable-stream');
 const asyncForEach = require('async/forEach');
 const { LEVEL, SPLAT } = require('triple-beam');
 const isStream = require('is-stream');
@@ -20,9 +20,9 @@ const config = require('./config');
 /**
  * TODO: add class description.
  * @type {Logger}
- * @extends {stream.Transform}
+ * @extends {Transform}
  */
-class Logger extends stream.Transform {
+class Logger extends Transform {
   /**
    * Constructor function for the Logger object responsible for persisting log
    * messages and metadata to one or more transports.


### PR DESCRIPTION
I've tried using winston using `create-react-app`, however I encountered this issue:
https://github.com/winstonjs/winston/issues/1495#issuecomment-432305343

Looking at the bundled code I noticed that the `stream` variable required from `readable-stream` was not the one used to extend the class `stream.Transform`.

The code would look like:
```
var _stream = __webpack_require__(
  /*! readable-stream */
  "./node_modules/readable-stream/readable-browser.js");

// file content

   }(stream.Transform);
```
instead of
```
_stream.Transform
```

Importing the `Transform` class works as expected.