### PR TITLE
Fix crash on JSON.stringify in HTTP transport

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -11,6 +11,7 @@ const http = require('http');
 const https = require('https');
 const { Stream } = require('readable-stream');
 const TransportStream = require('winston-transport');
+const jsonStringify = require('safe-stable-stringify');
 
 /**
  * Transport for outputting to a json-rpc server.
@@ -197,6 +198,6 @@ module.exports = class Http extends TransportStream {
     req.on('response', res => (
       res.on('end', () => callback(null, res)).resume()
     ));
-    req.end(Buffer.from(JSON.stringify(options), 'utf8'));
+    req.end(Buffer.from(jsonStringify(options), 'utf8'));
   }
 };


### PR DESCRIPTION
Related: #98

They missed a spot when doing #98.