### PR TITLE
docs(#2319): Syntax error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,11 +764,11 @@ const logger = winston.createLogger({
       level: 'error',
       format: winston.format.json()
     }),
-    new transports.Http({
+    new winston.transports.Http({
       level: 'warn',
       format: winston.format.json()
     }),
-    new transports.Console({
+    new winston.transports.Console({
       level: 'info',
       format: winston.format.combine(
         winston.format.colorize(),


### PR DESCRIPTION
This PR is solving the issue [2319](https://github.com/winstonjs/winston/issues/2319#issue-1779236172).