### PR TITLE
Remove gitter link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ A logger for just about everything.
 
 [![NPM](https://nodei.co/npm/winston.png?downloads=true&downloadRank=true)](https://nodei.co/npm/winston/)
 
-[![Join the chat at https://gitter.im/winstonjs/winston](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/winstonjs/winston?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 ## winston@3
 
 See the [Upgrade Guide](UPGRADE-3.0.md) for more information. Bug reports and


### PR DESCRIPTION
I don't like the gitter app, the app seems largely unmaintained, and it generally doesn't seem like the best place for folks to get help.  If we want to do something like this in the future, a better tool is probably Slack or Discord.  Please feel free to agree/disagree/discuss :)