### PR TITLE
Utilizing async 2.6.4 for node 4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## v2.4.6
+## v2.4.7
 
 - [#2130] Update async dependency for node 4 compatibility
+
+## v2.4.6
+
 - [#2112] Update async dependency to address https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827
 
 ## v2.4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v2.4.6
 
+- [#2130] Update async dependency for node 4 compatibility
 - [#2112] Update async dependency to address https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827
 
 ## v2.4.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,19 @@
   "requires": true,
   "dependencies": {
     "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "requires": {
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
     },
     "colors": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tools"
   ],
   "dependencies": {
-    "async": "^3.2.3",
+    "async": "^2.6.4",
     "colors": "1.0.x",
     "cycle": "1.0.x",
     "eyes": "0.1.x",


### PR DESCRIPTION
Good afternoon Winston developers,

This PR is to restore node 4 compatibility while maintain the CVE fix linked here: https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827

This is in regards to this issue: https://github.com/winstonjs/winston/issues/2130

I attempted to update the testing, but the 2.X branch does not have the CI/CD workflow. So I tested it manually and it passed.

Please let me know if you have any questions.