### PR TITLE
Add gz extension on renaming first file

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -95,7 +95,7 @@ looking for daily log rotation see [DailyRotateFile]
 * __maxFiles:__ Limit the number of files created when the size of the logfile is exceeded.
 * __tailable:__ If true, log files will be rolled based on maxsize and maxfiles, but in ascending order. The __filename__ will always have the most recent log lines. The larger the appended number, the older the log file.  This option requires __maxFiles__ to be set, or it will be ignored.
 * __maxRetries:__ The number of stream creation retry attempts before entering a failed state. In a failed state the transport stays active but performs a NOOP on it's log function. (default 2)
-* __zippedArchive:__ If true, all log files but the current one will be zipped.
+* __zippedArchive:__ If true, all log files will be zipped, including the current one.
 * __options:__ options passed to `fs.createWriteStream` (default `{flags: 'a'}`).
 * __stream:__ **DEPRECATED** The WriteableStream to write output to.
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -679,7 +679,7 @@ module.exports = class File extends TransportStream {
 
     asyncSeries(tasks, () => {
       fs.rename(
-        path.join(this.dirname, `${basename}${ext}`),
+        path.join(this.dirname, `${basename}${ext}${isZipped}`),
         path.join(this.dirname, `${basename}1${ext}${isZipped}`),
         callback
       );


### PR DESCRIPTION
This problem verifies when both zippedArchive and tailable are true
In winston 3.1 you modified the feature brought by zippedArchive option: now a gzipped stream is created for the current file as well. In this case while rotating (tailable), you have to rename `<file>.gz` to `<file>1.gz`.
Relative documentation should be updated too.