### PR TITLE
Custom log levels can be silent unless level is also specified #1491

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -135,6 +135,11 @@ class Logger extends Transform {
       );
     }
 
+    //logger is not going to log if this is not thrown
+    if (!Object.keys(this.levels).includes(this.level)) {
+      throw new Error(`Logger level "${this.level}" is not in the levels: ${JSON.stringify(this.levels)}`);
+    }
+
     if (exceptionHandlers) {
       this.exceptions.handle(exceptionHandlers);
     }


### PR DESCRIPTION
Added a simple check in logger constructor. Will throw an error if level (default or specified) is not one of the custom log levels defined.

Resolves #1491  