### PR TITLE
Fix typing for Profile.start (was Date, should be Number)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ declare namespace winston {
 
   interface Profiler {
     logger: Logger;
-    start: Date;
+    start: Number;
     done(info?: any): boolean;
   }
 


### PR DESCRIPTION
`Profile.start` is actually a number:

https://github.com/winstonjs/winston/blob/master/lib/winston/profiler.js#L29
```js
this.start = Date.now();
```