### PR TITLE
Add custom merge function for child logger default metadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,7 @@ declare namespace winston {
 
   type LogCallback = (error?: any, level?: level, message?: string, meta?: any) => void;
 
+  type ChildMergeFunc = (overrideMetadata: Object, currentMetadata: Object) => Object;
 
   interface LogEntry {
     level: level;
@@ -152,7 +153,7 @@ declare namespace winston {
 
     configure(options: LoggerOptions): void;
 
-    child(options: Object): Logger;
+    child(options: Object, mergeFunc?: ChildMergeFunc): Logger;
 
     isLevelEnabled(level: level): boolean;
     isErrorEnabled(): boolean;

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -42,16 +42,12 @@ class Logger extends Transform {
     this.configure(options);
   }
 
-  child(defaultRequestMetadata) {
+  child(defaultRequestMetadata, mergeFunc = (overrides, current) => Object.assign({}, overrides, current)) {
     const logger = this;
     return Object.create(logger, {
       write: {
         value: function (info) {
-          const infoClone = Object.assign(
-            {},
-            defaultRequestMetadata,
-            info
-          );
+          const infoClone = mergeFunc(defaultRequestMetadata, info);
 
           // Object.assign doesn't copy inherited Error
           // properties so we have to do that explicitly


### PR DESCRIPTION
* Add a parameter to `logger.child` that accepts a function whose result will be used as the infoClone for that child
* Provide the current merge functionality as the default argument for this parameter

New PR from suggested changes in #1885

This enables a user to implement their own, arbitrary merge functionality for child loggers.