### PR TITLE
Add the stringify replacer option to the HTTP transport

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -262,6 +262,6 @@ module.exports = class Http extends TransportStream {
     req.on('response', res => (
       res.on('end', () => callback(null, res)).resume()
     ));
-    req.end(Buffer.from(jsonStringify(options), 'utf8'));
+    req.end(Buffer.from(jsonStringify(options, this.options.replacer), 'utf8'));
   }
 };

--- a/lib/winston/transports/index.d.ts
+++ b/lib/winston/transports/index.d.ts
@@ -62,6 +62,7 @@ declare namespace winston {
     batch?: boolean;
     batchInterval?: number;
     batchCount?: number;
+    replacer?: (key: string, value: any) => any;
   }
 
   interface HttpTransportInstance extends Transport {


### PR DESCRIPTION
Support custom stringify replacer when sending logs via HTTP transport.

Usage of the `format.json` with the custom replacer does not work with
HTTP transport since the message symlink ([which is mutated](https://github.com/winstonjs/logform/blob/master/json.js#L28)) is not sent
in the request.

Work done:
- Add the replacer property into the type of the `HttpTransportOptions`
- Use the replacer from the options optionally in the `jsonStringify` of HTTP transport