### PR TITLE
Add default metadata when calling log with string level and message

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -220,7 +220,9 @@ class Logger extends Transform {
         return this;
       }
 
-      this.write({ [LEVEL]: level, level, message: msg });
+      msg = { [LEVEL]: level, level, message: msg };
+      this._addDefaultMeta(msg);
+      this.write(msg);
       return this;
     }
 


### PR DESCRIPTION
### The problem

When calling `logger.log` with two string values it does not add the values from `defaultMeta`.

### Before

```
const logger = winston.createLogger({
  defaultMeta: {testing: 'it works!'},
  transports: [new Console()],
});
logger.log('info', 'did it work?'); // {"level":"info","message":"did it work?"}
```

### After

```
const logger = winston.createLogger({
  defaultMeta: {testing: 'it works!'},
  transports: [new Console()],
});
logger.log('info', 'did it work?'); // {"level":"info","message":"did it work?","testing":"it works!"}
```