### PR TITLE
[Doc] Update Datadog ddsource parameter

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -426,7 +426,7 @@ logger.add(
     apiKey: 'super_secret_datadog_api_key',
     hostname: 'my_machine',
     service: 'super_service',
-    ddsource: 'node.js',
+    ddsource: 'nodejs',
     ddtags: 'foo:bar,boo:baz'
   })
 )


### PR DESCRIPTION
Hello!

The Datadog official source for node.js logs is `nodejs` and not `node.js` cf https://docs.datadoghq.com/logs/log_collection/nodejs/?tab=winston30#configure-your-datadog-agent

Changing the default ddsource to the official one will allow users to have the nodejs integration pipeline installed to parse his logs.

Thanks,

Pierre