### PR TITLE
Expose `child` on default logger

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -169,6 +169,7 @@ declare namespace winston {
   let startTimer: () => Profiler;
   let profile: (id: string | number) => Logger;
   let configure: (options: LoggerOptions) => void;
+  let child(options: Object): Logger;
   let level: string;
   let exceptions: ExceptionHandler;
   let exitOnError: Function | boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -169,7 +169,7 @@ declare namespace winston {
   let startTimer: () => Profiler;
   let profile: (id: string | number) => Logger;
   let configure: (options: LoggerOptions) => void;
-  let child(options: Object): Logger;
+  let child: (options: Object) => Logger;
   let level: string;
   let exceptions: ExceptionHandler;
   let exitOnError: Function | boolean;

--- a/lib/winston.js
+++ b/lib/winston.js
@@ -104,7 +104,8 @@ Object.keys(winston.config.npm.levels)
     'unhandleExceptions',
     'handleRejections',
     'unhandleRejections',
-    'configure'
+    'configure',
+    'child'
   ])
   .forEach(
     method => (winston[method] = (...args) => defaultLogger[method](...args))

--- a/test/winston.test.js
+++ b/test/winston.test.js
@@ -27,7 +27,7 @@ describe('winston', function () {
 
   it('has expected methods', function () {
     assume(winston.config).is.an('object');
-    ['createLogger', 'add', 'remove', 'clear']
+    ['createLogger', 'add', 'remove', 'clear', 'child']
       .concat(Object.keys(winston.config.npm.levels))
       .forEach(function (key) {
         assume(winston[key]).is.a('function', 'winston.' + key);


### PR DESCRIPTION
This allows use to add child loggers to the default logger.

This makes it easy to establish a pattern for sub-components to scope their logs without needing to call `createLogger` or be passed the application logger.

**Example:**

_app.js_
```js
const winston = require('winston');
winston.configure({
  level: 'info',
  format: winston.format.combine(
    winston.format.colorize(),
    winston.format.json()
  ),
  defaultMeta: { service: 'abc-service' },
  transports: [
    new winston.transports.Console()
  ]
})
```

_component-xyz.js_
```js
const logger = require('winston').child({ component: 'xyz-middleware' });
```
