### PR TITLE
Fix child logger overrides

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -45,10 +45,12 @@ class Logger extends Transform {
   child(defaultRequestMetadata) {
     const logger = this;
     return Object.create(logger, {
+      defaultMeta: Object.assign({}, this.defaultMeta, defaultRequestMetadata),
       write: {
         value: function (info) {
           const infoClone = Object.assign(
             {},
+            logger.defaultMeta,
             defaultRequestMetadata,
             info
           );


### PR DESCRIPTION
- child metadata should override parent metadata
- custom meta should override logger's meta
- support for multi-level child logger inheritance (`child({meta: 1}).child({meta: 2})`)

Tests added that fail for current master.

Fixes #1788