### PR TITLE
Add typings for the isLevelEnabled(string) and isXXXEnabled() functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -124,8 +124,16 @@ declare namespace winston {
     profile(id: string | number, meta?: LogEntry): Logger;
 
     configure(options: LoggerOptions): void;
-    
+
     child(options: Object): Logger;
+
+    isLevelEnabled(level: string): boolean;
+    isErrorEnabled(): boolean;
+    isWarnEnabled(): boolean;
+    isInfoEnabled(): boolean;
+    isVerboseEnabled(): boolean;
+    isDebugEnabled(): boolean;
+    isSillyEnabled(): boolean;
 
     new(options?: LoggerOptions): Logger;
   }

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -49,3 +49,11 @@ const level = container.options.level;
 
 container = new winston.Container();
 logger = container.get('testLogger2');
+
+logger.isLevelEnabled('debug');
+logger.isErrorEnabled();
+logger.isWarnEnabled();
+logger.isInfoEnabled();
+logger.isVerboseEnabled();
+logger.isDebugEnabled();
+logger.isSillyEnabled();


### PR DESCRIPTION
Added types for `isLevelEnabled(level: string)` and `isXXXEnabled()` for each of the default npm levels.

Not sure what the best approach is for the `isXXXEnabled()` functions. Let me know if you have any thoughts or would like to remove these altogether.

Resolves #1621 