### PR TITLE
Remove nonexistent Logger methods from types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,13 +139,6 @@ declare namespace winston {
     input: LeveledLogMethod;
     silly: LeveledLogMethod;
 
-    // for syslog levels only
-    emerg: LeveledLogMethod;
-    alert: LeveledLogMethod;
-    crit: LeveledLogMethod;
-    warning: LeveledLogMethod;
-    notice: LeveledLogMethod;
-
     query(
       options?: QueryOptions,
       callback?: (err: Error, results: any) => void


### PR DESCRIPTION
Remove nonexistent Logger methods from types. Fixes #2280

## Testing

```
Welcome to Node.js v18.16.1.
Type ".help" for more information.
> const winston = require("winston")
undefined
> const logger = winston.createLogger({})
undefined
> logger.warning
undefined
> logger.emerg
undefined
> logger.alert
undefined
> logger.crit
undefined
> logger.notice
undefined
```