### PR TITLE
This adds Node.js 14 and removes Node.js 8 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
-  - "13"
+  - "14"
 
 before_install:
   - travis_retry npm install
@@ -16,7 +15,7 @@ script:
 
 matrix:
   allow_failures:
-  - node_js: "13"
+  - node_js: "14"
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ version: "{build}"
 
 environment:
   matrix:
-    - nodejs_version: 8
     - nodejs_version: 10
     - nodejs_version: 12
+    - nodejs_version: 14
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Because Node.js v8 is EOL since December 31, 2019