### PR TITLE
Make winston more ESM friendly

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -11,61 +11,55 @@ const logform = require('logform');
 const { warn } = require('./winston/common');
 
 /**
- * Setup to expose.
- * @type {Object}
- */
-const winston = exports;
-
-/**
  * Expose version. Use `require` method for `webpack` support.
  * @type {string}
  */
-winston.version = require('../package.json').version;
+exports.version = require('../package.json').version;
 /**
  * Include transports defined by default by winston
  * @type {Array}
  */
-winston.transports = require('./winston/transports');
+exports.transports = require('./winston/transports');
 /**
  * Expose utility methods
  * @type {Object}
  */
-winston.config = require('./winston/config');
+exports.config = require('./winston/config');
 /**
  * Hoist format-related functionality from logform.
  * @type {Object}
  */
-winston.addColors = logform.levels;
+exports.addColors = logform.levels;
 /**
  * Hoist format-related functionality from logform.
  * @type {Object}
  */
-winston.format = logform.format;
+exports.format = logform.format;
 /**
  * Expose core Logging-related prototypes.
  * @type {function}
  */
-winston.createLogger = require('./winston/create-logger');
+exports.createLogger = require('./winston/create-logger');
 /**
  * Expose core Logging-related prototypes.
  * @type {Object}
  */
-winston.ExceptionHandler = require('./winston/exception-handler');
+exports.ExceptionHandler = require('./winston/exception-handler');
 /**
  * Expose core Logging-related prototypes.
  * @type {Object}
  */
-winston.RejectionHandler = require('./winston/rejection-handler');
+exports.RejectionHandler = require('./winston/rejection-handler');
 /**
  * Expose core Logging-related prototypes.
  * @type {Container}
  */
-winston.Container = require('./winston/container');
+exports.Container = require('./winston/container');
 /**
  * Expose core Logging-related prototypes.
  * @type {Object}
  */
-winston.Transport = require('winston-transport');
+exports.Transport = require('winston-transport');
 /**
  * We create and expose a default `Container` to `winston.loggers` so that the
  * programmer may manage multiple `winston.Logger` instances without any
@@ -77,7 +71,7 @@ winston.Transport = require('winston-transport');
  *   // some-file2.js
  *   const logger = require('winston').loggers.get('something');
  */
-winston.loggers = new winston.Container();
+exports.loggers = new exports.Container();
 
 /**
  * We create and expose a 'defaultLogger' so that the programmer may do the
@@ -87,10 +81,10 @@ winston.loggers = new winston.Container();
  *   winston.log('info', 'some message');
  *   winston.error('some error');
  */
-const defaultLogger = winston.createLogger();
+const defaultLogger = exports.createLogger();
 
 // Pass through the target methods onto `winston.
-Object.keys(winston.config.npm.levels)
+Object.keys(exports.config.npm.levels)
   .concat([
     'log',
     'query',
@@ -108,7 +102,7 @@ Object.keys(winston.config.npm.levels)
     'child'
   ])
   .forEach(
-    method => (winston[method] = (...args) => defaultLogger[method](...args))
+    method => (exports[method] = (...args) => defaultLogger[method](...args))
   );
 
 /**
@@ -116,7 +110,7 @@ Object.keys(winston.config.npm.levels)
  * by winston.
  * @type {string}
  */
-Object.defineProperty(winston, 'level', {
+Object.defineProperty(exports, 'level', {
   get() {
     return defaultLogger.level;
   },
@@ -130,7 +124,7 @@ Object.defineProperty(winston, 'level', {
  * `unhandleExceptions`.
  * @type {Object}
  */
-Object.defineProperty(winston, 'exceptions', {
+Object.defineProperty(exports, 'exceptions', {
   get() {
     return defaultLogger.exceptions;
   }
@@ -142,7 +136,7 @@ Object.defineProperty(winston, 'exceptions', {
  * @type {Logger}
  */
 ['exitOnError'].forEach(prop => {
-  Object.defineProperty(winston, prop, {
+  Object.defineProperty(exports, prop, {
     get() {
       return defaultLogger[prop];
     },
@@ -156,7 +150,7 @@ Object.defineProperty(winston, 'exceptions', {
  * The default transports and exceptionHandlers for the default winston logger.
  * @type {Object}
  */
-Object.defineProperty(winston, 'default', {
+Object.defineProperty(exports, 'default', {
   get() {
     return {
       exceptionHandlers: defaultLogger.exceptionHandlers,
@@ -168,15 +162,15 @@ Object.defineProperty(winston, 'default', {
 
 // Have friendlier breakage notices for properties that were exposed by default
 // on winston < 3.0.
-warn.deprecated(winston, 'setLevels');
-warn.forFunctions(winston, 'useFormat', ['cli']);
-warn.forProperties(winston, 'useFormat', ['padLevels', 'stripColors']);
-warn.forFunctions(winston, 'deprecated', [
+warn.deprecated(exports, 'setLevels');
+warn.forFunctions(exports, 'useFormat', ['cli']);
+warn.forProperties(exports, 'useFormat', ['padLevels', 'stripColors']);
+warn.forFunctions(exports, 'deprecated', [
   'addRewriter',
   'addFilter',
   'clone',
   'extend'
 ]);
-warn.forProperties(winston, 'deprecated', ['emitErrs', 'levelLength']);
+warn.forProperties(exports, 'deprecated', ['emitErrs', 'levelLength']);
 // Throw a useful error when users attempt to run `new winston.Logger`.
-warn.moved(winston, 'createLogger', 'Logger');
+warn.moved(exports, 'createLogger', 'Logger');


### PR DESCRIPTION
This PR should make winston friendlier to ESM module named exports.

Basically, with ESM modules, we can't do this:
```js
import { warn, error } from 'winston';
```

and instead have to do this:
```js
import winston from 'winston';
const { warn, error } = winston;
```

This is a great blog post that explains the issue: https://simonplend.com/node-js-now-supports-named-imports-from-commonjs-modules-but-what-does-that-mean/