### PR TITLE
Fix FileDescriptors release on file rotate [#2100]

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -169,7 +169,12 @@ module.exports = class File extends TransportStream {
       // This could potentially be optimized to not run a stat call but its
       // the safest way since we are supporting `maxFiles`.
       this._rotate = true;
-      this._endStream(() => this._rotateFile());
+      this._endStream(() => {
+        if (this._rotate === true) {
+          this._rotate = false;
+          this._rotateFile();
+        }
+      });
     }
 
     // Keep track of the pending bytes being written while files are opening


### PR DESCRIPTION
As reported by @kpalumbokitu in #2100 the file descriptors for rotated logs were not released after rotation. This change is an copy of the code provided by @kpalumbokitu in #2100.

This code works for me and also solves the problem of winston writing to multiple logfiles at the same time as reported in #1972 and #1905.