### PR TITLE
fix(types): Allow any object to be passed as meta to logger.profile

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,7 @@ declare namespace winston {
     stream(options?: any): NodeJS.ReadableStream;
 
     startTimer(): Profiler;
-    profile(id: string | number, meta?: LogEntry): Logger;
+    profile(id: string | number, meta?: Record<string, any>): Logger;
 
     configure(options: LoggerOptions): void;
 


### PR DESCRIPTION
It was typed as `LogEntry` which requires both `level` and `message` to be set. That contradicts the implementation that treats these fields as optional.

fixes #1969