### PR TITLE
fix: handle undefined rejections

### DIFF
--- a/lib/winston/rejection-handler.js
+++ b/lib/winston/rejection-handler.js
@@ -74,9 +74,9 @@ module.exports = class RejectionHandler {
    * @returns {mixed} - TODO: add return description.
    */
   getAllInfo(err) {
-    let { message } = err;
-    if (!message && typeof err === 'string') {
-      message = err;
+    let message = null;
+    if (err) {
+      message = typeof err === 'string' ? err : err.message;
     }
 
     return {
@@ -85,9 +85,9 @@ module.exports = class RejectionHandler {
       level: 'error',
       message: [
         `unhandledRejection: ${message || '(no error message)'}`,
-        err.stack || '  No stack trace'
+        err && err.stack || '  No stack trace'
       ].join('\n'),
-      stack: err.stack,
+      stack: err && err.stack,
       exception: true,
       date: new Date().toString(),
       process: this.getProcessInfo(),

--- a/test/rejection-handler.test.js
+++ b/test/rejection-handler.test.js
@@ -106,6 +106,12 @@ describe('UnhandledRejectionHandler', function () {
     helpers.reject('wtf this rejection').then(done());
   });
 
+  it('.getAllInfo(undefined)', function () {
+    var handler = helpers.rejectionHandler();
+    // eslint-disable-next-line no-undefined
+    handler.getAllInfo(undefined);
+  });
+
   after(function () {
     //
     // Restore normal `runTest` functionality


### PR DESCRIPTION
Winston cannot handle promise rejections if the rejected object is `undefined`.
A simple test is to add `Promise.reject(undefined)` somewhere in your app and Winston will throw the following exception:

```
TypeError: Cannot destructure property 'message' of 'err' as it is undefined.
    at RejectionHandler.getAllInfo (/.../node_modules/winston/lib/winston/rejection-handler.js:77:11)
    at RejectionHandler._unhandledRejection (/.../node_modules/winston/lib/winston/rejection-handler.js:168:23)
```

I added a test that checks for this error, and a fix that makes this test go green.