### PR TITLE
Fix error: Cannot destructure property `message` of 'undefined' or 'n…

### DIFF
--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -73,7 +73,7 @@ module.exports = class ExceptionHandler {
    * @returns {mixed} - TODO: add return description.
    */
   getAllInfo(err) {
-    let { message } = err;
+    let { message } = err || {};
     if (!message && typeof err === 'string') {
       message = err;
     }


### PR DESCRIPTION
…ull'

Fix error: Cannot destructure property `message` of 'undefined' or 'null' on getAllInfo(err)
    at ExceptionHandler.getAllInfo (node_modules/winston/lib/winston/exception-handler.js:76:9)
    at ExceptionHandler._uncaughtException (node_modules/winston/lib/winston/exception-handler.js:167:23)
    at process.emit (events.js:215:7)
    at process.EventEmitter.emit (domain.js:475:20)
    at process._fatalException (internal/process/execution.js:150:25)