### PR TITLE
Add Typescript support for custom log levels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -113,7 +113,7 @@ declare namespace winston {
     [key in T]: LeveledLogMethod;
   };
   type LoggerLogEnabledMap<T extends string> = {
-    [key in T]: () => boolean;
+    [key in `is${Capitalize<T>}Enabled`]: () => boolean;
   };
 
   interface LoggerBase<T extends string> extends NodeJSStream.Transform {

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ declare namespace winston {
     (infoObject: object): Logger;
   }
 
-  interface LoggerOptions<T extends string> {
+  interface LoggerOptions<T extends string = defaultLevels> {
     levels?: Config.AbstractConfigSetLevels<T>;
     silent?: boolean;
     format?: logform.Format;
@@ -117,11 +117,11 @@ declare namespace winston {
   };
 
   interface LoggerBase<T extends string> extends NodeJSStream.Transform {
-    constructor(options?: LoggerOptions);
+    constructor(options?: LoggerOptions<T>): Logger<T>;
 
     silent: boolean;
     format: logform.Format;
-    levels: Config.AbstractConfigSetLevels;
+    levels: Config.AbstractConfigSetLevels<T>;
     level: string;
     transports: Transport[];
     exceptions: ExceptionHandler;
@@ -145,7 +145,7 @@ declare namespace winston {
     startTimer(): Profiler;
     profile(id: string | number, meta?: Record<string, any>): this;
 
-    configure(options: LoggerOptions): void;
+    configure(options: LoggerOptions<T>): void;
 
     child(options: Object): this;
 
@@ -155,21 +155,21 @@ declare namespace winston {
 
   class Container {
     loggers: Map<string, Logger>;
-    options: LoggerOptions;
+    options: LoggerOptions<string>;
 
-    add(id: string, options?: LoggerOptions): Logger;
-    get(id: string, options?: LoggerOptions): Logger;
+    add(id: string, options?: LoggerOptions<string>): Logger;
+    get(id: string, options?: LoggerOptions<string>): Logger;
     has(id: string): boolean;
     close(id?: string): void;
 
-    constructor(options?: LoggerOptions);
+    constructor(options?: LoggerOptions<string>);
   }
 
   let version: string;
   let loggers: Container;
 
   let addColors: (target: Config.AbstractConfigSetColors) => any;
-  let createLogger: (options?: LoggerOptions) => Logger;
+  let createLogger: <T extends string>(options?: LoggerOptions<T>) => Logger<T>;
 
   // Pass-through npm level methods routed to the default logger.
   let error: LeveledLogMethod;
@@ -192,7 +192,7 @@ declare namespace winston {
   let clear: () => Logger;
   let startTimer: () => Profiler;
   let profile: (id: string | number) => Logger;
-  let configure: (options: LoggerOptions) => void;
+  let configure: <T extends string>(options: LoggerOptions<T>) => void;
   let child: (options: Object) => Logger;
   let level: string;
   let exceptions: ExceptionHandler;

--- a/lib/winston/config/index.d.ts
+++ b/lib/winston/config/index.d.ts
@@ -3,17 +3,18 @@
 
 /// <reference types="node" />
 
+
 declare namespace winston {
-  interface AbstractConfigSetLevels<T extends string> {
-    [key: T]: number;
+  type AbstractConfigSetLevels<T extends string = string> = {
+    [key in T]: number;
   }
 
   interface AbstractConfigSetColors {
     [key: string]: string | string[];
   }
 
-  interface AbstractConfigSet {
-    levels: AbstractConfigSetLevels;
+  interface AbstractConfigSet<T extends string = string> {
+    levels: AbstractConfigSetLevels<T>;
     colors: AbstractConfigSetColors;
   }
 

--- a/lib/winston/config/index.d.ts
+++ b/lib/winston/config/index.d.ts
@@ -4,8 +4,8 @@
 /// <reference types="node" />
 
 declare namespace winston {
-  interface AbstractConfigSetLevels {
-    [key: string]: number;
+  interface AbstractConfigSetLevels<T extends string> {
+    [key: T]: number;
   }
 
   interface AbstractConfigSetColors {


### PR DESCRIPTION
This is a small change in the typescript types that allows for the automatic detection of log levels (including custom log levels).

## Breaking Changes
- This uses Template Literal Types and other string manipulation which is only available from TypeScript 4.1 onwards
- This actually checks which log levels are there, and does not assume NPM, Syslog, etc. are there, so it may break some builds at transpile time (which would have broken in runtime)

## To Do
- Create a bigger test suite for TypeScript types
- Test on more TS versions