### PR TITLE
add http property to NpmConfigSetColors

### DIFF
--- a/lib/winston/config/index.d.ts
+++ b/lib/winston/config/index.d.ts
@@ -57,6 +57,7 @@ declare namespace winston {
     error: string | string[];
     warn: string | string[];
     info: string | string[];
+    http: string | string[];
     verbose: string | string[];
     debug: string | string[];
     silly: string | string[];


### PR DESCRIPTION
The http property in the NpmConfigSetLevels interface does not exist in the NpmConfigSetColors interface.
The triple-beam module also has http as a color option. (https://github.com/winstonjs/triple-beam/blob/master/config/npm.js)
I think http property is missing.