### PR TITLE
UPDATE levels on readme (http added)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,13 @@ from most important to least important._
 
 ``` js
 const levels = { 
-  error: 0, 
-  warn: 1, 
-  info: 2, 
-  verbose: 3, 
-  debug: 4, 
-  silly: 5 
+  error: 0,
+  warn: 1,
+  info: 2,
+  http: 3,
+  verbose: 4,
+  debug: 5,
+  silly: 6
 };
 ```
 


### PR DESCRIPTION
README currently displays 5 logging levels, while the correct should be 6. Http loggging level was added.