### PR TITLE
Update requires to fix #1578

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -13,7 +13,7 @@ const { LEVEL, SPLAT } = require('triple-beam');
 const isStream = require('is-stream');
 const ExceptionHandler = require('./exception-handler');
 const RejectionHandler = require('./rejection-handler');
-const LegacyTransportStream = require('winston-transport/legacy');
+const LegacyTransportStream = require('winston-transport').LegacyTransportStream;
 const Profiler = require('./profiler');
 const { warn } = require('./common');
 const config = require('./config');
@@ -101,7 +101,7 @@ class Logger extends Transform {
     }
 
     this.silent = silent;
-    this.format = format || this.format || require('logform/json')();
+    this.format = format || this.format || require('logform').format.json();
 
     this.defaultMeta = defaultMeta || null;
     // Hoist other options onto this instance.


### PR DESCRIPTION
This updates the requires to use the exported types to allow bundlers to pick the correct precompiled files.
For more information please see #1578