### PR TITLE
chore(README.md): adds documentation around coloring json formatted logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,10 +675,21 @@ To colorize the standard logging level add
 ```js
 winston.format.combine(
   winston.format.colorize(),
-  winston.format.json()
+  winston.format.simple()
 );
 ```
-where `winston.format.json()` is whatever other formatter you want to use.  The `colorize` formatter must come before any formatters adding text you wish to color.
+where `winston.format.simple()` is whatever other formatter you want to use.  The `colorize` formatter must come before any formatters adding text you wish to color.
+
+### Colorizing full log line when json formatting logs
+
+To colorize the full log line with the json formatter you can apply the following
+
+```js
+winston.format.combine(
+  winston.format.json(),
+  winston.format.colorize({ all })
+);
+```
 
 ## Transports
 


### PR DESCRIPTION
Hey there! I think I stumbled with the same issue as https://github.com/winstonjs/winston/issues/1336 trying to get json formatted logs coloured for local development and got me scratching my head for a bit. I think @indexzero [comment](https://github.com/winstonjs/winston/issues/1336#issuecomment-394564398) makes total sense in that trying to colourize the log level or other specific log field would result in it being escaped when json formatted, so this would be intended behaviour. 

But, I also agree with @pdiniz13 [here](https://github.com/winstonjs/winston/issues/1336#issuecomment-413688179) (which also seems to have an amount of upvotes) in that it would be nice for the current documentation to bring some of this up. 

On the side I also stumbled with https://github.com/winstonjs/winston/issues/1135 which pointed me to `colorize({ all: true })` [on this SO post](https://stackoverflow.com/a/52650695) which does the trick for me.

---

On code, how my logger looked initially:
```ts
import { createLogger, format, transports } from "winston";

export default createLogger({
  format: format.combine(format.colorize(), format.timestamp(), format.json()),
  transports: [new transports.Console()],
});
```
<img width="1044" alt="image" src="https://github.com/winstonjs/winston/assets/40798232/b55e9fe3-bb1b-4a51-9e02-3674feeceb4e">

And after
```ts
import { createLogger, format, transports } from "winston";

export default createLogger({
  format: format.combine(format.timestamp(), format.json(), format.colorize({ all: true })),
  transports: [new transports.Console()],
});
````
<img width="1044" alt="image" src="https://github.com/winstonjs/winston/assets/40798232/6c9b9bdd-b2b0-45a3-928d-307b5450937d">

---

One last note is that when json formatting from my vague understanding even trying to colorize first which feels like the suggested path on similar issues will also mean the characters are escaped, like
```ts
import { createLogger, format, transports } from "winston";

export default createLogger({
  format: format.combine(format.colorize({ all: true }), format.timestamp(), format.json()),
  transports: [new transports.Console()],
});
```
<img width="1218" alt="image" src="https://github.com/winstonjs/winston/assets/40798232/8df83e91-d1b8-43ce-b35a-d169ac395a4b">

hence why I flipped this on the json colouring example 

```js
winston.format.combine(
  winston.format.json(),
  winston.format.colorize({ all })
);
```

My humble suggestion would be to expand this documentation slightly with the attached changes to cover for these cases and hopefully save a couple minutes to the future folks, though open to comments