### PR TITLE
[Fix] logger.info({message:...}) modifies original object

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -76,7 +76,7 @@ module.exports = function (opts = {}) {
       if (args.length === 1) {
         const [msg] = args;
         const info = msg && msg.message && msg || { message: msg };
-        const cloneInfo = Object.assign(Object.create(info), info)
+        const cloneInfo = Object.assign(Object.create(info), info);
         cloneInfo.level = cloneInfo[LEVEL] = level;
         self._addDefaultMeta(cloneInfo);
         self.write(cloneInfo);

--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -76,9 +76,10 @@ module.exports = function (opts = {}) {
       if (args.length === 1) {
         const [msg] = args;
         const info = msg && msg.message && msg || { message: msg };
-        info.level = info[LEVEL] = level;
-        self._addDefaultMeta(info);
-        self.write(info);
+        const cloneInfo = Object.assign(Object.create(info), info)
+        cloneInfo.level = cloneInfo[LEVEL] = level;
+        self._addDefaultMeta(cloneInfo);
+        self.write(cloneInfo);
         return (this || logger);
       }
 

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -220,15 +220,16 @@ class Logger extends Transform {
     // Slightly less hotpath, but worth optimizing for.
     if (arguments.length === 2) {
       if (msg && typeof msg === 'object') {
-        msg[LEVEL] = msg.level = level;
-        this._addDefaultMeta(msg);
-        this.write(msg);
+        const cloneMsg=Object.assign(Object.create(msg), msg)
+        cloneMsg[LEVEL] = cloneMsg.level = level;
+        this._addDefaultMeta(cloneMsg);
+        this.write(cloneMsg);
         return this;
       }
 
-      msg = { [LEVEL]: level, level, message: msg };
-      this._addDefaultMeta(msg);
-      this.write(msg);
+      const obj = { [LEVEL]: level, level, message: msg };
+      this._addDefaultMeta(obj);
+      this.write(obj);
       return this;
     }
 

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -211,16 +211,17 @@ class Logger extends Transform {
       // Yo dawg, I heard you like levels ... seriously ...
       // In this context the LHS `level` here is actually the `info` so read
       // this as: info[LEVEL] = info.level;
-      level[LEVEL] = level.level;
-      this._addDefaultMeta(level);
-      this.write(level);
+      const cloneLevel = Object.assign(Object.create(level), level);
+      cloneLevel[LEVEL] = level.level;
+      this._addDefaultMeta(cloneLevel);
+      this.write(cloneLevel);
       return this;
     }
 
     // Slightly less hotpath, but worth optimizing for.
     if (arguments.length === 2) {
       if (msg && typeof msg === 'object') {
-        const cloneMsg=Object.assign(Object.create(msg), msg)
+        const cloneMsg = Object.assign(Object.create(msg), msg);
         cloneMsg[LEVEL] = cloneMsg.level = level;
         this._addDefaultMeta(cloneMsg);
         this.write(cloneMsg);

--- a/test/unit/winston/logger.test.js
+++ b/test/unit/winston/logger.test.js
@@ -701,6 +701,7 @@ describe('Logger Instance', function () {
 
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
+          assume(info).equals(err);
           done();
         });
 
@@ -771,6 +772,7 @@ describe('Logger Instance', function () {
         const err = new Error('test');
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
+          assume(info).is.not.equals(err)
           done();
         });
 
@@ -957,6 +959,7 @@ describe('Logger Instance', function () {
         const err = new Error('test');
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
+          assume(info).is.not.equals(err)
           done();
         });
 

--- a/test/unit/winston/logger.test.js
+++ b/test/unit/winston/logger.test.js
@@ -701,7 +701,6 @@ describe('Logger Instance', function () {
 
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
-          assume(info).equals(err);
           done();
         });
 
@@ -772,7 +771,6 @@ describe('Logger Instance', function () {
         const err = new Error('test');
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
-          assume(info).equals(err);
           done();
         });
 
@@ -959,7 +957,6 @@ describe('Logger Instance', function () {
         const err = new Error('test');
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
-          assume(info).equals(err);
           done();
         });
 

--- a/test/unit/winston/logger.test.js
+++ b/test/unit/winston/logger.test.js
@@ -26,7 +26,7 @@ const testLogFixturesPath = path.join(__dirname, '..', '..', 'fixtures', 'logs')
 describe('Logger Instance', function () {
   describe('Configuration', function () {
     it('.configure()', function () {
-      let logger = winston.createLogger({
+      const logger = winston.createLogger({
         transports: [new winston.transports.Console()]
       });
 
@@ -39,7 +39,7 @@ describe('Logger Instance', function () {
     });
 
     it('.configure({ transports })', function () {
-      let logger = winston.createLogger();
+      const logger = winston.createLogger();
 
       assume(logger.transports.length).equals(0);
 
@@ -52,8 +52,8 @@ describe('Logger Instance', function () {
     });
 
     it('.configure({ transports, format })', function () {
-      let logger = winston.createLogger(),
-          format = logger.format;
+      const logger = winston.createLogger();
+      const format = logger.format;
 
       assume(logger.transports.length).equals(0);
 
@@ -68,23 +68,23 @@ describe('Logger Instance', function () {
     });
   });
 
-  describe('Transports', function() {
+  describe('Transports', function () {
     describe('add', function () {
       it('should throw error when adding an invalid transport', function () {
-        let logger = winston.createLogger();
+        const logger = winston.createLogger();
         assume(function () {
           logger.add(5);
         }).throws(/invalid transport/i);
       });
 
       it('should add the expected transport', function (done) {
-        let logger = winston.createLogger();
-        let expected = {message: 'foo', level: 'info'};
-        let transport = new TransportStream({
+        const logger = winston.createLogger();
+        const expected = { message: 'foo', level: 'info' };
+        const transport = new TransportStream({
           log: function (info) {
             assume(info.message).equals('foo');
             assume(info.level).equals('info');
-            assume(JSON.parse(info[MESSAGE])).deep.equals({level: 'info', message: 'foo'});
+            assume(JSON.parse(info[MESSAGE])).deep.equals({ level: 'info', message: 'foo' });
             done();
           }
         });
@@ -94,7 +94,7 @@ describe('Logger Instance', function () {
       });
 
       it('should allow adding multiple transports', function () {
-        let transports = [
+        const transports = [
           new winston.transports.File({
             name: 'filelog-info.log',
             filename: path.join(testLogFixturesPath, 'filelog-info.log'),
@@ -106,7 +106,7 @@ describe('Logger Instance', function () {
             level: 'error'
           })
         ];
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           transports: transports
         });
 
@@ -119,13 +119,13 @@ describe('Logger Instance', function () {
 
     describe('remove', function () {
       it('should do nothing if transport was not added', function () {
-        let transports = [
+        const transports = [
           new winston.transports.Console(),
-          new winston.transports.File({filename: path.join(testLogFixturesPath, 'filelog.log')})
+          new winston.transports.File({ filename: path.join(testLogFixturesPath, 'filelog.log') })
         ];
 
-        let logger = winston.createLogger({transports: transports})
-            .remove(new winston.transports.Console());
+        const logger = winston.createLogger({ transports: transports })
+          .remove(new winston.transports.Console());
 
         assume(logger.transports.length).equals(2);
         assume(logger.transports.map(function (wrap) {
@@ -135,12 +135,12 @@ describe('Logger Instance', function () {
       });
 
       it('should remove transport when matching one is found', function () {
-        let transports = [
+        const transports = [
           new winston.transports.Console(),
-          new winston.transports.File({filename: path.join(testLogFixturesPath, 'filelog.log')})
+          new winston.transports.File({ filename: path.join(testLogFixturesPath, 'filelog.log') })
         ];
 
-        let logger = winston.createLogger({transports: transports});
+        const logger = winston.createLogger({ transports: transports });
 
         assume(logger.transports.length).equals(2);
         logger.remove(transports[0]);
@@ -149,7 +149,7 @@ describe('Logger Instance', function () {
       });
 
       it('should remove specified logger even when duplicate exists', function () {
-        let transports = [
+        const transports = [
           new winston.transports.File({
             name: 'filelog-info.log',
             filename: path.join(testLogFixturesPath, 'filelog-info.log'),
@@ -161,7 +161,7 @@ describe('Logger Instance', function () {
             level: 'error'
           })
         ];
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           transports: transports
         });
 
@@ -173,14 +173,14 @@ describe('Logger Instance', function () {
 
     describe('clear', function () {
       it('should do nothing when no transports exist', function () {
-        let logger = winston.createLogger();
+        const logger = winston.createLogger();
         assume(logger.transports.length).equals(0);
         logger.clear();
         assume(logger.transports.length).equals(0);
       });
 
       it('should remove all transports', function () {
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           transports: [new winston.transports.Console()]
         });
 
@@ -192,8 +192,8 @@ describe('Logger Instance', function () {
 
     describe('stream', function () {
       it('should return a log stream for all transports', function () {
-        let logger = winston.createLogger();
-        let outStream = logger.stream();
+        const logger = winston.createLogger();
+        const outStream = logger.stream();
 
         assume(isStream(outStream)).true();
       });
@@ -203,20 +203,20 @@ describe('Logger Instance', function () {
   describe('Log Levels', function () {
     it('report unknown levels', function (done) {
       stdMocks.use();
-      let logger = helpers.createLogger(function (info) {
+      const logger = helpers.createLogger(function (info) {
       });
-      let expected = {message: 'foo', level: 'bar'};
+      const expected = { message: 'foo', level: 'bar' };
       logger.log(expected);
 
       stdMocks.restore();
-      let output = stdMocks.flush();
+      const output = stdMocks.flush();
 
       assume(output.stderr).deep.equals(['[winston] Unknown logger level: bar\n']);
       done();
     });
 
     it('.<level>()', function (done) {
-      let logger = helpers.createLogger(function (info) {
+      const logger = helpers.createLogger(function (info) {
         assume(info).is.an('object');
         assume(info.level).equals('info');
         assume(info.message).is.a('string');
@@ -235,8 +235,8 @@ describe('Logger Instance', function () {
     });
 
     it('default levels', function (done) {
-      let logger = winston.createLogger();
-      let expected = {message: 'foo', level: 'debug'};
+      const logger = winston.createLogger();
+      const expected = { message: 'foo', level: 'debug' };
 
       function logLevelTransport(level) {
         return new TransportStream({
@@ -248,7 +248,7 @@ describe('Logger Instance', function () {
 
             assume(obj.message).equals('foo');
             assume(obj.level).equals('debug');
-            assume(JSON.parse(obj[MESSAGE])).deep.equals({level: 'debug', message: 'foo'});
+            assume(JSON.parse(obj[MESSAGE])).deep.equals({ level: 'debug', message: 'foo' });
             done();
           }
         });
@@ -258,13 +258,13 @@ describe('Logger Instance', function () {
       assume(logger.debug).is.a('function');
 
       logger
-          .add(logLevelTransport('info'))
-          .add(logLevelTransport('debug'))
-          .log(expected);
+        .add(logLevelTransport('info'))
+        .add(logLevelTransport('debug'))
+        .log(expected);
     });
 
     it('custom levels', function (done) {
-      let logger = winston.createLogger({
+      const logger = winston.createLogger({
         levels: {
           bad: 0,
           test: 1,
@@ -272,7 +272,7 @@ describe('Logger Instance', function () {
         }
       });
 
-      let expected = {message: 'foo', level: 'test'};
+      const expected = { message: 'foo', level: 'test' };
 
       function filterLevelTransport(level) {
         return new TransportStream({
@@ -284,7 +284,7 @@ describe('Logger Instance', function () {
 
             assume(obj.message).equals('foo');
             assume(obj.level).equals('test');
-            assume(JSON.parse(obj[MESSAGE])).deep.equals({level: 'test', message: 'foo'});
+            assume(JSON.parse(obj[MESSAGE])).deep.equals({ level: 'test', message: 'foo' });
             done();
           }
         });
@@ -295,9 +295,9 @@ describe('Logger Instance', function () {
       assume(logger.ok).is.a('function');
 
       logger
-          .add(filterLevelTransport('bad'))
-          .add(filterLevelTransport('ok'))
-          .log(expected);
+        .add(filterLevelTransport('bad'))
+        .add(filterLevelTransport('ok'))
+        .log(expected);
     });
 
     it('sets transports levels', done => {
@@ -310,7 +310,7 @@ describe('Logger Instance', function () {
 
           assume(obj.message).equals('foo');
           assume(obj.level).equals('error');
-          assume(JSON.parse(obj[MESSAGE])).deep.equals({level: 'error', message: 'foo'});
+          assume(JSON.parse(obj[MESSAGE])).deep.equals({ level: 'error', message: 'foo' });
           done();
         }
       });
@@ -318,8 +318,8 @@ describe('Logger Instance', function () {
       // Begin our test in the next tick after the pipe event is
       // emitted from the transport.
       transport.once('pipe', () => setImmediate(() => {
-        const expectedError = {message: 'foo', level: 'error'};
-        const expectedInfo = {message: 'bar', level: 'info'};
+        const expectedError = { message: 'foo', level: 'error' };
+        const expectedInfo = { message: 'bar', level: 'info' };
 
         assume(logger.error).is.a('function');
         assume(logger.info).is.a('function');
@@ -329,8 +329,8 @@ describe('Logger Instance', function () {
 
         // Log the messages. "info" should never arrive.
         logger
-            .log(expectedInfo)
-            .log(expectedError);
+          .log(expectedInfo)
+          .log(expectedError);
       }));
 
       logger = winston.createLogger({
@@ -340,7 +340,7 @@ describe('Logger Instance', function () {
 
     describe('Log Levels Enabled', function () {
       it('default levels', function () {
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           level: 'verbose',
           levels: winston.config.npm.levels,
           transports: [new winston.transports.Console()]
@@ -371,10 +371,10 @@ describe('Logger Instance', function () {
       });
 
       it('default levels, transport override', function () {
-        let transport = new winston.transports.Console();
+        const transport = new winston.transports.Console();
         transport.level = 'debug';
 
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           level: 'info',
           levels: winston.config.npm.levels,
           transports: [transport]
@@ -405,7 +405,7 @@ describe('Logger Instance', function () {
       });
 
       it('default levels, no transports', function () {
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           level: 'verbose',
           levels: winston.config.npm.levels,
           transports: []
@@ -436,7 +436,7 @@ describe('Logger Instance', function () {
       });
 
       it('custom levels', function () {
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           level: 'test',
           levels: {
             bad: 0,
@@ -462,7 +462,7 @@ describe('Logger Instance', function () {
       });
 
       it('custom levels, no transports', function () {
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           level: 'test',
           levels: {
             bad: 0,
@@ -488,10 +488,10 @@ describe('Logger Instance', function () {
       });
 
       it('custom levels, transport override', function () {
-        let transport = new winston.transports.Console();
+        const transport = new winston.transports.Console();
         transport.level = 'ok';
 
-        let logger = winston.createLogger({
+        const logger = winston.createLogger({
           level: 'bad',
           levels: {
             bad: 0,
@@ -515,7 +515,7 @@ describe('Logger Instance', function () {
         assume(logger.isTestEnabled()).true();
         assume(logger.isOkEnabled()).true();
       });
-    })
+    });
   });
 
   describe('Transport Events', function () {
@@ -536,7 +536,7 @@ describe('Logger Instance', function () {
       ];
 
       const finished = [];
-      const logger = winston.createLogger({transports});
+      const logger = winston.createLogger({ transports });
 
       // Assert each transport emits finish
       transports.forEach((transport, i) => {
@@ -586,7 +586,7 @@ describe('Logger Instance', function () {
       });
       consoleTransport.emit('warn', new Error());
     });
-  })
+  });
 
   describe('Formats', function () {
     it(`rethrows errors from user-defined formats`, function () {
@@ -623,11 +623,11 @@ describe('Logger Instance', function () {
       assume(actual.stdout).deep.equals(expected.map(msg => `${msg}${EOL}`));
       assume(actual.stderr).deep.equals([]);
     });
-  })
+  });
 
   describe('Profiling', function () {
     it('ending profiler with object argument should be included in output', function (done) {
-      let logger = helpers.createLogger(function (info) {
+      const logger = helpers.createLogger(function (info) {
         assume(info).is.an('object');
         assume(info.something).equals('ok');
         assume(info.level).equals('info');
@@ -642,13 +642,13 @@ describe('Logger Instance', function () {
         logger.profile('testing1', {
           something: 'ok',
           level: 'info'
-        })
+        });
       }, 100);
     });
 
     // TODO: Revisit if this is a valid test
     it('calling profile with a callback function should not make a difference', function (done) {
-      let logger = helpers.createLogger(function (info) {
+      const logger = helpers.createLogger(function (info) {
         assume(info).is.an('object');
         assume(info.something).equals('ok');
         assume(info.level).equals('info');
@@ -666,12 +666,12 @@ describe('Logger Instance', function () {
         logger.profile('testing2', {
           something: 'ok',
           level: 'info'
-        })
+        });
       }, 100);
     });
 
     it('should stop a timer when `done` is called on it', function (done) {
-      let logger = helpers.createLogger(function (info) {
+      const logger = helpers.createLogger(function (info) {
         assume(info).is.an('object');
         assume(info.something).equals('ok');
         assume(info.level).equals('info');
@@ -681,7 +681,7 @@ describe('Logger Instance', function () {
         done();
       });
 
-      let timer = logger.startTimer();
+      const timer = logger.startTimer();
       setTimeout(function () {
         timer.done({
           message: 'testing1',
@@ -701,7 +701,7 @@ describe('Logger Instance', function () {
 
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
-          assume(info).equals(err);
+          assume(info).is.not.equals(err);
           done();
         });
 
@@ -718,7 +718,7 @@ describe('Logger Instance', function () {
           if (logged.length === 1) done();
         });
 
-        logger.info('Hello', {label: 'world'});
+        logger.info('Hello', { label: 'world' });
       });
 
       it(`.info('Hello %d') does not mutate unnecessarily with string interpolation tokens`, function (done) {
@@ -731,7 +731,7 @@ describe('Logger Instance', function () {
           if (logged.length === 1) done();
         });
 
-        logger.info('Hello %j', {label: 'world'}, {extra: true});
+        logger.info('Hello %j', { label: 'world' }, { extra: true });
       });
 
       it(`.info('Hello') and .info('Hello %d') preserve meta with splat format`, function (done) {
@@ -744,8 +744,8 @@ describe('Logger Instance', function () {
           if (logged.length === 2) done();
         }, format.splat());
 
-        logger.info('Hello', {label: 'world'});
-        logger.info('Hello %d', 100, {label: 'world'});
+        logger.info('Hello', { label: 'world' });
+        logger.info('Hello %d', 100, { label: 'world' });
       });
     });
 
@@ -772,7 +772,7 @@ describe('Logger Instance', function () {
         const err = new Error('test');
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
-          assume(info).is.not.equals(err)
+          assume(info).is.not.equals(err);
           done();
         });
 
@@ -807,7 +807,7 @@ describe('Logger Instance', function () {
           ]
         });
 
-        const childLogger = logger.child({requestId: '451'});
+        const childLogger = logger.child({ requestId: '451' });
         childLogger.info('dummy message');
       });
 
@@ -825,8 +825,8 @@ describe('Logger Instance', function () {
           ]
         });
 
-        const childLogger = logger.child({requestId: '451'});
-        childLogger.info({text: 'dummy'});
+        const childLogger = logger.child({ requestId: '451' });
+        childLogger.info({ text: 'dummy' });
       });
 
       it('merges child and provided meta correctly', (done) => {
@@ -844,8 +844,8 @@ describe('Logger Instance', function () {
           ]
         });
 
-        const childLogger = logger.child({service: 'user-service'});
-        childLogger.info('dummy message', {requestId: '451'});
+        const childLogger = logger.child({ service: 'user-service' });
+        childLogger.info('dummy message', { requestId: '451' });
       });
 
       it('provided meta take precedence over defaultMeta', (done) => {
@@ -858,7 +858,7 @@ describe('Logger Instance', function () {
         });
 
         const logger = winston.createLogger({
-          defaultMeta: {service: 'user-service'},
+          defaultMeta: { service: 'user-service' },
           transports: [
             mockTransport.createMockTransport(assertFn)
           ]
@@ -885,7 +885,7 @@ describe('Logger Instance', function () {
           ]
         });
 
-        const childLogger = logger.child({service: 'user-service'});
+        const childLogger = logger.child({ service: 'user-service' });
         childLogger.info('dummy message', {
           requestId: '451',
           service: 'audit-service'
@@ -907,7 +907,7 @@ describe('Logger Instance', function () {
           ]
         });
 
-        const childLogger = logger.child({service: 'user-service'});
+        const childLogger = logger.child({ service: 'user-service' });
         childLogger.error(Error('dummy error'));
       });
 
@@ -926,7 +926,7 @@ describe('Logger Instance', function () {
   describe('Backwards Compatability', function () {
     describe('Winston V2 Log', function () {
       it('.log(level, message)', function (done) {
-        let logger = helpers.createLogger(function (info) {
+        const logger = helpers.createLogger(function (info) {
           assume(info).is.an('object');
           assume(info.level).equals('info');
           assume(info.message).equals('Some super awesome log message');
@@ -934,7 +934,7 @@ describe('Logger Instance', function () {
           done();
         });
 
-        logger.log('info', 'Some super awesome log message')
+        logger.log('info', 'Some super awesome log message');
       });
 
       it(`.log(level, undefined) creates info with { message: undefined }`, function (done) {
@@ -959,7 +959,7 @@ describe('Logger Instance', function () {
         const err = new Error('test');
         const logger = helpers.createLogger(function (info) {
           assume(info).instanceOf(Error);
-          assume(info).is.not.equals(err)
+          assume(info).is.not.equals(err);
           done();
         });
 
@@ -967,8 +967,8 @@ describe('Logger Instance', function () {
       });
 
       it('.log(level, message, meta)', function (done) {
-        let meta = {one: 2};
-        let logger = helpers.createLogger(function (info) {
+        const meta = { one: 2 };
+        const logger = helpers.createLogger(function (info) {
           assume(info).is.an('object');
           assume(info.level).equals('info');
           assume(info.message).equals('Some super awesome log message');
@@ -982,39 +982,39 @@ describe('Logger Instance', function () {
 
       it('.log(level, formatStr, ...splat)', function (done) {
         const format = winston.format.combine(
-            winston.format.splat(),
-            winston.format.printf(info => `${info.level}: ${info.message}`)
+          winston.format.splat(),
+          winston.format.printf(info => `${info.level}: ${info.message}`)
         );
 
-        let logger = helpers.createLogger(function (info) {
+        const logger = helpers.createLogger(function (info) {
           assume(info).is.an('object');
           assume(info.level).equals('info');
           assume(info.message).equals('100% such wow {"much":"javascript"}');
-          assume(info[SPLAT]).deep.equals([100, 'wow', {much: 'javascript'}]);
+          assume(info[SPLAT]).deep.equals([100, 'wow', { much: 'javascript' }]);
           assume(info[MESSAGE]).equals('info: 100% such wow {"much":"javascript"}');
           done();
         }, format);
 
-        logger.log('info', '%d%% such %s %j', 100, 'wow', {much: 'javascript'});
+        logger.log('info', '%d%% such %s %j', 100, 'wow', { much: 'javascript' });
       });
 
       it('.log(level, formatStr, ...splat, meta)', function (done) {
         const format = winston.format.combine(
-            winston.format.splat(),
-            winston.format.printf(info => `${info.level}: ${info.message} ${JSON.stringify({thisIsMeta: info.thisIsMeta})}`)
+          winston.format.splat(),
+          winston.format.printf(info => `${info.level}: ${info.message} ${JSON.stringify({ thisIsMeta: info.thisIsMeta })}`)
         );
 
-        let logger = helpers.createLogger(function (info) {
+        const logger = helpers.createLogger(function (info) {
           assume(info).is.an('object');
           assume(info.level).equals('info');
           assume(info.message).equals('100% such wow {"much":"javascript"}');
-          assume(info[SPLAT]).deep.equals([100, 'wow', {much: 'javascript'}]);
+          assume(info[SPLAT]).deep.equals([100, 'wow', { much: 'javascript' }]);
           assume(info.thisIsMeta).true();
           assume(info[MESSAGE]).equals('info: 100% such wow {"much":"javascript"} {"thisIsMeta":true}');
           done();
         }, format);
 
-        logger.log('info', '%d%% such %s %j', 100, 'wow', {much: 'javascript'}, {thisIsMeta: true});
+        logger.log('info', '%d%% such %s %j', 100, 'wow', { much: 'javascript' }, { thisIsMeta: true });
       });
     });
   });


### PR DESCRIPTION
Hi @wbt ,

This PR closes #1775 

## What is wrong here?

When we copy the original object to a new object it also copies the reference of the original object to avoid this we need to implement deep copy which stores two objects in two different locations.

## Work

- Update `lib/winston/create-logger.js` and `lib/winston/logger.js`
- Update test cases in `test/unit/winston/logger.test.js`

Thank you!! waiting for your response.
