### PR TITLE
Add winston-newrelic-agent-transport to transport documentation

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -665,20 +665,18 @@ If `env` is either 'dev' or 'test' the lib will _not_ load the included newrelic
 import winston from 'winston'
 import NewrelicTransport from 'winston-newrelic-agent-transport'
 
-const options = {}
+const logger = winston.createLogger()
 
-const logger = winston.createLogger({
-  transports: [
-    new NewrelicTransport(options)
-  ]
-})
+const options = {}
+logger.add(new NewrelicTransport(options))
 ```
 
-The New Relic agent typically automatically sends Winston logs to New Relic when using CommonJS. With CommonJS no additional transport should be needed. However, when using ECMAScript modules, the automatic sending of logs can with certain coding patterns not work. This transport leverages the New Relic agent to send logs to New Relic for the times when automatic log sending is not working.
+The New Relic agent typically automatically forwards Winston logs to New Relic when using CommonJS. With CommonJS no additional transport should be needed. However, when using ECMAScript modules, the automatic forwarding of logs can with certain coding patterns not work. If the New Relic agent is not automatically forwarding your logs, this transport provides a solution.
 
 Options:
-* __level__: The Winston logging level to use as the maximum level of messages that the transport will log.
-* __rejectCriteria__: The rejectCriteria option allows you to specify an array of regexes that will be matched against either the Winston info object or log message to determine whether or not a log message should be rejected and not logged to New Relic.
+
+* __level__ (optional): The Winston logging level to use as the maximum level of messages that the transport will log.
+* __rejectCriteria__ (optional): The rejectCriteria option allows you to specify an array of regexes that will be matched against either the Winston info object or log message to determine whether or not a log message should be rejected and not logged to New Relic.
 
 ### Papertrail Transport
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -676,6 +676,10 @@ const logger = winston.createLogger({
 
 The New Relic agent typically automatically sends Winston logs to New Relic when using CommonJS. With CommonJS no additional transport should be needed. However, when using ECMAScript modules, the automatic sending of logs can with certain coding patterns not work. This transport leverages the New Relic agent to send logs to New Relic for the times when automatic log sending is not working.
 
+Options:
+* __level__: The Winston logging level to use as the maximum level of messages that the transport will log.
+* __rejectCriteria__: The rejectCriteria option allows you to specify an array of regexes that will be matched against either the Winston info object or log message to determine whether or not a log message should be rejected and not logged to New Relic.
+
 ### Papertrail Transport
 
 [winston-papertrail][27] is a Papertrail transport:

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -49,6 +49,7 @@ there are additional transports written by
   * [Logz.io](#logzio-transport)
   * [Mail](#mail-transport)
   * [Newrelic](#newrelic-transport) (errors only)
+  * [New Relic](#new-relic-agent-transport)
   * [Papertrail](#papertrail-transport)
   * [PostgresQL](#postgresql-transport)
   * [Pusher](#pusher-transport)
@@ -656,6 +657,25 @@ The Newrelic transport will send your errors to newrelic and accepts the follwin
 
 If `env` is either 'dev' or 'test' the lib will _not_ load the included newrelic module saving devs from anoying errors ;)
 
+### New Relic Agent Transport
+
+[winston-newrelic-agent-transport][47] is a New Relic transport that leverages the New Relic agent:
+
+``` js
+import winston from 'winston'
+import NewrelicTransport from 'winston-newrelic-agent-transport'
+
+const options = {}
+
+const logger = winston.createLogger({
+  transports: [
+    new NewrelicTransport(options)
+  ]
+})
+```
+
+The New Relic agent typically automatically sends Winston logs to New Relic when using CommonJS. With CommonJS no additional transport should be needed. However, when using ECMAScript modules, the automatic sending of logs can with certain coding patterns not work. This transport leverages the New Relic agent to send logs to New Relic for the times when automatic log sending is not working.
+
 ### Papertrail Transport
 
 [winston-papertrail][27] is a Papertrail transport:
@@ -1010,3 +1030,4 @@ That's why we say it's a logger for just about everything
 [44]: https://github.com/Quintinity/humio-winston
 [45]: https://github.com/datalust/winston-seq
 [46]: https://github.com/arpad1337/winston-console-transport-in-worker
+[47]: https://github.com/kimnetics/winston-newrelic-agent-transport


### PR DESCRIPTION
### Background
The New Relic agent typically automatically sends Winston logs to New Relic when using CommonJS. With CommonJS no additional transport should be needed. However, when using ECMAScript modules, the automatic sending of logs can with certain coding patterns not work.

The winston-newrelic-agent-transport transport was created to leverage the New Relic agent to send logs to New Relic for the times when automatic log sending is not working.

### PR
This PR updates the transports documentation to include information about winston-newrelic-agent-transport.

### Why create another New Relic transport?
The current [Newrelic Transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#newrelic-transport) only handles errors. Its use of [newrelic.noticeError](https://github.com/namshi/newrelic-winston/blob/224b5ec0eb1b0ea4274c1dae725d30840aeee44b/index.js#L34C18-L34C18) to transmit log messages constrains it to specific use cases. Also, the [noticeError](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#noticeError) method was not intended for logging.
