### PR TITLE
Update to @colors/colors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "@dabh/eslint-config-populist",
   "rules": {
     "one-var": ["error", { "var": "never", "let": "never", "const": "never" }],
-    "linebreak-style": ["error", "windows"],
     "strict": 0
   },
   "parserOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,11 @@
         "@babel/cli": "^7.16.7",
         "@babel/core": "^7.16.7",
         "@babel/preset-env": "^7.16.7",
+        "@colors/colors": "1.5.0",
         "@dabh/eslint-config-populist": "^5.0.0",
         "@types/node": "^17.0.8",
         "abstract-winston-transport": "^0.5.1",
         "assume": "^2.2.0",
-        "colors": "1.4.0",
         "cross-spawn-async": "^2.2.5",
         "eslint": "^8.8.0",
         "hock": "^1.4.1",
@@ -1681,6 +1681,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -7987,6 +7996,12 @@
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true
     },
     "@dabh/diagnostics": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/node": "^17.0.8",
     "abstract-winston-transport": "^0.5.1",
     "assume": "^2.2.0",
-    "colors": "1.4.0",
+    "@colors/colors": "1.5.0",
     "cross-spawn-async": "^2.2.5",
     "eslint": "^8.8.0",
     "@dabh/eslint-config-populist": "^5.0.0",

--- a/test/integration/formats.test.js
+++ b/test/integration/formats.test.js
@@ -8,7 +8,7 @@
 
 var path = require('path'),
     assume = require('assume'),
-    colors = require('colors/safe'),
+    colors = require('@colors/colors/safe'),
     spawn = require('cross-spawn-async'),
     winston = require('../../lib/winston'),
     helpers = require('../helpers');


### PR DESCRIPTION
The `colors` package has been renamed/moved to `@colors/colors` per https://github.com/Marak/colors.js/issues/340.