### PR TITLE
Add defaultMeta to Logger index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,7 @@ declare namespace winston {
     exceptions: ExceptionHandler;
     profilers: object;
     exitOnError: Function | boolean;
+    defaultMeta?: any;
 
     log: LogMethod;
     add(transport: Transport): Logger;


### PR DESCRIPTION
The defaultMeta property was missing on the Logger interface