### PR TITLE
Update lodash to fix audit failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## v2.4.7
+
+- Update lodash packages to fix audit failures
+
 ## v2.4.6
 
 - [#2112] Update async dependency to address https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827
-- Update lodash packages to fix audit failures
 
 ## v2.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - [#2130] Update async dependency for node 4 compatibility
 - Update lodash packages to fix audit failures
-=======
 
 ## v2.4.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.4.6
 
 - [#2112] Update async dependency to address https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827
+- Update lodash packages to fix audit failures
 
 ## v2.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v2.4.7
 
+- [#2130] Update async dependency for node 4 compatibility
 - Update lodash packages to fix audit failures
 
 ## v2.4.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "colors": {
       "version": "1.0.3",
@@ -68,10 +68,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lru-cache": {
       "version": "4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,12 @@
   "requires": true,
   "dependencies": {
     "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "colors": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tools"
   ],
   "dependencies": {
-    "async": "^3.2.3",
+    "async": "^2.6.4",
     "colors": "1.0.x",
     "cycle": "1.0.x",
     "eyes": "0.1.x",


### PR DESCRIPTION
Hello Winston developers,

When working on this PR: https://github.com/winstonjs/winston/pull/2166, there was some `lodash` vulnerabilities that looked concerning. I updated the package accordingly. The changes successfully tested in both node 10 and node 4.

This is a separate PR so that you can decide whether you wish to include these changes.

Note: Due to the CHANGELOG, there will likely be a merge conflict between these two PRs. If you'd like I can combine them (this and #2166) into a single PR.