### PR TITLE
Do Not Concatenate Error Message When An Error Stack is Present

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,13 +280,16 @@ console.log(SPLAT === Symbol.for('splat'));
 ```
 
 > **NOTE:** any `{ message }` property in a `meta` object provided will
-> automatically be concatenated to any `msg` already provided: For 
+> automatically be concatenated to any `message` already provided. For
 > example the below will concatenate 'world' onto 'hello':
 >
 > ``` js
 > logger.log('error', 'hello', { message: 'world' });
 > logger.info('hello', { message: 'world' });
 > ```
+>
+> The `{ message }` property of an `Error` with a `stack` will *not* be
+> concatenated to the previous `message`.
 
 ## Formats
 

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -238,8 +238,9 @@ class Logger extends Transform {
           message: msg
         });
 
-        if (meta.message) info.message += `${meta.message}`;
+        // Do not modify message if error stack is available.
         if (meta.stack) info.stack = meta.stack;
+        else if (meta.message) info.message += `${meta.message}`;
 
         this.write(info);
         return this;


### PR DESCRIPTION
Normally, the functionality described to concatenate the `message` properties of additional `meta` objects makes sense. However, when the `meta` object is an `Error`, this does not make sense: a custom `printf` that prints the stack will double-print the `Error.message` as it is by default included in the `Error.stack`.

Example:
```
error: Exception raised when calling methodConnection closed.                                                        
Error: Connection closed.                                                                                                
    at WebSocket.closeListener (C:\Users\me\Desktop\project\src\index.js:96:16)              
    at WebSocket.emit (events.js:194:15)                                                                                 
    at WebSocket.emitClose (C:\Users\me\Desktop\project\node_modules\ws\lib\websocket.js:191:10)                  
    at Socket.socketOnClose (C:\Users\me\Desktop\project\node_modules\ws\lib\websocket.js:850:15)                 
    at Socket.emit (events.js:189:13)                                                                                    
    at TCP._handle.close (net.js:597:12)
```

Therefore, if a `stack` property exists in the meta object, do not append the `message` to the initial `message`.

Related:
https://github.com/winstonjs/winston/issues/1338