### PR TITLE
Handle undefined errors in getAllInfo in exception-handler

### DIFF
--- a/lib/winston/exception-handler.js
+++ b/lib/winston/exception-handler.js
@@ -73,9 +73,9 @@ module.exports = class ExceptionHandler {
    * @returns {mixed} - TODO: add return description.
    */
   getAllInfo(err) {
-    let { message } = err;
-    if (!message && typeof err === 'string') {
-      message = err;
+    let message = null;
+    if (err) {
+      message = typeof err === 'string' ? err : err.message;
     }
 
     return {
@@ -84,9 +84,9 @@ module.exports = class ExceptionHandler {
       level: 'error',
       message: [
         `uncaughtException: ${(message || '(no error message)')}`,
-        err.stack || '  No stack trace'
+        err && err.stack || '  No stack trace'
       ].join('\n'),
-      stack: err.stack,
+      stack: err && err.stack,
       exception: true,
       date: new Date().toString(),
       process: this.getProcessInfo(),

--- a/test/unit/winston/exception-handler.test.js
+++ b/test/unit/winston/exception-handler.test.js
@@ -106,6 +106,12 @@ describe('ExceptionHandler', function () {
     helpers.throw('wtf this error');
   });
 
+  it('.getAllInfo(undefined)', function () {
+    var handler = helpers.exceptionHandler();
+    // eslint-disable-next-line no-undefined
+    handler.getAllInfo(undefined);
+  });
+
   after(function () {
     //
     // Restore normal `runTest` functionality


### PR DESCRIPTION
This PR is basically the same as this: https://github.com/winstonjs/winston/pull/1961, except this one applies the same fix to `exception-handler.js`. I was seeing an error reported from `getAllInfo` in the `exception-handler.js` for certain errors that are passed down as `null` or `undefined` (for whatever reason).