### PR TITLE
[Doc] Update Sentry transport `require` change

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -697,7 +697,7 @@ This transport sends the logs to a Pusher app for real time processing and it us
 [winston-transport-sentry-node][41] is a transport for [Sentry](https://sentry.io/) uses [@sentry/node](https://www.npmjs.com/package/@sentry/node).
 
 ```js
-const Sentry = require('winston-transport-sentry-node');
+const Sentry = require('winston-transport-sentry-node').default;
 logger.add(new Sentry({
   sentry: {
     dsn: 'https://******@sentry.io/12345',


### PR DESCRIPTION
- use `.default`, if not will shown `TypeError: Sentry is not a constructor`

reference to https://github.com/aandrewww/winston-transport-sentry-node