### PR TITLE
Add options to request of HTTP transport

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -26,6 +26,7 @@ module.exports = class Http extends TransportStream {
   constructor(options = {}) {
     super(options);
 
+    this.options = options;
     this.name = options.name || 'http';
     this.ssl = !!options.ssl;
     this.host = options.host || 'localhost';
@@ -182,6 +183,7 @@ module.exports = class Http extends TransportStream {
       headers['Authorization'] = `Bearer ${auth.bearer}`;
     }
     const req = (this.ssl ? https : http).request({
+      ...this.options,
       method: 'POST',
       host: this.host,
       port: this.port,


### PR DESCRIPTION
I have a server where I need to [authenticate over certificates](https://stackoverflow.com/a/35478865). This is currently not possible with HTTP transport. This pull requests adds a functionality to add options to your request.