### PR TITLE
Add Slack Winston transport

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -49,6 +49,7 @@ there are additional transports written by
   * [Papertrail](#papertrail-transport)
   * [Pusher](#pusher-transport)
   * [SimpleDB](#simpledb-transport)
+  * [Slack](#slack-transport)
   * [SSE with KOA 2](#sse-transport-with-koa-2)
   * [Sumo Logic](#sumo-logic-transport)
   * [Winlog2 Transport](#winlog2-transport)
@@ -629,6 +630,38 @@ The SimpleDB transport takes the following options. All items marked with an ast
 
 *Metadata:* Logged as a native JSON object to the 'meta' attribute of the item.
 
+### Slack Transport
+[winston-slack-webhook-transport][38] is a transport that sends all log messages to the Slack chat service. 
+
+```js
+const winston = require('winston');
+const SlackHook = require('winston-slack-webhook-transport');
+
+const logger = winston.createLogger({
+	level: 'info',
+	transports: [
+		new SlackHook({
+			webhookUrl: 'https://hooks.slack.com/services/xxx/xxx/xxx'
+		})
+	]
+});
+
+logger.info('This should now appear on Slack');
+```
+
+This transport takes the following options: 
+
+* __webhookUrl__ - Slack incoming webhook URL. This can be from a basic integration or a bot. **REQUIRED**
+* __channel__ - Slack channel to post message to.
+* __username__ - Username to post message with.
+* __iconEmoji__ - Status icon to post message with. (interchangeable with __iconUrl__)
+* __iconUrl__ - Status icon to post message with. (interchangeable with __iconEmoji__)
+* __formatter__ - Custom function to format messages with. This function accepts the __info__ object ([see Winston documentation](https://github.com/winstonjs/winston/blob/master/README.md#streams-objectmode-and-info-objects)) and must return an object with at least one of the following three keys: __text__ (string), __attachments__ (array of [attachment objects](https://api.slack.com/docs/message-attachments)), __blocks__ (array of [layout block objects](https://api.slack.com/messaging/composing/layouts)). These will be used to structure the format of the logged Slack message. By default, messages will use the format of `[level]: [message]` with no attachments or layout blocks.
+* __level__ - Level to log. Global settings will apply if this is blank.
+* __unfurlLinks__ - Enables or disables [link unfurling.](https://api.slack.com/docs/message-attachments#unfurling) (Default: false)
+* __unfurlMedia__ - Enables or disables [media unfurling.](https://api.slack.com/docs/message-link-unfurling) (Default: false)
+* __mrkdwn__ - Enables or disables [`mrkdwn` formatting](https://api.slack.com/messaging/composing/formatting#basics) within attachments or layout blocks (Default: false)
+
 ### Sumo Logic Transport
 [winston-sumologic-transport][32] is a transport for Sumo Logic
 
@@ -798,3 +831,4 @@ That's why we say it's a logger for just about everything
 [35]: https://github.com/SerayaEryn/fast-file-rotate
 [36]: https://github.com/inspiredjw/winston-dynamodb
 [37]: https://github.com/logdna/logdna-winston
+[38]: https://github.com/TheAppleFreak/winston-slack-webhook-transport


### PR DESCRIPTION
* Adds `winston-slack-webhook-transport`, a transport to send all logs to the Slack chat service, to the list of community transports.
* Adds documentation on how to configure the transport