### PR TITLE
fix: Rework Typings to use Generics on levels instead of hardcoded npm values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,8 +19,8 @@ declare namespace winston {
   export import transports = Transports;
   export import transport = Transport;
 
-  interface ExceptionHandler {
-    logger: Logger;
+  interface ExceptionHandler<L extends string = Config.NpmLevels> {
+    logger: Logger<L>;
     handlers: Map<any, any>;
     catcher: Function | boolean;
 
@@ -31,11 +31,11 @@ declare namespace winston {
     getOsInfo(): object;
     getTrace(err: Error): object;
 
-    new(logger: Logger): ExceptionHandler;
+    new(logger: Logger<L>): ExceptionHandler<L>;
   }
   
-  interface RejectionHandler {
-    logger: Logger;
+  interface RejectionHandler<L extends string = Config.NpmLevels> {
+    logger: Logger<L>;
     handlers: Map<any, any>;
     catcher: Function | boolean;
 
@@ -46,7 +46,7 @@ declare namespace winston {
     getOsInfo(): object;
     getTrace(err: Error): object;
 
-    new(logger: Logger): RejectionHandler;
+    new(logger: Logger<L>): RejectionHandler<L>;
   }
 
   interface QueryOptions {
@@ -59,29 +59,27 @@ declare namespace winston {
     fields: any;
   }
 
-  interface Profiler {
-    logger: Logger;
+  interface Profiler<L extends string = Config.NpmLevels> {
+    logger: Logger<L>;
     start: Number;
     done(info?: any): boolean;
   }
 
-  type level = "error" | "warn" | "info" | "http" | "verbose" | "debug" | "silly";
-
-  type LogCallback = (error?: any, level?: level, message?: string, meta?: any) => void;
+  type LogCallback = <L extends string = Config.NpmLevels>(error?: any, level?: L, message?: string, meta?: any) => void;
 
 
-  interface LogEntry {
-    level: level;
+  interface LogEntry<L extends string = Config.NpmLevels> {
+    level: L;
     message: string;
     [optionName: string]: any;
   }
 
-   interface LogMethod {
-    (level: level, message: string, callback: LogCallback): Logger;
-    (level: level, message: string, meta: any, callback: LogCallback): Logger;
-    (level: level, message: string, ...meta: any[]): Logger;
-    (entry: LogEntry): Logger;
-    (level: level, message: any): Logger;
+   interface LogMethod<L extends string = Config.NpmLevels> {
+    (level: L, message: string, callback: LogCallback): Logger<L>;
+    (level: L, message: string, meta: any, callback: LogCallback): Logger<L>;
+    (level: L, message: string, ...meta: any[]): Logger<L>;
+    (entry: LogEntry<L>): Logger<L>;
+    (level: L, message: any): Logger<L>;
   }
 
   interface LeveledLogMethod {
@@ -92,69 +90,49 @@ declare namespace winston {
     (infoObject: object): Logger;
   }
 
-  interface LoggerOptions {
-    levels?: Config.AbstractConfigSetLevels;
+  interface LoggerOptions<L extends string = Config.NpmLevels> {
+    levels?: Config.AbstractConfigSetLevels<L>;
     silent?: boolean;
     format?: logform.Format;
-    level?: level;
+    level?: string;
     exitOnError?: Function | boolean;
     defaultMeta?: any;
     transports?: Transport[] | Transport;
     handleExceptions?: boolean;
     handleRejections?: boolean;
     exceptionHandlers?: any;
-    rejectionHandlers?: any;
+    RejectionHandlers?: any;
   }
 
-  interface Logger extends NodeJSStream.Transform {
+  type Logger<L extends string = Config.NpmLevels> = Record<L, LeveledLogMethod> & NodeJSStream.Transform & {
     silent: boolean;
     format: logform.Format;
-    levels: Config.AbstractConfigSetLevels;
-    level: level;
+    levels: Config.AbstractConfigSetLevels<L>;
+    level: L;
     transports: Transport[];
-    exceptions: ExceptionHandler;
-    rejections: RejectionHandler;
+    exceptions: ExceptionHandler<L>;
+    rejections: RejectionHandler<L>;
     profilers: object;
     exitOnError: Function | boolean;
     defaultMeta?: any;
 
-    log: LogMethod;
-    add(transport: Transport): Logger;
-    remove(transport: Transport): Logger;
-    clear(): Logger;
-    close(): Logger;
-
-    // for cli and npm levels
-    error: LeveledLogMethod;
-    warn: LeveledLogMethod;
-    help: LeveledLogMethod;
-    data: LeveledLogMethod;
-    info: LeveledLogMethod;
-    debug: LeveledLogMethod;
-    prompt: LeveledLogMethod;
-    http: LeveledLogMethod;
-    verbose: LeveledLogMethod;
-    input: LeveledLogMethod;
-    silly: LeveledLogMethod;
-
-    // for syslog levels only
-    emerg: LeveledLogMethod;
-    alert: LeveledLogMethod;
-    crit: LeveledLogMethod;
-    warning: LeveledLogMethod;
-    notice: LeveledLogMethod;
+    log: LogMethod<L>;
+    add(transport: Transport): Logger<L>;
+    remove(transport: Transport): Logger<L>;
+    clear(): Logger<L>;
+    close(): Logger<L>;
 
     query(options?: QueryOptions, callback?: (err: Error, results: any) => void): any;
     stream(options?: any): NodeJS.ReadableStream;
 
-    startTimer(): Profiler;
-    profile(id: string | number, meta?: LogEntry): Logger;
+    startTimer(): Profiler<L>;
+    profile(id: string | number, meta?: LogEntry<L>): Logger<L>;
 
     configure(options: LoggerOptions): void;
 
-    child(options: Object): Logger;
+    child(options: Object): Logger<L>;
 
-    isLevelEnabled(level: level): boolean;
+    isLevelEnabled(level: L): boolean;
     isErrorEnabled(): boolean;
     isWarnEnabled(): boolean;
     isInfoEnabled(): boolean;
@@ -162,19 +140,19 @@ declare namespace winston {
     isDebugEnabled(): boolean;
     isSillyEnabled(): boolean;
 
-    new(options?: LoggerOptions): Logger;
-  }
+    new(options?: LoggerOptions<L>): Logger<L>;
+  };
 
-  interface Container {
-    loggers: Map<string, Logger>;
-    options: LoggerOptions;
+  interface Container<L extends string = Config.NpmLevels> {
+    loggers: Map<string, Logger<L>>;
+    options: LoggerOptions<L>;
 
-    add(id: string, options?: LoggerOptions): Logger;
-    get(id: string, options?: LoggerOptions): Logger;
+    add(id: string, options?: LoggerOptions): Logger<L>;
+    get(id: string, options?: LoggerOptions): Logger<L>;
     has(id: string): boolean;
     close(id?: string): void;
 
-    new(options?: LoggerOptions): Container;
+    new(options?: LoggerOptions<L>): Container<L>;
   }
 
   let version: string;
@@ -184,7 +162,7 @@ declare namespace winston {
   let loggers: Container;
 
   let addColors: (target: Config.AbstractConfigSetColors) => any;
-  let createLogger: (options?: LoggerOptions) => Logger;
+  let createLogger: <L extends string = Config.NpmLevels>(options?: LoggerOptions<L>) => Logger<L>;
 
   // Pass-through npm level methods routed to the default logger.
   let error: LeveledLogMethod;
@@ -206,7 +184,7 @@ declare namespace winston {
   let profile: (id: string | number) => Logger;
   let configure: (options: LoggerOptions) => void;
   let child: (options: Object) => Logger;
-  let level: level;
+  let level: Config.NpmLevels;
   let exceptions: ExceptionHandler;
   let rejections: RejectionHandler;
   let exitOnError: Function | boolean;

--- a/lib/winston/config/index.d.ts
+++ b/lib/winston/config/index.d.ts
@@ -4,86 +4,26 @@
 /// <reference types="node" />
 
 declare namespace winston {
-  interface AbstractConfigSetLevels {
-    [key: string]: number;
-  }
+  type AbstractConfigSetLevels<L extends string = string> = Record<L, number>;
 
-  interface AbstractConfigSetColors {
-    [key: string]: string | string[];
-  }
+  type AbstractConfigSetColors<L extends string = string> = Record<L, string|string[]>;
 
   interface AbstractConfigSet {
     levels: AbstractConfigSetLevels;
     colors: AbstractConfigSetColors;
   }
 
-  interface CliConfigSetLevels extends AbstractConfigSetLevels {
-    error: number;
-    warn: number;
-    help: number;
-    data: number;
-    info: number;
-    debug: number;
-    prompt: number;
-    verbose: number;
-    input: number;
-    silly: number;
-  }
+  type CliLevels = 'data'|'debug'|'error'|'info'|'input'|'help'|'prompt'|'silly'|'verbose'|'warn';
+  type CliConfigSetLevels = AbstractConfigSetLevels<CliLevels>;
+  type CliConfigSetColors = AbstractConfigSetColors<CliLevels>;
 
-  interface CliConfigSetColors extends AbstractConfigSetColors {
-    error: string | string[];
-    warn: string | string[];
-    help: string | string[];
-    data: string | string[];
-    info: string | string[];
-    debug: string | string[];
-    prompt: string | string[];
-    verbose: string | string[];
-    input: string | string[];
-    silly: string | string[];
-  }
+  type NpmLevels = 'debug'|'error'|'http'|'info'|'silly'|'verbose'|'warn';
+  type NpmConfigSetLevels = AbstractConfigSetLevels<NpmLevels>;
+  type NpmConfigSetColors = AbstractConfigSetColors<NpmLevels>;
 
-  interface NpmConfigSetLevels extends AbstractConfigSetLevels {
-    error: number;
-    warn: number;
-    info: number;
-    http: number;
-    verbose: number;
-    debug: number;
-    silly: number;
-  }
-
-  interface NpmConfigSetColors extends AbstractConfigSetColors {
-    error: string | string[];
-    warn: string | string[];
-    info: string | string[];
-    http: string | string[];
-    verbose: string | string[];
-    debug: string | string[];
-    silly: string | string[];
-  }
-
-  interface SyslogConfigSetLevels extends AbstractConfigSetLevels {
-    emerg: number;
-    alert: number;
-    crit: number;
-    error: number;
-    warning: number;
-    notice: number;
-    info: number;
-    debug: number;
-  }
-
-  interface SyslogConfigSetColors extends AbstractConfigSetColors {
-    emerg: string | string[];
-    alert: string | string[];
-    crit: string | string[];
-    error: string | string[];
-    warning: string | string[];
-    notice: string | string[];
-    info: string | string[];
-    debug: string | string[];
-  }
+  type SyslogLevels = 'alert'|'crit'|'debug'|'emerg'|'error'|'info'|'notice'|'warning';
+  type SyslogConfigSetLevels = AbstractConfigSetLevels<SyslogLevels>;
+  type SyslogConfigSetColors = AbstractConfigSetColors<SyslogLevels>;
 
   interface Config {
     allColors: AbstractConfigSetColors;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -22,6 +22,7 @@
     "noEmit": true
   },
   "files": [
+    "typescript-config-definitions.ts",
     "typescript-definitions.ts"
   ]
 }

--- a/test/typescript-config-definitions.ts
+++ b/test/typescript-config-definitions.ts
@@ -1,0 +1,70 @@
+import type { CliConfigSetColors, CliConfigSetLevels, NpmConfigSetColors, NpmConfigSetLevels, SyslogConfigSetColors, SyslogConfigSetLevels } from '../lib/winston/config';
+
+/** Config Types */
+const cliConfigLevels: CliConfigSetLevels = {
+  error: 0,
+  warn: 0,
+  help: 0,
+  data: 0,
+  info: 0,
+  debug: 0,
+  prompt: 0,
+  verbose: 0,
+  input: 0,
+  silly: 0
+}
+
+const cliConfigColors: CliConfigSetColors = {
+  error: "",
+  warn: "",
+  help: "",
+  data: "",
+  info: "",
+  debug: "",
+  prompt: "",
+  verbose:"",
+  input: [""],
+  silly: ["", ""]
+}
+
+const npmLogLevels: NpmConfigSetLevels = {
+  error: 0,
+  warn: 0,
+  info: 0,
+  http: 0,
+  verbose: 0,
+  debug: 0,
+  silly: 0
+}
+
+const npmColors: NpmConfigSetColors = {
+  error: "",
+  warn: "",
+  info: "",
+  http: "",
+  verbose: "",
+  debug: [""],
+  silly: ["", ""]
+}
+
+const syslogLevels: SyslogConfigSetLevels = {
+  emerg: 0,
+  alert: 0,
+  crit: 0,
+  error: 0,
+  warning: 0,
+  notice: 0,
+  info: 0,
+  debug: 0
+}
+
+const syslogColors: SyslogConfigSetColors = {
+  emerg: "",
+  alert: "",
+  crit: "",
+  error: "",
+  warning: "",
+  notice: "",
+  info: [""],
+  debug: ["", ""]
+}

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -57,3 +57,52 @@ logger.isInfoEnabled();
 logger.isVerboseEnabled();
 logger.isDebugEnabled();
 logger.isSillyEnabled();
+
+logger.error('error');
+logger.warn('warn');
+logger.info('info');
+logger.http('http');
+logger.verbose('verbose');
+logger.debug('debug');
+logger.silly('silly');
+// @ts-expect-error
+logger.notExists('notExists')
+
+const syslogLogger = winston.createLogger({
+    level: 'notice',
+    levels: {
+        emerg: 0,
+        alert: 1,
+        crit: 2,
+        error: 3,
+        warning: 4,
+        notice: 5,
+        info: 6,
+        debug: 7
+    },
+    format: winston.format.json(),
+    transports: [
+        new winston.transports.Console({ level: 'info' }),
+    ],
+});
+
+syslogLogger.emerg('emerg');
+syslogLogger.alert('alert');
+syslogLogger.crit('crit');
+syslogLogger.error('error');
+syslogLogger.warning('warning');
+syslogLogger.notice('notice');
+syslogLogger.info('info');
+syslogLogger.debug('debug');
+// @ts-expect-error
+syslogLogger.warn('warn') // using npm-level
+
+// Assign loglevel from a string #2047
+const stringLevel = 'test'
+winston.createLogger({
+    level: stringLevel,
+    format: winston.format.json(),
+    transports: [
+        new winston.transports.Console({ level: 'info' }),
+    ],
+});


### PR DESCRIPTION
Fixes #2047

v3.5.0 introduced typings changes that broke typings for  custom (non-npm) levels
Generous application of Generics allowed to circumvent the original issues, whilst maintaining typings improvements

Keeping in line with the spirit of #1896, use of default (npm-based) levels should see no change.

Users of custom (not the default npm-based ones), WILL have to tweak their type annotations.  
Whereas this used to work for <= 3.4.0
```typescript
import * as winston from 'winston';

const syslogLogger: winston.Logger = winston.createLogger({
    level: 'notice',
    levels: {
        emerg: 0,
        alert: 1,
        crit: 2,
        error: 3,
        warning: 4,
        notice: 5,
        info: 6,
        debug: 7
    },
    format: winston.format.json(),
    transports: [
        new winston.transports.Console({ level: 'info' }),
    ],
});
```

The type annotations will have to be given when using non-default values.
Here, for a logger using syslog-based levels.
And using the exported config.syslogLevels type
```typescript
import * as winston from 'winston';

const syslogLogger: winston.Logger<winston.config.syslogLevels> = winston.createLogger({
    level: 'notice',
    levels: {
        emerg: 0,
        alert: 1,
        crit: 2,
        error: 3,
        warning: 4,
        notice: 5,
        info: 6,
        debug: 7
    },
    format: winston.format.json(),
    transports: [
        new winston.transports.Console({ level: 'info' }),
    ],
});
```

---

Another change to the types is the logging functions are no longer hardcoded but dynamically typed from the `levels` configuration used (or the default one).

This should eliminate confusion between npm's `warn` level & syslog's `warning`.  
Both used to be in the types, so typescript wouldn't raise any issue at transpilation time.  

Same goes for any confusion that could've arisen from the previously hardcoded logging functions and whichever custom levels were used at runtime.