### PR TITLE
Fix removes a logger when pass undefined transport

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -373,6 +373,7 @@ class Logger extends Transform {
    * @returns {Logger} - TODO: add return description.
    */
   remove(transport) {
+    if (!transport) return this;
     let target = transport;
     if (!isStream(transport) || transport.log.length > 2) {
       target = this.transports.filter(


### PR DESCRIPTION
While working with winston, I found a small bug. When you pass `undefined` transport in logger.remove() method it removes the logger. Ideally it should not do anything.

You can follow below steps to reproduce this:

```javascript
const logger = winston.createLogger({
    level: 'info',
    format: winston.format.simple(),
    timestamp: true,
    defaultMeta: { service: 'user-service', deploymentId: 'abcd', 'containerId': 'kube-5' },
});
const consoleLogger = new winston.transports.Console({
    format: winston.format.simple(),
    timestamp: true,
    level: 'debug',
    logId:'console'
});

logger.add(consoleLogger);

logger.info('Hello!'); // This statement logs perfectly

logger.remove(undefined);

logger.info('Hi'); //This statement logs nothing as the logger got removed.
```

