### PR TITLE
Remove export to ./file in client-side code so Winston works in the browser

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": ["./babel-transform"]
 }

--- a/babel-transform.js
+++ b/babel-transform.js
@@ -1,0 +1,14 @@
+module.exports = () => {
+  return {
+    visitor: {
+      CallExpression(path) {
+        if (!path.container.expression) return;
+
+        const args = path.container.expression.arguments;
+        if (args.length === 3 && args[0].loc && args[0].loc.identifierName === 'exports' && args[1].value === 'File') {
+          path.remove();
+        }
+      }
+    }
+  };
+};


### PR DESCRIPTION
The File transport is included in the browser bundle, which requires the `fs` module and so it blows up when bundling winston with something like Webpack.

This is mostly a proof of concept because the code is hideous, but the idea is to remove that transport completely when building the browser version.

The following code will be removed from the output transports.js file:

```js
Object.defineProperty(exports, 'File', {		
  configurable: true,		
  enumerable: true,		
  get: function get() {		
    return require('./file');		
  }		
});
```

I am sure there is a more elegant way to write the babel transformation, but I've never done one before so I will defer to someone who knows what they're doing as far as best practices.