### PR TITLE
Add TypeScript typing for RejectionHandler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,21 @@ declare namespace winston {
     new(logger: Logger): ExceptionHandler;
   }
 
+  interface RejectionHandler {
+    logger: Logger;
+    handlers: Map<any, any>;
+    catcher: Function | boolean;
+
+    handle(...transports: Transport[]): void;
+    unhandle(...transports: Transport[]): void;
+    getAllInfo(err: string | Error): object;
+    getProcessInfo(): object;
+    getOsInfo(): object;
+    getTrace(err: Error): object;
+
+    new(logger: Logger): RejectionHandler;
+  }
+
   interface QueryOptions {
     rows?: number;
     limit?: number;
@@ -93,6 +108,7 @@ declare namespace winston {
     level: string;
     transports: Transport[];
     exceptions: ExceptionHandler;
+    rejections: RejectionHandler;
     profilers: object;
     exitOnError: Function | boolean;
     defaultMeta?: any;


### PR DESCRIPTION
_I was looking if I could monkey patch https://github.com/winstonjs/winston/pull/1824 without waiting for a release that includes the memory leak fix._

https://github.com/winstonjs/winston/pull/1462 added handleRejections and https://github.com/winstonjs/winston-transport/pull/41 added handleRejections option

but the TypeScript typing is missing, this PR compensates this.
