### PR TITLE
Memory leak fix: do not wait for `process.nextTick` to clear pending callbacks

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -314,8 +314,8 @@ class Logger extends Transform {
     } catch (ex) {
       throw ex;
     } finally {
-      // eslint-disable-next-line callback-return
       this._writableState.sync = false;
+      // eslint-disable-next-line callback-return
       callback();
     }
   }

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -315,6 +315,7 @@ class Logger extends Transform {
       throw ex;
     } finally {
       // eslint-disable-next-line callback-return
+      this._writableState.sync = false;
       callback();
     }
   }


### PR DESCRIPTION
Addresses the memory leak identified here:

https://github.com/winstonjs/winston/issues/1871#issuecomment-1025490757