### PR TITLE
Add space between `info.message` and `meta.message`

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -238,7 +238,7 @@ class Logger extends Transform {
           message: msg
         });
 
-        if (meta.message) info.message += `${meta.message}`;
+        if (meta.message) info.message = `${info.message} ${meta.message}`;
         if (meta.stack) info.stack = meta.stack;
 
         this.write(info);

--- a/test/formats/errors.test.js
+++ b/test/formats/errors.test.js
@@ -110,7 +110,7 @@ describe('format.errors (integration)', function () {
       format.printf(info => info.message)
     ));
 
-    logger.log('info', 'Caught error: ', new Error('Errors lack .toJSON() lulz'));
+    logger.log('info', 'Caught error:', new Error('Errors lack .toJSON() lulz'));
   });
 
   it('logger.log(level, msg, meta<error>) [custom error properties]', (done) => {
@@ -132,7 +132,7 @@ describe('format.errors (integration)', function () {
       format.printf(info => info.message)
     ));
 
-    logger.log('info', 'Caught error: ', err);
+    logger.log('info', 'Caught error:', err);
   });
 
   it('logger.<level>(error)', (done) => {
@@ -209,7 +209,7 @@ describe('format.errors (integration)', function () {
       format.printf(info => info.message)
     ));
 
-    logger.info('Caught error: ', new Error('Errors lack .toJSON() lulz'));
+    logger.info('Caught error:', new Error('Errors lack .toJSON() lulz'));
   });
 
   it('logger.<level>(msg, meta<error>) [custom error properties]', (done) => {
@@ -231,7 +231,7 @@ describe('format.errors (integration)', function () {
       format.printf(info => info.message)
     ));
 
-    logger.info('Caught error: ', err);
+    logger.info('Caught error:', err);
   });
 
   it(`Promise.reject().catch(logger.<level>)`, (done) => {


### PR DESCRIPTION
Fix #1739 