### PR TITLE
Typings on LoggerOptions and Logger interfaces.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,7 @@ declare namespace winston {
     transports?: Transport[] | Transport;
     handleExceptions?: boolean;
     exceptionHandlers?: any;
+    rejectionHandlers?: any;
   }
 
   interface Logger extends NodeJSStream.Transform {

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,6 +83,7 @@ declare namespace winston {
     defaultMeta?: any;
     transports?: Transport[] | Transport;
     handleExceptions?: boolean;
+    handleRejections?: boolean;
     exceptionHandlers?: any;
     rejectionHandlers?: any;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,21 @@ declare namespace winston {
 
     new(logger: Logger): ExceptionHandler;
   }
+  
+  interface RejectionHandler {
+    logger: Logger;
+    handlers: Map<any, any>;
+    catcher: Function | boolean;
+
+    handle(...transports: Transport[]): void;
+    unhandle(...transports: Transport[]): void;
+    getAllInfo(err: string | Error): object;
+    getProcessInfo(): object;
+    getOsInfo(): object;
+    getTrace(err: Error): object;
+
+    new(logger: Logger): RejectionHandler;
+  }
 
   interface QueryOptions {
     rows?: number;
@@ -95,6 +110,7 @@ declare namespace winston {
     level: string;
     transports: Transport[];
     exceptions: ExceptionHandler;
+    rejections: RejectionHandler;
     profilers: object;
     exitOnError: Function | boolean;
     defaultMeta?: any;
@@ -160,6 +176,7 @@ declare namespace winston {
 
   let version: string;
   let ExceptionHandler: ExceptionHandler;
+  let RejectionHandler: RejectionHandler;
   let Container: Container;
   let loggers: Container;
 
@@ -188,6 +205,7 @@ declare namespace winston {
   let child: (options: Object) => Logger;
   let level: string;
   let exceptions: ExceptionHandler;
+  let rejections: RejectionHandler;
   let exitOnError: Function | boolean;
   // let default: object;
 }


### PR DESCRIPTION
Some typings are missing on index.d.ts.

Missing fields:
on LoggerOptions interface:
+ handleRejections (boolean)
+ rejectionHandlers (any)

on Logger interface (suggested by DABH):
+ rejections (RejectionHandler)

Missing interfaces (suggested by DABH):
+ RejectionHandler

This commit fix it (3 commits):

Issue: https://github.com/winstonjs/winston/issues/1801

---

One workaround for part of the problem(only for missing fields on LoggerOptions) is doing a declaration merging on winston module.

```
declare module 'winston' {
    export interface LoggerOptions {
        handleRejections?: boolean;
        rejectionHandlers?: any;
    }
}

export {}
```
