### PR TITLE
fix: add guard clause to prevent FD leak

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -155,11 +155,13 @@ module.exports = class File extends TransportStream {
       debug('logged %s %s', this._size, output);
       this.emit('logged', info);
 
-      // Do not attempt to rotate files while opening
-      if (this._opening) {
+      // Do not attempt to rotate files while rotating
+      if (this._rotate) {
         return;
       }
-      if (this._rotate) {
+
+      // Do not attempt to rotate files while opening
+      if (this._opening) {
         return;
       }
 

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -159,6 +159,9 @@ module.exports = class File extends TransportStream {
       if (this._opening) {
         return;
       }
+      if (this._rotate) {
+        return;
+      }
 
       // Check to see if we need to end the stream and create a new one.
       if (!this._needsNewFile()) {
@@ -502,6 +505,7 @@ module.exports = class File extends TransportStream {
    */
   _cleanupStream(stream) {
     stream.removeListener('error', this._onError);
+    stream.destroy();
 
     return stream;
   }


### PR DESCRIPTION
- Added guard clause to prevent trying to rotate files when there is already ongoing rotation
- Destroy streams in cleanup method to make sure they are "destroyed"