### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ import * as Transports from './lib/winston/transports/index';
 declare namespace winston {
   // Hoisted namespaces from other modules
   export import format = logform.format;
+  export import Logform = logform;
   export import config = Config;
   export import transports = Transports;
 


### PR DESCRIPTION
Hoist type defs from the logform module.

Currently there isn't a way to write correct type definitions for
when e.g creating a format since the types for such objects are
declared in `logform`.
This patch move logform type defs so that they can be used by
user code - For example by doing:

`import { Logform } from 'winston'; const f: Logform.Format;`