### PR TITLE
refactor: improve log message type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,24 +52,26 @@ declare namespace winston {
 
   type LogCallback = (error?: any, level?: string, message?: string, meta?: any) => void;
 
+  type Message = string | Record<string, any>;
+
   interface LogEntry {
     level: string;
-    message: string;
+    message: Message;
     [optionName: string]: any;
   }
 
    interface LogMethod {
-    (level: string, message: string, callback: LogCallback): Logger;
-    (level: string, message: string, meta: any, callback: LogCallback): Logger;
-    (level: string, message: string, ...meta: any[]): Logger;
+    (level: string, message: Message, callback: LogCallback): Logger;
+    (level: string, message: Message, meta: any, callback: LogCallback): Logger;
+    (level: string, message: Message, ...meta: any[]): Logger;
     (entry: LogEntry): Logger;
     (level: string, message: any): Logger;
   }
 
   interface LeveledLogMethod {
-    (message: string, callback: LogCallback): Logger;
-    (message: string, meta: any, callback: LogCallback): Logger;
-    (message: string, ...meta: any[]): Logger;
+    (message: Message, callback: LogCallback): Logger;
+    (message: Message, meta: any, callback: LogCallback): Logger;
+    (message: Message, ...meta: any[]): Logger;
     (message: any): Logger;
     (infoObject: object): Logger;
   }

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -57,3 +57,16 @@ logger.isInfoEnabled();
 logger.isVerboseEnabled();
 logger.isDebugEnabled();
 logger.isSillyEnabled();
+
+// Message type
+logger.log('info', 'string', () => {});
+logger.log('info', 'string', { meta: '1' }, () => {});
+logger.log('info', 'string', { meta: '1' }, { meta: '2' });
+logger.log({ level: 'info', message: 'string' });
+logger.log('info', 'string');
+
+logger.log('info', { message: 'object' }, () => {});
+logger.log('info', { message: 'object' }, { meta: '1' }, () => {});
+logger.log('info', { message: 'object' }, { meta: '1' }, { meta: '2' });
+logger.log({ level: 'info', message: { nested: 'object' } });
+logger.log('info', { message: 'object' });


### PR DESCRIPTION
**Fixes:** #1753

This PR aim to improve current log message type to allow passing a `Record<string, any>` as well as `string`, being both supported by the library as seen in the source: 

https://github.com/winstonjs/winston/blob/2625f60c5c85b8c4926c65e98a591f8b42e0db9a/lib/winston/logger.js#L201-L259