### PR TITLE
Fix bugs in `createLogger` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,7 @@ declare namespace winston {
     exitOnError?: Function | boolean;
     defaultMeta?: any;
     transports?: Transport[] | Transport;
+    handleExceptions?: boolean;
     exceptionHandlers?: any;
   }
 
@@ -133,6 +134,14 @@ declare namespace winston {
     configure(options: LoggerOptions): void;
 
     child(options: Object): Logger;
+
+    isLevelEnabled(level: string): boolean;
+    isErrorEnabled(): boolean;
+    isWarnEnabled(): boolean;
+    isInfoEnabled(): boolean;
+    isVerboseEnabled(): boolean;
+    isDebugEnabled(): boolean;
+    isSillyEnabled(): boolean;
 
     new(options?: LoggerOptions): Logger;
   } & {[K in keyof T]: LeveledLogMethod;}

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ declare namespace winston {
     [optionName: string]: any;
   }
 
-   interface LogMethod {
+  interface LogMethod {
     (level: string, message: string, callback: LogCallback): Logger;
     (level: string, message: string, meta: any, callback: LogCallback): Logger;
     (level: string, message: string, ...meta: any[]): Logger;
@@ -74,19 +74,40 @@ declare namespace winston {
     (infoObject: object): Logger;
   }
 
-  interface LoggerOptions {
-    levels?: Config.AbstractConfigSetLevels;
+  interface LoggerOptions<T extends Config.AbstractConfigSetLevels = Config.AbstractConfigSetLevels> {
+    levels?: T;
     silent?: boolean;
     format?: logform.Format;
     level?: string;
     exitOnError?: Function | boolean;
     defaultMeta?: any;
     transports?: Transport[] | Transport;
-    handleExceptions?: boolean;
     exceptionHandlers?: any;
   }
 
-  interface Logger extends NodeJSStream.Transform {
+  type DefaulLevels = {
+    // for cli and npm levels
+    error: number;
+    warn: number;
+    help: number;
+    data: number;
+    info: number;
+    debug: number;
+    prompt: number;
+    http: number;
+    verbose: number;
+    input: number;
+    silly: number;
+    
+    // for syslog levels only
+    emerg: number;
+    alert: number;
+    crit: number;
+    warning: number;
+    notice: number;
+  }
+
+  type Logger<T extends Config.AbstractConfigSetLevels = DefaulLevels> = NodeJSStream.Transform & {
     silent: boolean;
     format: logform.Format;
     levels: Config.AbstractConfigSetLevels;
@@ -103,26 +124,6 @@ declare namespace winston {
     clear(): Logger;
     close(): Logger;
 
-    // for cli and npm levels
-    error: LeveledLogMethod;
-    warn: LeveledLogMethod;
-    help: LeveledLogMethod;
-    data: LeveledLogMethod;
-    info: LeveledLogMethod;
-    debug: LeveledLogMethod;
-    prompt: LeveledLogMethod;
-    http: LeveledLogMethod;
-    verbose: LeveledLogMethod;
-    input: LeveledLogMethod;
-    silly: LeveledLogMethod;
-
-    // for syslog levels only
-    emerg: LeveledLogMethod;
-    alert: LeveledLogMethod;
-    crit: LeveledLogMethod;
-    warning: LeveledLogMethod;
-    notice: LeveledLogMethod;
-
     query(options?: QueryOptions, callback?: (err: Error, results: any) => void): any;
     stream(options?: any): NodeJS.ReadableStream;
 
@@ -133,16 +134,8 @@ declare namespace winston {
 
     child(options: Object): Logger;
 
-    isLevelEnabled(level: string): boolean;
-    isErrorEnabled(): boolean;
-    isWarnEnabled(): boolean;
-    isInfoEnabled(): boolean;
-    isVerboseEnabled(): boolean;
-    isDebugEnabled(): boolean;
-    isSillyEnabled(): boolean;
-
     new(options?: LoggerOptions): Logger;
-  }
+  } & {[K in keyof T]: LeveledLogMethod;}
 
   interface Container {
     loggers: Map<string, Logger>;
@@ -162,7 +155,7 @@ declare namespace winston {
   let loggers: Container;
 
   let addColors: (target: Config.AbstractConfigSetColors) => any;
-  let createLogger: (options?: LoggerOptions) => Logger;
+  let createLogger: <T extends Config.AbstractConfigSetLevels = DefaulLevels>(options?: LoggerOptions<T>) => Logger<T>;
 
   // Pass-through npm level methods routed to the default logger.
   let error: LeveledLogMethod;


### PR DESCRIPTION
There is a lack of type correctness, and it causes TypeScript error when we set `levels` option.
This PR aims to fix it.

# Problem

We can set `levels` option in `createLogger`. For this option, you can use any string as a log level.

However, in the type world, it wasn't accepted. 

<img width="546" alt="スクリーンショット 2020-06-11 22 05 00" src="https://user-images.githubusercontent.com/31976113/84388486-a59a1380-ac2f-11ea-86a5-a4fe82b7ca12.png">

Additionally, there is more bug in here.

Following [the implementation](https://github.com/winstonjs/winston/blob/master/lib/winston/create-logger.js#L29), if we set the `levels` option, the default levels options are overridden. However, in type world, it was accepted.

<img width="600" alt="スクリーンショット 2020-06-11 22 13 13" src="https://user-images.githubusercontent.com/31976113/84389281-c4e57080-ac30-11ea-9a90-9e78928c71b3.png">

# After this PR

Works with `levels` option.

<img width="937" alt="スクリーンショット 2020-06-11 22 18 04" src="https://user-images.githubusercontent.com/31976113/84389765-856b5400-ac31-11ea-8bb4-0109887439f2.png">

Of course, without `levels` option, default `levels` are inferred correctly.

<img width="642" alt="スクリーンショット 2020-06-11 22 18 38" src="https://user-images.githubusercontent.com/31976113/84389775-88fedb00-ac31-11ea-8212-212c5e0bd2bb.png">


