### PR TITLE
Cannot destructure property `message`

### DIFF
--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -73,9 +73,11 @@ module.exports = class ExceptionHandler {
    * @returns {mixed} - TODO: add return description.
    */
   getAllInfo(err) {
-    let { message } = err;
-    if (!message && typeof err === 'string') {
+    let message;
+    if (typeof err === 'string' || err === null) {
       message = err;
+    } else {
+      message = err.message; 
     }
 
     return {


### PR DESCRIPTION
Cannot destructure property `message` of undefined or null.
if `err` is null in `getAllInfo(err)` method. We have a fatal error.