### PR TITLE
[fix] Add support for undefined params

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -172,10 +172,10 @@ Logger.prototype.log = function (level) {
   var ptokens = tokens.filter(function(t) { return t === '%%' });
   if (((args.length - 1) - (tokens.length - ptokens.length)) > 0 || args.length === 1) {
     // last arg is meta
-    meta = args[args.length - 1] || args;
+    meta = args[args.length - 1];
     var metaType = Object.prototype.toString.call(meta);
     validMeta = metaType === '[object Object]' ||
-      metaType === '[object Error]' || metaType === '[object Array]' || '[object Null]' || '[object Undefined]';
+      metaType === '[object Error]' || metaType === '[object Array]';
     meta = validMeta ? args.pop() : {};
   }
   msg = util.format.apply(null, args);

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -175,7 +175,7 @@ Logger.prototype.log = function (level) {
     meta = args[args.length - 1] || args;
     var metaType = Object.prototype.toString.call(meta);
     validMeta = metaType === '[object Object]' ||
-      metaType === '[object Error]' || metaType === '[object Array]';
+      metaType === '[object Error]' || metaType === '[object Array]' || '[object Null]' || '[object Undefined]';
     meta = validMeta ? args.pop() : {};
   }
   msg = util.format.apply(null, args);

--- a/test/log-rewriter-test.js
+++ b/test/log-rewriter-test.js
@@ -96,4 +96,31 @@ vows.describe('winston/logger/rewriter').addBatch({
       }
     }
   }
+}).addBatch({
+  "An instance of winston.Logger": {
+    topic: new (winston.Logger)({transports: [
+      new (winston.transports.Console)({ level: 'info' })
+    ]}),
+    "the addRewriter() method": {
+      topic: function (logger) {
+        logger.rewriters.push(function (level, msg, meta) {
+          return meta;
+        });
+
+        return logger;
+      },
+      "should add the rewriter": function (logger) {
+        assert.equal(helpers.size(logger.rewriters), 1);
+      },
+      "the log() method with undefined last param": {
+        topic: function (logger) {
+          logger.once('logging', this.callback);
+          logger.log('info', 'test message', undefined);
+        },
+        "should run the rewriter with meta as empty object": function (transport, level, msg, meta) {
+          assert.deepEqual(meta, {});
+        }
+      },
+    }
+  }
 }).export(module);


### PR DESCRIPTION
After migrating from `v2.2` to` v2.4` we found that that rewriter return undefined meta if last parameter got undefined. We've spend some time to understand why our projects start failing sometimes. I suggest make it more consistent.