### PR TITLE
Update async to 3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "colors": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tools"
   ],
   "dependencies": {
-    "async": "~1.0.0",
+    "async": "^3.2.3",
     "colors": "1.0.x",
     "cycle": "1.0.x",
     "eyes": "0.1.x",


### PR DESCRIPTION
Since some of the other libraries still rely on the version `2` and it will take them some time to migrate, I open this PR to upgrade async from version `1` to `3` (yes huge difference but works the same) which at least will solve this [Snyk vulnerability](https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827) for `winston` 2.x.