### PR TITLE
Fix: add missing type definition of batch http option

### DIFF
--- a/lib/winston/transports/index.d.ts
+++ b/lib/winston/transports/index.d.ts
@@ -59,6 +59,9 @@ declare namespace winston {
     path?: string;
     agent?: Agent;
     headers?: object;
+    batch?: boolean;
+    batchInterval?: number;
+    batchCount?: number;
   }
 
   interface HttpTransportInstance extends Transport {


### PR DESCRIPTION
Hi, it looks like winston has support batch mode in HTTP Transport in recent release(#1970, https://github.com/winstonjs/winston/blob/b2fde9da5398f6129541454a9275d1243cc18b0b/lib/winston/transports/http.js#L41), but in the type definition file, it still not support do the batch HTTP related configuration.  
In this pull request, I add batch HTTP related types in transports type definition file to support configuration.