### PR TITLE
enhance message for logs with no transports #2114

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -300,7 +300,7 @@ class Logger extends Transform {
     if (!this._readableState.pipes) {
       // eslint-disable-next-line no-console
       console.error(
-        '[winston] Attempt to write logs with no transports, logger with no transports may produce a high memory usage issue %j',
+        '[winston] Attempt to write logs with no transports, which can increase memory usage: %j',
         info
       );
     }

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -300,7 +300,7 @@ class Logger extends Transform {
     if (!this._readableState.pipes) {
       // eslint-disable-next-line no-console
       console.error(
-        '[winston] Attempt to write logs with no transports %j',
+        '[winston] Attempt to write logs with no transports, logger with no transports may produce a high memory usage issue %j',
         info
       );
     }


### PR DESCRIPTION
If the user uses logger **with no transports**, Winston will only console certain logs with a warning.
![image](https://user-images.githubusercontent.com/1803942/170485313-f412cb22-cd24-46a2-9612-47c1c9c7c09d.png)

As we add documentation for the point memory issue in PR #2138. Today, when I discuss this with team member cc @superobin, maybe it's better to enhance the existing no transports warning message.

Message in this PR:

![image](https://user-images.githubusercontent.com/1803942/170486239-fedb0031-3caa-41f5-82e6-822e14f1b162.png)

Test code :
```js
const w = require('winston')
// const w = require('./lib/winston')

setInterval(() => {
    w.error('test'.repeat(100))
}, 10)
```