### PR TITLE
logger method can be called without any arguments

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -72,8 +72,8 @@ module.exports = function (opts = {}) {
       // Prefer any instance scope, but default to "root" logger
       const self = this || logger;
 
-      // Optimize the hot-path which is the single object.
-      if (args.length === 1) {
+      // Optimize the hot-path which might be a single object.
+      if (args.length === 0 || args.length === 1) {
         const [msg] = args;
         const info = msg && msg.message && msg || { message: msg };
         info.level = info[LEVEL] = level;

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -296,6 +296,23 @@ describe('Logger (levels)', function () {
     var logger = helpers.createLogger(function (info) {
       assume(info).is.an('object');
       assume(info.level).equals('info');
+      assume(info.message).is.a('undefined');
+      assume(info[MESSAGE]).is.a('string');
+      assume(info.message).equals('');
+      assume(info[MESSAGE]).equals(JSON.stringify({
+        level: 'info'
+      }));
+
+      done();
+    });
+
+    logger.info();
+  });
+
+  it('.<level>(\'\')', function (done) {
+    var logger = helpers.createLogger(function (info) {
+      assume(info).is.an('object');
+      assume(info.level).equals('info');
       assume(info.message).is.a('string');
       assume(info[MESSAGE]).is.a('string');
       assume(info.message).equals('');
@@ -307,7 +324,6 @@ describe('Logger (levels)', function () {
       done();
     });
 
-    logger.info();
     logger.info('');
   });
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -298,7 +298,6 @@ describe('Logger (levels)', function () {
       assume(info.level).equals('info');
       assume(info.message).is.a('undefined');
       assume(info[MESSAGE]).is.a('string');
-      assume(info.message).equals('');
       assume(info[MESSAGE]).equals(JSON.stringify({
         level: 'info'
       }));
@@ -317,8 +316,8 @@ describe('Logger (levels)', function () {
       assume(info[MESSAGE]).is.a('string');
       assume(info.message).equals('');
       assume(info[MESSAGE]).equals(JSON.stringify({
-        level: 'info',
-        message: ''
+        message: '',
+        level: 'info'
       }));
 
       done();


### PR DESCRIPTION
We should allow log method to be called without passing any arguments to it, currently if we don't do that then it results in error -

e.g. Sails uses below kind of logs -

https://github.com/balderdashy/sails/blob/v1.2.2/bin/sails-run.js#L59
sails.log.error();

https://github.com/balderdashy/sails/blob/v1.2.2/lib/app/lift.js#L110
sails.log.silly();

Fixes #1438 