### PR TITLE
Enable child logger to override parent metadata

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -42,14 +42,17 @@ class Logger extends Transform {
     this.configure(options);
   }
 
-  child(defaultRequestMetadata) {
+  child(defaultMetadata) {
     const logger = this;
     return Object.create(logger, {
+      defaultMeta: {
+        value: Object.assign({}, logger.defaultMeta, defaultMetadata)
+      },
       write: {
         value: function (info) {
           const infoClone = Object.assign(
             {},
-            defaultRequestMetadata,
+            defaultMetadata,
             info
           );
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -997,6 +997,9 @@ describe('Should support child loggers & defaultMeta', () => {
     });
 
     const logger = winston.createLogger({
+      defaultMeta: {
+        service: "dummy-service"
+      },
       transports: [
         mockTransport.createMockTransport(assertFn)
       ]


### PR DESCRIPTION
Currently parent logger defaultMeta cannot be overridden in child logger.
Should resolve #1596 , this is alternative PR to  with less functionality breaking #1598 