### PR TITLE
Add detection of log file deletion or renaming.

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -79,7 +79,7 @@ module.exports = class File extends TransportStream {
     this.maxFiles = options.maxFiles || null;
     this.eol = options.eol || os.EOL;
     this.tailable = options.tailable || false;
-
+    this.deleteChecks = options.deleteChecks || true;
     // Internal state variables representing the number of files this instance
     // has created and the current size (in bytes) of the current logfile.
     this._size = 0;
@@ -475,7 +475,16 @@ module.exports = class File extends TransportStream {
    */
   _needsNewFile(size) {
     size = size || this._size;
-    return this.maxsize && size >= this.maxsize;
+    // Checking if the file was deleted or changed.
+    // Note - the check is done asynchronously, 
+    // meaning that the only in the next call the function would return true. 
+    const fullpath = path.join(this.dirname,this.filename);
+    if(!this._opening){
+      fs.stat(fullpath, (err, state) => {
+        this.fileDeleted = (err && err.code === 'ENOENT');
+      })
+    }
+    return (this.maxsize && size >= this.maxsize) || this.fileDeleted;
   }
 
   /**
@@ -551,6 +560,8 @@ module.exports = class File extends TransportStream {
       .on('error', err => debug(err))
       .on('close', () => debug('close', dest.path, dest.bytesWritten))
       .on('open', () => {
+        // reset the fileDeleted flag when a new file was created.
+        this.fileDeleted = false;
         debug('file open ok', fullpath);
         this.emit('open', fullpath);
         source.pipe(dest);
@@ -577,7 +588,7 @@ module.exports = class File extends TransportStream {
 
     return dest;
   }
-
+  
   /**
    * TODO: add method description.
    * @param {function} callback - TODO: add param description.
@@ -657,7 +668,7 @@ module.exports = class File extends TransportStream {
    */
   _checkMaxFilesTailable(ext, basename, callback) {
     const tasks = [];
-    if (!this.maxFiles) {
+    if (!this.maxFiles && !this.fileDeleted) {
       return;
     }
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -88,6 +88,7 @@ module.exports = class File extends TransportStream {
     this._drain = false;
     this._opening = false;
     this._ending = false;
+    this._fileDeleted = false;
 
     if (this.dirname) this._createLogDirIfNotExist(this.dirname);
     this.open();
@@ -475,16 +476,18 @@ module.exports = class File extends TransportStream {
    */
   _needsNewFile(size) {
     size = size || this._size;
-    // Checking if the file was deleted or changed.
-    // Note - the check is done asynchronously, 
-    // meaning that the only in the next call the function would return true. 
-    const fullpath = path.join(this.dirname,this.filename);
-    if(!this._opening){
-      fs.stat(fullpath, (err, state) => {
-        this.fileDeleted = (err && err.code === 'ENOENT');
-      })
+    if(this.deleteChecks){
+      // Checking if the file was deleted or changed.
+      // Note - the check is done asynchronously, 
+      // meaning that the only in the next call the function would return true. 
+      const fullpath = path.join(this.dirname,this.filename);
+      if(!this._opening){
+        fs.stat(fullpath, (err, state) => {
+          this._fileDeleted = (err && err.code === 'ENOENT');
+        })
+      }
     }
-    return (this.maxsize && size >= this.maxsize) || this.fileDeleted;
+    return (this.maxsize && size >= this.maxsize) || this._fileDeleted;
   }
 
   /**
@@ -561,7 +564,7 @@ module.exports = class File extends TransportStream {
       .on('close', () => debug('close', dest.path, dest.bytesWritten))
       .on('open', () => {
         // reset the fileDeleted flag when a new file was created.
-        this.fileDeleted = false;
+        this._fileDeleted = false;
         debug('file open ok', fullpath);
         this.emit('open', fullpath);
         source.pipe(dest);
@@ -588,7 +591,7 @@ module.exports = class File extends TransportStream {
 
     return dest;
   }
-  
+
   /**
    * TODO: add method description.
    * @param {function} callback - TODO: add param description.
@@ -668,7 +671,7 @@ module.exports = class File extends TransportStream {
    */
   _checkMaxFilesTailable(ext, basename, callback) {
     const tasks = [];
-    if (!this.maxFiles && !this.fileDeleted) {
+    if (!this.maxFiles && !this._fileDeleted) {
       return;
     }
 


### PR DESCRIPTION
**Issue:**
Currently, when a log file is deleted or renamed the logs are not being logged to any file and the logs are lost.

**Suggestion:**
Check for file state changes and when detecting the deletion or renaming of a file initiate a new file creating. The new file creation would use the already implemented mechanism meaning that the "tailable" configuration won't be affected.
This solution would provide 2 benefits:
1) Never lose loges in an event the file was deleted.
2) Manual log rotation would be possible.