### PR TITLE
Always store metadata in info.meta, not just when using string interpolation.

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -171,7 +171,8 @@ class Logger extends Transform {
 
     const [meta] = splat;
     if (typeof meta === 'object' && meta !== null) {
-      this.write(Object.assign({}, meta, {
+      this.write(Object.assign({}, {
+        meta,
         [LEVEL]: level,
         [SPLAT]: splat.slice(1),
         level,

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -679,7 +679,7 @@ describe('Logger (winston@2 logging API)', function () {
       assume(info).is.an('object');
       assume(info.level).equals('info');
       assume(info.message).equals('Some super awesome log message');
-      assume(info.one).equals(2);
+      assume(info.meta.one).equals(2);
       assume(info[MESSAGE]).is.a('string');
       done();
     });
@@ -744,7 +744,7 @@ describe('Logger (logging exotic data types)', function () {
       const logged = [];
       const logger = helpers.createLogger(function (info, enc, next) {
         logged.push(info);
-        assume(info.label).equals('world');
+        assume(info.meta.label).equals('world');
         next();
 
         if (logged.length === 2) done();


### PR DESCRIPTION
This change ensures any logged metadata is always accessible from the info object's meta property (i.e. info.meta), which is consistent with the behavior exhibited when using string interpolation/format.splat.

Prior to 3.0, a custom transport could use the log function's meta argument to access any metadata. Now that the log method's signature only has two arguments (info, callback), it makes sense to have a designated meta property from which to access any metadata. 