### PR TITLE
Enables hrTime for profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,21 @@ on:
  }, 1000);
 ```
 
+If you pass `true` to `startTimer()`, the profiling precision will be in
+nanoseconds instead of milliseconds. If `process.hrTime()` is not available,
+it will fall back to regular millisecond precision.
+
+```js
+ // Measures time in nanoseconds:
+ //
+ const profiler = logger.startTimer(true);
+ setTimeout(function () {
+   // `durationMs` will be a decimal number:
+   // {"message":"Logging message","level":"info","durationMs":13.036486}
+   profiler.done({ message: 'Logging message' });
+ }, 1000);
+```
+
 All profile messages are set to 'info' level by default, and both message and
 metadata are optional.  For individual profile messages, you can override the default log level by supplying a metadata object with a `level` property:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -126,7 +126,7 @@ declare namespace winston {
     query(options?: QueryOptions, callback?: (err: Error, results: any) => void): any;
     stream(options?: any): NodeJS.ReadableStream;
 
-    startTimer(): Profiler;
+    startTimer(useHrTime?: boolean): Profiler;
     profile(id: string | number, meta?: LogEntry): Logger;
 
     configure(options: LoggerOptions): void;

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -531,6 +531,7 @@ class Logger extends Transform {
   /**
    * Returns an object corresponding to a specific timing. When done is called
    * the timer will finish and log the duration. e.g.:
+   * @param {boolean} useHrTime - If true, try to use timer precision in nanoseconds.
    * @returns {Profile} - TODO: add return description.
    * @example
    *    const timer = winston.startTimer()
@@ -540,8 +541,8 @@ class Logger extends Transform {
    *      });
    *    }, 1000);
    */
-  startTimer() {
-    return new Profiler(this);
+  startTimer(useHrTime) {
+    return new Profiler(this, useHrTime);
   }
 
   /**
@@ -552,29 +553,26 @@ class Logger extends Transform {
    * @returns {Logger} - TODO: add return description.
    */
   profile(id, ...args) {
-    const time = Date.now();
-    if (this.profilers[id]) {
-      const timeEnd = this.profilers[id];
-      delete this.profilers[id];
-
-      // Attempt to be kind to users if they are still using older APIs.
-      if (typeof args[args.length - 2] === 'function') {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'Callback function no longer supported as of winston@3.0.0'
-        );
-        args.pop();
-      }
-
-      // Set the duration property of the metadata
-      const info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
-      info.level = info.level || 'info';
-      info.durationMs = time - timeEnd;
-      info.message = info.message || id;
-      return this.write(info);
+    // Attempt to be kind to users if they are still using older APIs.
+    if (args.length > 0 && typeof args[0] === 'function') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Callback function no longer supported as of winston@3.0.0'
+      );
+      args.pop();
     }
 
-    this.profilers[id] = time;
+    if (this.profilers[id]) {
+      const info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
+      info.message = info.message || id;
+
+      const response = this.profilers[id].done(info);
+      delete this.profilers[id];
+
+      return response;
+    }
+
+    this.profilers[id] = new Profiler(this);
     return this;
   }
 

--- a/lib/winston/profiler.js
+++ b/lib/winston/profiler.js
@@ -18,15 +18,26 @@ module.exports = class Profiler {
    * `Logger.prototype.startTimer`. When done is called the timer will finish
    * and log the duration.
    * @param {!Logger} logger - TODO: add param description.
+   * @param {boolean} useHrTime - If true, try to use timer precision in nanoseconds.
    * @private
    */
-  constructor(logger) {
+  constructor(logger, useHrTime) {
     if (!logger) {
       throw new Error('Logger is required for profiling.');
     }
 
+    if (typeof useHrTime === 'undefined') {
+      useHrTime = false;
+    }
+
     this.logger = logger;
-    this.start = Date.now();
+    this.useHrTime = useHrTime;
+
+    if (this.useHrTime && this.hasHrTime()) {
+      this.start = process.hrtime();
+    } else {
+      this.start = Date.now();
+    }
   }
 
   /**
@@ -44,8 +55,22 @@ module.exports = class Profiler {
 
     const info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
     info.level = info.level || 'info';
-    info.durationMs = (Date.now()) - this.start;
+
+    if (this.useHrTime && this.hasHrTime()) {
+      const [seconds, nanoseconds] = process.hrtime(this.start);
+      info.durationMs = seconds * 1000 + nanoseconds / 1000000;
+    } else {
+      info.durationMs = (Date.now()) - this.start;
+    }
 
     return this.logger.write(info);
+  }
+
+  /**
+   * @returns {boolean} - Returns `true` if `process.hrtime` is available.
+   * @private
+   */
+  hasHrTime() {
+    return typeof process !== 'undefined' && typeof process.hrtime === 'function';
   }
 };

--- a/test/profiler.test.js
+++ b/test/profiler.test.js
@@ -36,4 +36,28 @@ describe('Profiler', function () {
       });
     }, 200);
   });
+
+  it('supports hrTime', function(done) {
+    var profiler = new Profiler(
+      {
+        write: function (info) {
+          assume(info).is.an('object'),
+          assume(info.something).equals('ok');
+          assume(info.level).equals('info');
+          assume(info.durationMs).is.a('number');
+          assume(info.message).equals('testing1');
+          done();
+        }
+      },
+      true // This enables hrTime.
+    );
+
+    setTimeout(function () {
+      profiler.done({
+        something: 'ok',
+        level: 'info',
+        message: 'testing1'
+      });
+    }, 200);
+  });
 });


### PR DESCRIPTION
Enables hrTime for profiler

In a NodeJS environment, [`process.hrtime()`][1] can be used to get the current time with nanosecond resolution. We can use that to increase the precision of the profiler.

I added a check for whether `hrTime` is available to the `Profiler` to be able to use it. Since the logged message will now be a decimal with fractions of milliseconds, I added an optional boolean argument to keep backwards compatibility. This new argument must be set to `true` explicitly to try to use `hrTime`. If `hrTime` is not available, it will fall back to ms resolution using `Date`.

I added the same new optional boolean to the `logger`'s `startTimer()` function. However, I don't see a way how to add it in a backwards compatible way to the `logger`'s `profile` method. Is it ok to check if `args` contains a boolean and in that case enable `useHrTime`?

However, I refactored `profile` a bit to use the same `Profiler` class that `startTimer()` usees. The existing test ensure that it still works as expected. I think I also found and fixed a bug regarding the callback check. It should also be done if `this.profilers[id]` is not set. And it should check the overall second argument (first in `args`), not the second to last argument. This is now handled that way. Is it correct now?

- I also updated the README.
- I also updated the type definition.

The following example program compares the profiler with and without `hrTime` enabled (in a NodeJS environment):

```js
const winston = require('winston');
const { execSync } = require('child_process');

const logger = winston.createLogger({
  level: 'info',
  transports: [
    new winston.transports.Console({ format: winston.format.json() }),
  ],
});

let profiler = logger.startTimer();
execSync('ls -al');
profiler.done({hrTime: false});

profiler = logger.startTimer(true);
execSync('ls -al');
profiler.done({hrTime: true});
```

Output:
```js
{"hrTime":false,"level":"info","durationMs":11}
{"hrTime":true,"level":"info","durationMs":13.036486}
```

[1]: https://nodejs.org/docs/latest-v10.x/api/process.html#process_process_hrtime_time