### PR TITLE
Handle circular reference errors in http transport

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -166,6 +166,7 @@ module.exports = class Http extends TransportStream {
    * handle json-rpc.
    * @param {function} options - Options to sent the request.
    * @param {function} callback - Continuation to respond to when complete.
+   * @returns {undefined}
    */
   _request(options, callback) {
     options = options || {};
@@ -191,6 +192,11 @@ module.exports = class Http extends TransportStream {
     req.on('response', res => (
       res.on('end', () => callback(null, res)).resume()
     ));
-    req.end(Buffer.from(JSON.stringify(options), 'utf8'));
+
+    try {
+      req.end(Buffer.from(JSON.stringify(options), 'utf8'));
+    } catch (err) {
+      return callback(err);
+    }
   }
 };


### PR DESCRIPTION
Hi,

right now attempt to log object with circular reference leads to unhandled promise rejection. This PR should fix it..

Thanks