### PR TITLE
fix(transport): eol='' not work

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -30,7 +30,7 @@ module.exports = class Console extends TransportStream {
     this.name = options.name || 'console';
     this.stderrLevels = this._stringArrayToSet(options.stderrLevels);
     this.consoleWarnLevels = this._stringArrayToSet(options.consoleWarnLevels);
-    this.eol = options.eol || os.EOL;
+    this.eol = (typeof options.eol === 'string') ? options.eol : os.EOL;
 
     this.setMaxListeners(30);
   }

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -77,7 +77,7 @@ module.exports = class File extends TransportStream {
     this.rotationFormat = options.rotationFormat || false;
     this.zippedArchive = options.zippedArchive || false;
     this.maxFiles = options.maxFiles || null;
-    this.eol = options.eol || os.EOL;
+    this.eol = (typeof options.eol === 'string') ? options.eol : os.EOL;
     this.tailable = options.tailable || false;
 
     // Internal state variables representing the number of files this instance

--- a/lib/winston/transports/stream.js
+++ b/lib/winston/transports/stream.js
@@ -35,7 +35,7 @@ module.exports = class Stream extends TransportStream {
     this._stream = options.stream;
     this._stream.setMaxListeners(Infinity);
     this.isObjectMode = options.stream._writableState.objectMode;
-    this.eol = options.eol || os.EOL;
+    this.eol = (typeof options.eol === 'string') ? options.eol : os.EOL;
   }
 
   /**


### PR DESCRIPTION
`new winston.transports.Console({eol: ''})` not work. Because `Boolean('')` equals `false`.