### PR TITLE
fix typo related to exitOnError

### DIFF
--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -174,9 +174,9 @@ module.exports = class ExceptionHandler {
 
     if (!handlers.length && doExit) {
       // eslint-disable-next-line no-console
-      console.warn('winston: exitOnError cannot be false with no exception handlers.');
+      console.warn('winston: exitOnError cannot be true with no exception handlers.');
       // eslint-disable-next-line no-console
-      console.warn('winston: exiting process.');
+      console.warn('winston: not exiting process.');
       doExit = false;
     }
 

--- a/lib/winston/rejection-handler.js
+++ b/lib/winston/rejection-handler.js
@@ -176,11 +176,9 @@ module.exports = class RejectionHandler {
 
     if (!handlers.length && doExit) {
       // eslint-disable-next-line no-console
-      console.warn(
-        'winston: exitOnError cannot be false with no rejection handlers.'
-      );
+      console.warn('winston: exitOnError cannot be true with no rejection handlers.');
       // eslint-disable-next-line no-console
-      console.warn('winston: exiting process.');
+      console.warn('winston: not exiting process.');
       doExit = false;
     }
 


### PR DESCRIPTION
When I was reading https://github.com/winstonjs/winston/pull/1355, I found some awkward lines to me.

This might be not that important but I think the log messages are wrong and it might make readers confused.