### PR TITLE
Fix export from TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -190,4 +190,4 @@ declare namespace winston {
   // let default: object;
 }
 
-export = winston;
+export default winston;

--- a/index.d.ts
+++ b/index.d.ts
@@ -191,3 +191,4 @@ declare namespace winston {
 }
 
 export default winston;
+export { winston };


### PR DESCRIPTION
This pull request intends to remove the export of `export = winston` which fails for us since TypeScript 3.9 with the TS2498 error. The alternative to my understanding is to use `export default`. This however might impact what TypeScript version the typings are usable by.