### PR TITLE
Unbind uncaught exception/rejection event listeners on close

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -402,6 +402,8 @@ class Logger extends Transform {
    * @returns {Logger} - TODO: add return description.
    */
   close() {
+    this.exceptions.unhandle();
+    this.rejections.unhandle();
     this.clear();
     this.emit('close');
     return this;


### PR DESCRIPTION
This patch hopefully fixes Issue #1706, closing a small memory leak evident when loggers are repeatedly opened and closed.  It has only been lightly rather than rigorously tested (issue observed without but not with the patch), but is submitted in the hopes it may be helpful.

Until such time as the patch is adopted into Winston core, the workaround is to call `logger.exceptions.unhandle();` and/or `logger.rejections.unhandle();` before calling logger.close(); on a logger that was created or subsequently altered to have `handleExceptions` and/or `handleRejections` (respectively) `true`.

For semver purposes, this seems like a patch-level bump on release.