### PR TITLE
Simplify path so that e.g. 'npm run build' can find it more easily

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pretest": "npm run lint",
     "test": "nyc --reporter=text --reporter lcov npm run test:mocha",
     "test:mocha": "mocha test/*.test.js test/**/*.test.js --exit",
-    "build": "./node_modules/.bin/rimraf dist && babel lib -d dist",
+    "build": "rimraf dist && babel lib -d dist",
     "prepublishOnly": "npm run build"
   },
   "engines": {


### PR DESCRIPTION
What was previously explicit is the default, and gets past the error.