### PR TITLE
Alternative fix for #1501 

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -56,6 +56,12 @@ class DerivedLogger extends Logger {
           return this;
         }
 
+        // When provided nothing assume the empty string
+        if (args.length === 0) {
+          this.log(level, '');
+          return this;
+        }
+
         // Otherwise build argument list which could potentially conform to
         // either:
         // . v3 API: log(obj)


### PR DESCRIPTION
@pahan35 interested in your thoughts. Your fix could also work, but this one is more performant.
Assuming implicit argument values is also quite dangerous, but since the level helper methods (e.g. `logger.silly('wat ok')`) were created to be _a little_ magical it seems reasonable to assume that these two statements are equivalent:

``` js
logger.silly();
logger.silly('');
```

Where our fixes differ is that this behavior will still crash someone's program:

```
logger.log('silly');
```

It would crash because the `log` method is not being invoked with the correct number of arguments – which avoids having to add additional variable-arity or type checking into the core `log` method hot path.

If there are no objections will add some tests for this and push it out in the next release. 