### PR TITLE
Change callback format to properly support errors

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -473,7 +473,7 @@ class Logger extends Transform {
           }
 
           // eslint-disable-next-line callback-return
-          next();
+          next(err);
         }
 
         next = null;
@@ -485,7 +485,7 @@ class Logger extends Transform {
     asyncForEach(
       this.transports.filter(transport => !!transport.query),
       addResults,
-      () => callback(null, results)
+      (err) => callback(err, results)
     );
   }
 


### PR DESCRIPTION
## Summary

Previously, it was possible for Winston `query` callbacks to get called with `error` as a nullish value while `results` was an instance of `Error`. This fix should properly pass the error through to the user-level callback.

## Reference

Issue #2241 