### PR TITLE
:bug: fix: usage of MESSAGE symbol

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -75,7 +75,7 @@ module.exports = function (opts = {}) {
       // Optimize the hot-path which is the single object.
       if (args.length === 1) {
         const [msg] = args;
-        const info = msg && msg.message && msg || { message: msg };
+        const info = msg && msg.message && msg || { [MESSAGE]: msg, message: msg };
         info.level = info[LEVEL] = level;
         self._addDefaultMeta(info);
         self.write(info);

--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -226,7 +226,7 @@ class Logger extends Transform {
         return this;
       }
 
-      msg = { [LEVEL]: level, level, message: msg };
+      msg = { [LEVEL]: level, [MESSAGE]: msg, level, message: msg };
       this._addDefaultMeta(msg);
       this.write(msg);
       return this;
@@ -241,6 +241,7 @@ class Logger extends Transform {
       if (!tokens) {
         const info = Object.assign({}, this.defaultMeta, meta, {
           [LEVEL]: level,
+          [MESSAGE]: msg,
           [SPLAT]: splat,
           level,
           message: msg
@@ -256,6 +257,7 @@ class Logger extends Transform {
 
     this.write(Object.assign({}, this.defaultMeta, {
       [LEVEL]: level,
+      [MESSAGE]: msg,
       [SPLAT]: splat,
       level,
       message: msg


### PR DESCRIPTION
This PR closes issue: #2253 

## What was wrong
The MESSAGE symbol wasn't being used, so when adding in my project with NODE 12.22.12 the output in any transporter was empty

## Work

Added the MESSAGE symbol where it was needed