### PR TITLE
fix: use console.log/warn/error when possible

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -46,12 +46,12 @@ module.exports = class Console extends TransportStream {
 
     // Remark: what if there is no raw...?
     if (this.stderrLevels[info[LEVEL]]) {
-      if (console._stderr) {
-        // Node.js maps `process.stderr` to `console._stderr`.
-        console._stderr.write(`${info[MESSAGE]}${this.eol}`);
-      } else {
+      if (this.eol === '\n') {
         // console.error adds a newline
         console.error(info[MESSAGE]);
+      } else {
+        // Node.js maps `process.stderr` to `console._stderr`.
+        console._stderr.write(`${info[MESSAGE]}${this.eol}`);
       }
 
       if (callback) {
@@ -59,13 +59,13 @@ module.exports = class Console extends TransportStream {
       }
       return;
     } else if (this.consoleWarnLevels[info[LEVEL]]) {
-      if (console._stderr) {
+      if (this.eol === '\n') {
+        // console.warn adds a newline
+        console.warn(info[MESSAGE]);
+      } else {
         // Node.js maps `process.stderr` to `console._stderr`.
         // in Node.js console.warn is an alias for console.error
         console._stderr.write(`${info[MESSAGE]}${this.eol}`);
-      } else {
-        // console.warn adds a newline
-        console.warn(info[MESSAGE]);
       }
 
       if (callback) {
@@ -74,12 +74,12 @@ module.exports = class Console extends TransportStream {
       return;
     }
 
-    if (console._stdout) {
-      // Node.js maps `process.stdout` to `console._stdout`.
-      console._stdout.write(`${info[MESSAGE]}${this.eol}`);
-    } else {
+    if (this.eol === '\n') {
       // console.log adds a newline.
       console.log(info[MESSAGE]);
+    } else {
+      // Node.js maps `process.stdout` to `console._stdout`.
+      console._stdout.write(`${info[MESSAGE]}${this.eol}`);
     }
 
     if (callback) {


### PR DESCRIPTION
Fixes #1544.

The Node.js console does not use os.EOL (nodejs/node#5038).