### PR TITLE
fix memory leak issue for winston.defaultLogger

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -82,7 +82,7 @@ exports.loggers = new exports.Container();
  *   winston.error('some error');
  */
 const defaultLogger = exports.createLogger({
-  transports: [new exports.transports.Console()]
+    transports: [new exports.transports.Console()]
 });
 
 // Pass through the target methods onto `winston.

--- a/lib/winston.js
+++ b/lib/winston.js
@@ -81,7 +81,9 @@ exports.loggers = new exports.Container();
  *   winston.log('info', 'some message');
  *   winston.error('some error');
  */
-const defaultLogger = exports.createLogger();
+const defaultLogger = exports.createLogger({
+  transports: [new exports.transports.Console()]
+});
 
 // Pass through the target methods onto `winston.
 Object.keys(exports.config.npm.levels)

--- a/lib/winston.js
+++ b/lib/winston.js
@@ -82,7 +82,7 @@ exports.loggers = new exports.Container();
  *   winston.error('some error');
  */
 const defaultLogger = exports.createLogger({
-    transports: [new exports.transports.Console()]
+  transports: [new exports.transports.Console()]
 });
 
 // Pass through the target methods onto `winston.

--- a/test/integration/winston.test.js
+++ b/test/integration/winston.test.js
@@ -21,7 +21,8 @@ describe('winston', function () {
   });
 
   it('has expected initial state', function () {
-    assume(winston.default.transports).deep.equals([]);
+    assume(winston.default.transports.length).equals(1);
+    assume(winston.default.transports[0].name).equals('console');
     assume(winston.level).equals('info');
   });
 


### PR DESCRIPTION
Fix memory leak issue related to https://github.com/winstonjs/winston/issues/2114, this is found in our prod. 

From heap dump, `defaultLogger` clearly has a strings leak issue and these strings are log strings in my test case. And all logs seem to be kept in `logger._writableState.buffer` if no transport is configured.

I dig a little bit into history seems https://github.com/winstonjs/winston/commit/3e3b43c11d21bc95f76f853f9c990b1e4f6d50cb#diff-e71cd9aaf26c1886e8bb0233d74710a47c1d32c203ad80baffc901c3073f604e remove Console transport from `defaultLogger`.

So I added it back.

Below are two memory heaps,
 1. memory heap with **Winston version 3.7.2** and node version v16.15.0
 The log string object `distance` is too large and chain by `next` which probability hold by `logger._writableState.buffer`.

 ![heap-issue](https://user-images.githubusercontent.com/1803942/169867815-d4c804f8-dce9-45dd-84b8-41f0609744e1.jpg)

   Heap dump: [Heap-winston3.7.2.zip](https://github.com/winstonjs/winston/files/8756500/Heap-winston3.7.2.zip)

2. memory heap with **this PR code**
![fixedversion](https://user-images.githubusercontent.com/1803942/169872812-2eab4edc-c612-4e8d-a1af-48a2628451b7.jpg)
 Heap dump: [Heap-fixedversion.zip](https://github.com/winstonjs/winston/files/8756503/Heap-fixedversion.zip)

Test code
```js
const w = require('winston')
// const w = require('./lib/winston')

setInterval(() => {
    w.error('test'.repeat(100))
}, 10)
```
