### PR TITLE
fix: MaxListenersExceededWarning when much loggers share same transport

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -353,6 +353,10 @@ class Logger extends Transform {
       );
     }
 
+    // Because this.pipe(target) add many listeners,
+    // it emits MaxListenersExceededWarning when much loggers share same transport.
+    target.setMaxListeners(Infinity);
+
     // Listen for the `error` event and the `warn` event on the new Transport.
     this._onEvent('error', target);
     this._onEvent('warn', target);

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -31,8 +31,6 @@ module.exports = class Console extends TransportStream {
     this.stderrLevels = this._stringArrayToSet(options.stderrLevels);
     this.consoleWarnLevels = this._stringArrayToSet(options.consoleWarnLevels);
     this.eol = options.eol || os.EOL;
-
-    this.setMaxListeners(30);
   }
 
   /**

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1078,4 +1078,30 @@ describe('Should support child loggers & defaultMeta', () => {
     const log = logger.info;
     log('test');
   });
+
+  it('much loggers share same transport should not emit MaxListenersExceededWarning', function (done) {
+    const transports = [
+      new winston.transports.File({
+        filename: path.join(__dirname, 'fixtures', 'logs', 'filelog2.log')
+      }),
+      new winston.transports.Console()
+    ];
+
+    const warnings = [];
+    const warningListener = (warning) => {
+      warnings.push(warning);
+    };
+
+    process.on('warning', warningListener);
+
+    Array(100).fill().map(() => {
+      return winston.createLogger({ transports });
+    });
+
+    setImmediate(() => {
+      process.removeListener('warning', warningListener);
+      assume(warnings.length).equals(0);
+      done();
+    })
+  });
 });


### PR DESCRIPTION
fix #1791 