### PR TITLE
Add consoleWarnLevels field to the ConsoleTransportOptions interface 

### DIFF
--- a/lib/winston/transports/index.d.ts
+++ b/lib/winston/transports/index.d.ts
@@ -9,6 +9,7 @@ import * as Transport from 'winston-transport';
 
 declare namespace winston {
   interface ConsoleTransportOptions extends Transport.TransportStreamOptions {
+    consoleWarnLevels?: string[],
     stderrLevels?: string[];
     debugStdout?: boolean;
     eol?: string;


### PR DESCRIPTION
fixes issue #1545 