### PR TITLE
Fixing rendering of referenced links on npmjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ logger to use throughout your application if you so choose.
 ## Logging
 
 Logging levels in `winston` conform to the severity ordering specified by
-[RFC5424]: _severity of all levels is assumed to be numerically **ascending**
+[RFC5424], _severity of all levels is assumed to be numerically **ascending**
 from most important to least important._
 
 ``` js
@@ -497,7 +497,7 @@ console.dir(whisper.transform({
 ## Logging Levels
 
 Logging levels in `winston` conform to the severity ordering specified by
-[RFC5424]: _severity of all levels is assumed to be numerically **ascending**
+[RFC5424], _severity of all levels is assumed to be numerically **ascending**
 from most important to least important._
 
 Each `level` is given a specific integer priority. The higher the priority the


### PR DESCRIPTION
- Occurrences of `[text]:` in the body of the text break markdown rendering, leading to faulty documentation. 
- This is visible both when viewing the documentation on npmjs.com and while using the GitHub editor.
- Broken docs visible here: https://www.npmjs.com/package/winston#logging