### PR TITLE
docs: fix anchor in transports docs

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -59,7 +59,7 @@ there are additional transports written by
   * [SQLite3](#sqlite3-transport)
   * [SSE with KOA 2](#sse-transport-with-koa-2)
   * [Sumo Logic](#sumo-logic-transport)
-  * [VS Code extension](#vscode-extension)
+  * [VS Code extension](#vs-code-extension)
   * [Worker Thread based async Console transport](#worker-thread-based-async-console-transport)
   * [Winlog2 Transport](#winlog2-transport)
 


### PR DESCRIPTION
Fix the anchor to `winston-transport-vscode` in the transports docs.