### PR TITLE
fix: properly allow passing non-arry transport

### DIFF
--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -38,6 +38,8 @@ module.exports = class Container {
       options = Object.assign({}, options || this.options);
       const existing = options.transports || this.options.transports;
 
+      // Remark: Make sure if we have an array of transports we slice it to
+      // make copies of those references.
       if(existing) {
         options.transport = Array.isArray(existing) ? existing.slice() : [existing];
       } else {

--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -38,9 +38,11 @@ module.exports = class Container {
       options = Object.assign({}, options || this.options);
       const existing = options.transports || this.options.transports;
 
-      // Remark: Make sure if we have an array of transports we slice it to
-      // make copies of those references.
-      options.transports = existing ? existing.slice() : [];
+      if(existing) {
+        options.transport = Array.isArray(existing) ? existing.slice() : [existing];
+      } else {
+        options.transport = [];
+      }
 
       const logger = createLogger(options);
       logger.on('close', () => this._delete(id));

--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -40,10 +40,10 @@ module.exports = class Container {
 
       // Remark: Make sure if we have an array of transports we slice it to
       // make copies of those references.
-      if(existing) {
-        options.transport = Array.isArray(existing) ? existing.slice() : [existing];
+      if (existing) {
+        options.transports = Array.isArray(existing) ? existing.slice() : [existing];
       } else {
-        options.transport = [];
+        options.transports = [];
       }
 
       const logger = createLogger(options);

--- a/test/unit/winston/container.test.js
+++ b/test/unit/winston/container.test.js
@@ -66,4 +66,24 @@ describe('Container', function () {
       assume(all.someOtherLogger._readableState.pipes).equals(all.someLogger._readableState.pipes);
     });
   });
+
+  describe('explicit non-array transport', function () {
+    var transport = new winston.transports.Http({ port: 9412 });
+    var container = new winston.Container({ transports: transport });
+    var all = {};
+
+    it('.get(some-logger)', function () {
+      all.someLogger = container.get('some-logger');
+      assume(all.someLogger._readableState.pipes).instanceOf(winston.transports.Http);
+      assume(all.someLogger._readableState.pipes).equals(transport);
+    });
+
+    it('.get(some-other-logger)', function () {
+      all.someOtherLogger = container.get('some-other-logger');
+
+      assume(all.someOtherLogger._readableState.pipes).instanceOf(winston.transports.Http);
+      assume(all.someOtherLogger._readableState.pipes).equals(transport);
+      assume(all.someOtherLogger._readableState.pipes).equals(all.someLogger._readableState.pipes);
+    });
+  });
 });


### PR DESCRIPTION
LoggerOptions allows transports to be a single Transport instance as seen here:
https://github.com/winstonjs/winston/blob/2489a3d13b20797d3dbc55d3daf560cf52c2e6a3/index.d.ts#L102

in containers, if you do this it will result in an error that says `existing.slice` doesn't exist