### PR TITLE
Bump winston-transport; fix test issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
+        "winston-transport": "^4.6.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "safe-stable-stringify": "^2.3.1",
     "stack-trace": "0.0.x",
     "triple-beam": "^1.3.0",
-    "winston-transport": "^4.5.0"
+    "winston-transport": "^4.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.0",
@@ -60,7 +60,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "lint": "eslint lib/*.js lib/winston/*.js lib/winston/**/*.js --resolve-plugins-relative-to ./node_modules/@dabh/eslint-config-populist",
-    "test": "mocha",
+    "test": "rimraf test/fixtures/logs/* && mocha",
     "test:coverage": "nyc npm run test:unit",
     "test:unit": "mocha test/unit",
     "test:integration": "mocha test/integration",


### PR DESCRIPTION
On macOS 14.2.1 (npm 9.8.0, node 16.18.0), successive runs of `npm run test` would fail after the first run.  Specifically the `File (maxsize)` test.  I thought this was an issue with https://github.com/winstonjs/winston-transport/commit/656651817785b865fc6025644b2b57c4c6675b19 when I looked at this a few weeks ago.  However, even if I go back to the commit before that, I hit the same issue (not sure why I thought differently earlier).  I noticed that `test/fixtures/logs` is clean in the repo, but was getting left dirty after a test run.  Accordingly, I fixed this issue by prepending a command to empty that directory before running `mocha`, in the definition of the npm `test` script.  I ran several times in a row, and each test run now looks totally good, using the latest `winston-transport` (4.6.0).