### PR TITLE
Update .travis.yml to support Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
   - "11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "8"
   - "10"
   - "11"
+  - "12"
 
 before_install:
   - travis_retry npm install
@@ -16,7 +17,7 @@ script:
 
 matrix:
   allow_failures:
-  - node_js: "11"
+  - node_js: "12"
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ version: "{build}"
 
 environment:
   matrix:
-    - nodejs_version: 6
     - nodejs_version: 8
     - nodejs_version: 10
+    - nodejs_version: 12
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This adds Node.js 12 to the test matrix to make sure everything passes as expected.
Node.js 11 is in maintenance and won't receive significant changes anymore, so I updated that as well (no test failures should be accepted).