### PR TITLE
Add silent support to Console transport stream

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -44,6 +44,11 @@ module.exports = class Console extends TransportStream {
   log(info, callback) {
     setImmediate(() => this.emit('logged', info));
 
+    if (this.silent) {
+      callback()
+      return true;
+    }
+
     // Remark: what if there is no raw...?
     if (this.stderrLevels[info[LEVEL]]) {
       if (console._stderr) {


### PR DESCRIPTION
I'm not sure why this doesn't exist in Winston, but it doesn't.  In the file, I saw a comment 

```
    // Remark: (jcrugzz) What is necessary about this callback(null, true) now
    // when thinking about 3.x? Should silent be handled in the base
    // TransportStream _write method?
```

And not knowing anything about how this library works internally, it does sound like if silent mode is specified at the Logger level, that all TransportStream instances should support this option.