### PR TITLE
Add option forceConsole

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -31,6 +31,7 @@ module.exports = class Console extends TransportStream {
     this.stderrLevels = this._stringArrayToSet(options.stderrLevels);
     this.consoleWarnLevels = this._stringArrayToSet(options.consoleWarnLevels);
     this.eol = (typeof options.eol === 'string') ? options.eol : os.EOL;
+    this.forceConsole = options.forceConsole || false;
 
     this.setMaxListeners(30);
   }
@@ -46,7 +47,7 @@ module.exports = class Console extends TransportStream {
 
     // Remark: what if there is no raw...?
     if (this.stderrLevels[info[LEVEL]]) {
-      if (console._stderr) {
+      if (console._stderr && !this.forceConsole) {
         // Node.js maps `process.stderr` to `console._stderr`.
         console._stderr.write(`${info[MESSAGE]}${this.eol}`);
       } else {
@@ -59,7 +60,7 @@ module.exports = class Console extends TransportStream {
       }
       return;
     } else if (this.consoleWarnLevels[info[LEVEL]]) {
-      if (console._stderr) {
+      if (console._stderr && !this.forceConsole) {
         // Node.js maps `process.stderr` to `console._stderr`.
         // in Node.js console.warn is an alias for console.error
         console._stderr.write(`${info[MESSAGE]}${this.eol}`);
@@ -74,7 +75,7 @@ module.exports = class Console extends TransportStream {
       return;
     }
 
-    if (console._stdout) {
+    if (console._stdout && !this.forceConsole) {
       // Node.js maps `process.stdout` to `console._stdout`.
       console._stdout.write(`${info[MESSAGE]}${this.eol}`);
     } else {


### PR DESCRIPTION
Add new option to the Console transport:
forceConsole (Boolean): when true, force transport to use console log/warn/error instead of write. With this option, VSCode terminal will work without setting the "outputCapture" to "std".