### PR TITLE
Revert "Remove nonexistent Logger methods from types"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,6 +139,13 @@ declare namespace winston {
     input: LeveledLogMethod;
     silly: LeveledLogMethod;
 
+    // for syslog levels only
+    emerg: LeveledLogMethod;
+    alert: LeveledLogMethod;
+    crit: LeveledLogMethod;
+    warning: LeveledLogMethod;
+    notice: LeveledLogMethod;
+
     query(
       options?: QueryOptions,
       callback?: (err: Error, results: any) => void


### PR DESCRIPTION
This reverts commit c3c391122c44e3f0a46758997bfbb83aaea204ab.

Resolves https://github.com/winstonjs/winston/issues/2424, see also comments on https://github.com/winstonjs/winston/commit/c3c391122c44e3f0a46758997bfbb83aaea204ab