### PR TITLE
missing timestamp format in ready-to-use-pattern example

### DIFF
--- a/examples/ready-to-use-pattern.ts
+++ b/examples/ready-to-use-pattern.ts
@@ -31,6 +31,7 @@ const wLogger = (input: { logName: string; level: string }): winston.Logger =>
         level: `${input.level}`,
 
         format: winston.format.combine(
+          winston.format.timestamp(),
           winston.format.printf(
             info =>
               // https://stackoverflow.com/a/69044670/20358783 more detailLocaleString


### PR DESCRIPTION
Tried the ready-to-use-pattern example and would get Invalid Date in the logs, it seems the timestamp() format was missing at logger creation.