### PR TITLE
Fix issue #1817

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,7 +111,7 @@ declare namespace winston {
   type Logger<T extends Config.AbstractConfigSetLevels = DefaulLevels> = NodeJSStream.Transform & {
     silent: boolean;
     format: logform.Format;
-    levels: Config.AbstractConfigSetLevels;
+    levels: T;
     level: string;
     transports: Transport[];
     exceptions: ExceptionHandler;

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare namespace winston {
     exceptionHandlers?: any;
   }
 
-  type DefaulLevels = {
+  type DefaultLevels = {
     // for cli and npm levels
     error: number;
     warn: number;
@@ -108,7 +108,7 @@ declare namespace winston {
     notice: number;
   }
 
-  type Logger<T extends Config.AbstractConfigSetLevels = DefaulLevels> = NodeJSStream.Transform & {
+  type Logger<T extends Config.AbstractConfigSetLevels = DefaultLevels> = NodeJSStream.Transform & {
     silent: boolean;
     format: logform.Format;
     levels: T;
@@ -164,7 +164,7 @@ declare namespace winston {
   let loggers: Container;
 
   let addColors: (target: Config.AbstractConfigSetColors) => any;
-  let createLogger: <T extends Config.AbstractConfigSetLevels = DefaulLevels>(options?: LoggerOptions<T>) => Logger<T>;
+  let createLogger: <T extends Config.AbstractConfigSetLevels = DefaultLevels>(options?: LoggerOptions<T>) => Logger<T>;
 
   // Pass-through npm level methods routed to the default logger.
   let error: LeveledLogMethod;


### PR DESCRIPTION
This PR should fix [this](https://github.com/winstonjs/winston/issues/1817) issue.

It should correct a typo for `DefaultLevels` type, previously `DefaulLevels` (missing `t`).

This is my first ever PR here so please, be kind to me :smile: 