### PR TITLE
Fix README for awaiting logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ const logger = winston.createLogger({
   transports: [transport]
 });
 
-transport.on('finish', function (info) {
+logger.on('finish', function (info) {
   // All `info` log messages has now been logged
 });
 


### PR DESCRIPTION
Small tweak to add the correct code for awaiting all logs to be written.
As it is now, it shows the transport with a 'finish' event, which is incorrect.