### PR TITLE
Defensively cleanup streams

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -88,6 +88,7 @@ module.exports = class File extends TransportStream {
     this._drain = false;
     this._opening = false;
     this._ending = false;
+    this._streams = [];
 
     if (this.dirname) this._createLogDirIfNotExist(this.dirname);
     this.open();
@@ -114,7 +115,7 @@ module.exports = class File extends TransportStream {
    * @param {Function} callback - TODO: add param description.
    * @returns {undefined}
    */
-  log(info, callback = () => {}) {
+  log(info, callback = () => { }) {
     // Remark: (jcrugzz) What is necessary about this callback(null, true) now
     // when thinking about 3.x? Should silent be handled in the base
     // TransportStream _write method?
@@ -503,7 +504,11 @@ module.exports = class File extends TransportStream {
   _cleanupStream(stream) {
     stream.on('close', () => console.log('closed'));
     stream.removeListener('error', this._onError);
-    stream.destroy();
+    let streamToClose = this._streams.pop();
+    while (streamToClose) {
+      streamToClose.destroy();
+      streamToClose = this._streams.pop();
+    }
     return stream;
   }
 
@@ -521,7 +526,7 @@ module.exports = class File extends TransportStream {
    * @param {function} callback - Callback for when the current file has closed.
    * @private
    */
-  _endStream(callback = () => {}) {
+  _endStream(callback = () => { }) {
     if (this._dest) {
       this._stream.unpipe(this._dest);
       this._dest.end(() => {
@@ -565,6 +570,8 @@ module.exports = class File extends TransportStream {
           source.end();
         }
       });
+
+    this._streams.push(dest);
 
     debug('create stream ok', fullpath);
     if (this.zippedArchive) {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -88,7 +88,11 @@ module.exports = class File extends TransportStream {
     this._drain = false;
     this._opening = false;
     this._ending = false;
-    this._streams = [];
+
+    // https://github.com/winstonjs/winston/issues/2100
+    // Array to collect write streams created in this transport 
+    // for destruction later
+    this._writeStreams = [];
 
     if (this.dirname) this._createLogDirIfNotExist(this.dirname);
     this.open();
@@ -401,6 +405,13 @@ module.exports = class File extends TransportStream {
       debug('stat done: %s { size: %s }', this.filename, size);
       this._size = size;
       this._dest = this._createStream(this._stream);
+
+      // https://github.com/winstonjs/winston/issues/2100
+      // Collect the write stream created here - at some point a new stream is created and assigned to 
+      // this._dest before _this.cleanupStream is called; this ensures we collect all streams we need to 
+      // cleanup to prevent a file descriptor leak.
+      this._writeStreams.push(this._dest);
+
       this._opening = false;
       this.once('open', () => {
         if (this._stream.eventNames().includes('rotate')) {
@@ -502,12 +513,16 @@ module.exports = class File extends TransportStream {
    * @returns {mixed} - TODO: add return description.
    */
   _cleanupStream(stream) {
-    stream.on('close', () => console.log('closed'));
     stream.removeListener('error', this._onError);
-    let streamToClose = this._streams.pop();
+
+    // https://github.com/winstonjs/winston/issues/2100
+    // In testing it was found more than one stream is created beyond the one passed to this function;
+    // this logic ensures any streams are destroyed to prevent a file descriptor leak -
+    // the cause of additional stream is still unknown
+    let streamToClose = this._writeStreams.pop();
     while (streamToClose) {
       streamToClose.destroy();
-      streamToClose = this._streams.pop();
+      streamToClose = this._writeStreams.pop();
     }
     return stream;
   }
@@ -570,8 +585,6 @@ module.exports = class File extends TransportStream {
           source.end();
         }
       });
-
-    this._streams.push(dest);
 
     debug('create stream ok', fullpath);
     if (this.zippedArchive) {

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -501,8 +501,9 @@ module.exports = class File extends TransportStream {
    * @returns {mixed} - TODO: add return description.
    */
   _cleanupStream(stream) {
+    stream.on('close', () => console.log('closed'));
     stream.removeListener('error', this._onError);
-
+    stream.destroy();
     return stream;
   }
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -119,7 +119,7 @@ module.exports = class File extends TransportStream {
    * @param {Function} callback - TODO: add param description.
    * @returns {undefined}
    */
-  log(info, callback = () => { }) {
+  log(info, callback = () => {}) {
     // Remark: (jcrugzz) What is necessary about this callback(null, true) now
     // when thinking about 3.x? Should silent be handled in the base
     // TransportStream _write method?
@@ -541,7 +541,7 @@ module.exports = class File extends TransportStream {
    * @param {function} callback - Callback for when the current file has closed.
    * @private
    */
-  _endStream(callback = () => { }) {
+  _endStream(callback = () => {}) {
     if (this._dest) {
       this._stream.unpipe(this._dest);
       this._dest.end(() => {


### PR DESCRIPTION
Fix/workaround for https://github.com/winstonjs/winston/issues/2100 

This PR in local testing prevented file descriptors from leaking as demonstrated by running the `lsof` command and not seeing file descriptors increase.

The fix introduces a mechanism to capture all streams created in an array and ensures all are destroyed when `_cleanupStream` is called. 

The code reads to me like there should only ever be one file stream in scope at any time but for some reason we find multiple are created before they are closed.

This is a workaround really and it would be better to find the source of this issue; streams are being created but not cleaned up, this fix just ensures the resource leak does not occur.