### PR TITLE
FIX 1338: Error object is not parsed or printed

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -43,13 +43,16 @@ class DerivedLogger extends Logger {
         return;
       }
 
+      //Handle Error Objects
+      const errorMapper = o => o instanceof Error ? { message : o.message || 'Error', stack : o.stack} : o;
+
       // Define prototype methods for each log level
       // e.g. logger.log('info', msg) <––> logger.info(msg) & logger.isInfoEnabled()
       // this is not an arrow function so it'll always be called on the instance instead of a fixed place in the prototype chain.
       this[level] = function (...args) {
         // Optimize the hot-path which is the single object.
         if (args.length === 1) {
-          const [msg] = args;
+          const [msg] = args.map(errorMapper);
           const info = msg && msg.message && msg || { message: msg };
           info.level = info[LEVEL] = level;
           this.write(info);

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -157,6 +157,10 @@ class Logger extends Transform {
       return this;
     }
 
+    //Handle Error Objects
+    const errorMapper = o => o instanceof Error ? { message : o.message || 'Error', stack : o.stack} : o;
+    msg = errorMapper(msg);
+
     // Slightly less hotpath, but worth optimizing for.
     if (arguments.length === 2) {
       if (msg && typeof msg === 'object') {
@@ -169,9 +173,7 @@ class Logger extends Transform {
       return this;
     }
 
-    const errorMapper = o => o instanceof Error ? { message : o.message, stack : o.stack} : o;
     const [meta] = splat;
-    
     if (typeof meta === 'object' && meta !== null) {
       this.write(Object.assign({}, errorMapper(meta), {
         [LEVEL]: level,

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -169,9 +169,11 @@ class Logger extends Transform {
       return this;
     }
 
+    const errorMapper = o => o instanceof Error ? { message : o.message, stack : o.stack} : o;
     const [meta] = splat;
+    
     if (typeof meta === 'object' && meta !== null) {
-      this.write(Object.assign({}, meta, {
+      this.write(Object.assign({}, errorMapper(meta), {
         [LEVEL]: level,
         [SPLAT]: splat.slice(1),
         level,


### PR DESCRIPTION
Simple fix for Error objects being lost when passed as meta

logger.error("blah", new Error("oops"));