### PR TITLE
Bump @colors/colors package to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.10.0",
       "license": "MIT",
       "dependencies": {
-        "@colors/colors": "1.5.0",
+        "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
@@ -1826,9 +1826,9 @@
       }
     },
     "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -4795,6 +4795,14 @@
         "ms": "^2.1.1",
         "safe-stable-stringify": "^2.3.1",
         "triple-beam": "^1.3.0"
+      }
+    },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/logform/node_modules/fecha": {
@@ -8444,9 +8452,9 @@
       }
     },
     "@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
     },
     "@dabh/diagnostics": {
       "version": "2.0.3",
@@ -10659,6 +10667,11 @@
         "triple-beam": "^1.3.0"
       },
       "dependencies": {
+        "@colors/colors": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+          "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+        },
         "fecha": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@dabh/diagnostics": "^2.0.2",
-    "@colors/colors": "1.5.0",
+    "@colors/colors": "^1.6.0",
     "async": "^3.2.3",
     "is-stream": "^2.0.0",
     "logform": "^2.4.0",


### PR DESCRIPTION
This contains a a [fix for environments that do not have `argv`](https://github.com/DABH/colors.js/commit/5263348d3970574187ee76284077b49f2d6db5a3) and is breaking a large number of use cases.

Fixes #2327