### PR TITLE
Fix how metadata works

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -44,30 +44,10 @@ class Logger extends Transform {
 
   child(defaultRequestMetadata) {
     const logger = this;
-    return Object.create(logger, {
-      write: {
-        value: function (info) {
-          const infoClone = Object.assign(
-            {},
-            defaultRequestMetadata,
-            info
-          );
-
-          // Object.assign doesn't copy inherited Error
-          // properties so we have to do that explicitly
-          //
-          // Remark (indexzero): we should remove this
-          // since the errors format will handle this case.
-          //
-          if (info instanceof Error) {
-            infoClone.stack = info.stack;
-            infoClone.message = info.message;
-          }
-
-          logger.write(infoClone);
-        }
-      }
-    });
+    const childLogger = Object.create(logger);
+    childLogger.parentLogger = logger;
+    childLogger.defaultMeta = defaultRequestMetadata;
+    return childLogger;
   }
 
   /**
@@ -117,6 +97,7 @@ class Logger extends Transform {
     this.rejections = new RejectionHandler(this);
     this.profilers = {};
     this.exitOnError = exitOnError;
+    this.parentLogger = null;
 
     // Add all transports we have been provided.
     if (transports) {
@@ -233,34 +214,28 @@ class Logger extends Transform {
     }
 
     const [meta] = splat;
+    const info = {};
+    this._addDefaultMeta(info);
+    let mergeMessage = false;
     if (typeof meta === 'object' && meta !== null) {
       // Extract tokens, if none available default to empty array to
       // ensure consistancy in expected results
       const tokens = msg && msg.match && msg.match(formatRegExp);
 
       if (!tokens) {
-        const info = Object.assign({}, this.defaultMeta, meta, {
-          [LEVEL]: level,
-          [SPLAT]: splat,
-          level,
-          message: msg
-        });
-
-        if (meta.message) info.message = `${info.message} ${meta.message}`;
-        if (meta.stack) info.stack = meta.stack;
-
-        this.write(info);
-        return this;
+        assignWithGetters(info, meta);
+        mergeMessage = true;
       }
     }
-
-    this.write(Object.assign({}, this.defaultMeta, {
+    assignWithGetters(info, {
       [LEVEL]: level,
       [SPLAT]: splat,
       level,
       message: msg
-    }));
-
+    });
+    if (mergeMessage && meta.message) info.message = `${info.message} ${meta.message}`;
+    if (mergeMessage && meta.stack) info.stack = meta.stack;
+    this.write(info);
     return this;
   }
 
@@ -624,6 +599,13 @@ class Logger extends Transform {
     );
   }
 
+  write(chunk, ...args) {
+    if (!(chunk instanceof Error)) {
+      chunk = Object.assign({}, chunk);
+    }
+    super.write(chunk, ...args);
+  }
+
   /**
    * Bubbles the `event` that occured on the specified `transport` up
    * from this instance.
@@ -647,9 +629,12 @@ class Logger extends Transform {
   }
 
   _addDefaultMeta(msg) {
-    if (this.defaultMeta) {
-      Object.assign(msg, this.defaultMeta);
+    const merged = {};
+    if (this.parentLogger) {
+      this.parentLogger._addDefaultMeta(merged);
     }
+    assignWithGetters(merged, this.defaultMeta, msg);
+    assignWithGetters(msg, merged);
   }
 }
 
@@ -673,5 +658,21 @@ Object.defineProperty(Logger.prototype, 'transports', {
     return !Array.isArray(pipes) ? [pipes].filter(Boolean) : pipes;
   }
 });
+
+function assignWithGetters(target, ...sources) {
+  // eslint-disable-next-line no-shadow
+  return sources.reduce((target, source) => {
+    // eslint-disable-next-line eqeqeq
+    if (source != null) {
+      const enumerableKeys = Object.keys(source);
+      const symbolKeys = Object.getOwnPropertySymbols(source);
+      // Don't use Reflect.ownKeys here because we only want to assign enumerable ones
+      for (const key of enumerableKeys.concat(symbolKeys)) {
+        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+      }
+    }
+    return target;
+  }, target);
+}
 
 module.exports = Logger;

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -68,38 +68,33 @@ describe('Logger', function () {
   });
 
   it('new Logger({ levels }) custom methods are not bound to instance', function (done) {
-    var logger = winston.createLogger({
-      level: 'error',
-      exitOnError: false,
-      transports: []
-    });
 
-    let logs = [];
-    let extendedLogger = Object.create(logger, {
-      write: {
-        value: function(...args) {
-          logs.push(args);
-          if (logs.length === 4) {
-            assume(logs.length).is.eql(4);
-            assume(logs[0]).is.eql([{ test: 1, level: 'info' }]);
-            assume(logs[1]).is.eql([{ test: 2, level: 'warn' }]);
-            assume(logs[2]).is.eql([{ message: 'test3', level: 'info' }])
-            assume(logs[3]).is.eql([{ with: 'meta',
-              test: 4,
-              level: 'warn',
-              message: 'a warning'
-            }]);
+    var expected = [
+      { test: 1, level: 'info' },
+      { test: 2, level: 'warn' },
+      { message: 'test3', level: 'info' },
+      { with: 'meta',
+        test: 4,
+        level: 'warn',
+        message: 'a warning'
+      }
+    ];
 
-            done();
-          }
-        }
+    var i = 0;
+    var logger = helpers.createLogger(function (chunk, encoding, next) {
+      assume(i).is.lessThan(expected.length);
+      assume(chunk).is.eql(expected[i]);
+      i++;
+      next();
+      if (i === expected.length) {
+        done();
       }
     });
 
-    extendedLogger.log('info', { test: 1 });
-    extendedLogger.log('warn', { test: 2 });
-    extendedLogger.info('test3');
-    extendedLogger.warn('a warning', { with: 'meta', test: 4 });
+    logger.log('info', { test: 1 });
+    logger.log('warn', { test: 2 });
+    logger.info('test3');
+    logger.warn('a warning', { with: 'meta', test: 4 });
   });
 
   it('.add({ invalid Transport })', function () {


### PR DESCRIPTION
This PR rethinks how metadata works in Winston, supporting the following goals:
* Metadata should always merge in this order: message metadata > splat > logger.defaultMeta > parent.defaultMeta -> grandparent.defaultMeta....
* Metadata updated in a parent logger should be reflected dynamically when children log
* Metadata should allow for javascript getters() so you can have dynamic metadata
* Metadata should always be captured (in the case of dynamic metadata) at the same spot so callstacks are consistent

This PR attempts to solve all of these issues while making the smallest set of changes to the existing codebase.

Here's how it works:
## Child loggers
Child logging now works by holding onto a reference to the parent logger (`this.parentLogger`).
Then, the `defaultMetadata` for the child only contains the metadata specific to the child (which may override any parent metadata).

Parent and child metadata are merged together during _addDefaultMeta (explained below)

## Dynamic logging
Following the idea from #1626, this PR fully supports having dynamic metadata. The basic idea is you can do something like this:
`createLogger({defaultMeta: { get caller() { return new Error().stack}}`

Supporting this functionality requires two chages:
1. We want to keep these getters around. Calling Object.assign() would lose the getter since it actualizes the value and stores the result instead. So, instead, I made this helper function which mimics Object.assign(), except that it copies properties as well.
```
function assignWithGetters(target, ...sources) {
  // eslint-disable-next-line no-shadow
  return sources.reduce((target, source) => {
    // eslint-disable-next-line eqeqeq
    if (source != null) {
      const enumerableKeys = Object.keys(source);
      const symbolKeys = Object.getOwnPropertySymbols(source);
      // Don't use Reflect.ownKeys here because we only want to assign enumerable ones
      for (const key of enumerableKeys.concat(symbolKeys)) {
        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
      }
    }
    return target;
  }, target);
}
```

Then, we want to consistently actualize the final data when actually logging. The primary consideration here is to always have callstacks in the correct place (so that callers can do things like slice off a consistent number of frames). That is why this code exists:
```
  write(chunk, ...args) {
    if (!(chunk instanceof Error)) {
      chunk = Object.assign({}, chunk);
    }
    super.write(chunk, ...args);
  }
```
(Errors are treated special for winston. I'm not super thrilled with the cutout here - open for suggestions).

## Merging metadata in the correct order
The main idea is to always use this function when dealing with metadata:
```
  _addDefaultMeta(msg) {
    const merged = {};
    if (this.parentLogger) {
      this.parentLogger._addDefaultMeta(merged);
    }
    assignWithGetters(merged, this.defaultMeta, msg);
    assignWithGetters(msg, merged);
  }
```
It keeps the same semantics of _addDefaultMeta() before, but it does the update in the correct order.
First, it recursively merges any parent logger metadata.
Then it adds the current metadata, and finally the metadata for the existing object.
Then, it re-uses the msg() object by merging everything into that object.

There's some additional logic changes needed to the log() method, since not every codepath goes through the _addDefaultMeta() flow.

## Misc
Almost every test works out-of-the-box with this change.
The only test that doesn't work monkey-patches the `write` method, so it doesn't pick up all of my code changes. I fixed the test to properly use the transport to grab the data, but the logic of the test is unchanged

The nice thing about centralizing all of this behavior, is that it would make it easy to add new features in the future. For example, if you want to support custom merging (e.g #1884) then we could just add support for that in _addDefaultMeta


Closes #2029