### PR TITLE
fix: change property of handleRejections

### DIFF
--- a/lib/winston/rejection-handler.js
+++ b/lib/winston/rejection-handler.js
@@ -150,7 +150,7 @@ module.exports = class RejectionHandler {
    */
   _addHandler(handler) {
     if (!this.handlers.has(handler)) {
-      handler.handleExceptions = true;
+      handler.handleRejections = true;
       const wrapper = new ExceptionStream(handler);
       this.handlers.set(handler, wrapper);
       this.logger.pipe(wrapper);


### PR DESCRIPTION
I think the changes should be applied to make rejection handling works. 
The current version does pass the tests since the issue arises later when rejection-handler.js => _getRejectionHandlers() is invoked. This method filters all transports to find ones with **handleRejections** property which is never assigned.