### PR TITLE
Add ignore broken lines option to File Transport Query. Closes #1514

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -240,7 +240,7 @@ module.exports = class File extends TransportStream {
 
       for (; i < l; i++) {
         if (!options.start || row >= options.start) {
-          add(data[i]);
+          add(data[i], options.ignoreBorkenLines);
         }
         row++;
       }
@@ -344,6 +344,9 @@ module.exports = class File extends TransportStream {
 
       // 'asc' or 'desc'
       options.order = options.order || 'desc';
+
+      // ignore broken lines
+      options.ignoreBorkenLines = options.ignoreBorkenLines || false;
 
       return options;
     }


### PR DESCRIPTION
Add the option `ignoreBrokenLines` to `FileTransport.query`.
This allows to ignore invalid JSON lines so one corrupted entry wont fail the entire query.

Default behavior wont be affected.

See #1514
