### PR TITLE
Ts updates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,17 +56,19 @@ declare namespace winston {
     [optionName: string]: any;
   }
 
-  interface LogMethod {
+   interface LogMethod {
     (level: string, message: string, callback: LogCallback): Logger;
     (level: string, message: string, meta: any, callback: LogCallback): Logger;
     (level: string, message: string, ...meta: any[]): Logger;
     (entry: LogEntry): Logger;
+    (level: string, message: any)
   }
 
   interface LeveledLogMethod {
     (message: string, callback: LogCallback): Logger;
     (message: string, meta: any, callback: LogCallback): Logger;
     (message: string, ...meta: any[]): Logger;
+    (message: any)
     (infoObject: object): Logger;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,6 +78,7 @@ declare namespace winston {
     exitOnError?: Function | boolean;
     defaultMeta?: any;
     transports?: Transport[] | Transport;
+    handleExceptions?: boolean;
     exceptionHandlers?: any;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,14 +61,14 @@ declare namespace winston {
     (level: string, message: string, meta: any, callback: LogCallback): Logger;
     (level: string, message: string, ...meta: any[]): Logger;
     (entry: LogEntry): Logger;
-    (level: string, message: any)
+    (level: string, message: any): Logger;
   }
 
   interface LeveledLogMethod {
     (message: string, callback: LogCallback): Logger;
     (message: string, meta: any, callback: LogCallback): Logger;
     (message: string, ...meta: any[]): Logger;
-    (message: any)
+    (message: any): Logger;
     (infoObject: object): Logger;
   }
 


### PR DESCRIPTION
It is valid for a user to pass `logger.info({some:object})` or the same `logger.log('info',{some:object})` (or even an array or error) and unfortunately that means we need to add an any type to this declaration.