### PR TITLE
fix typo at test/unit/winston/transports/http.test.js

### DIFF
--- a/test/unit/winston/transports/http.test.js
+++ b/test/unit/winston/transports/http.test.js
@@ -79,7 +79,7 @@ describe('Http({ host, port, path })', function () {
 
   });
 
-  describe('bacth mode: max message', function () {
+  describe('batch mode: max message', function () {
 
     beforeEach(function (done) {
       context = mockHttpServer(done, [dummyLog, dummyLog, dummyLog, dummyLog, dummyLog]);
@@ -108,7 +108,7 @@ describe('Http({ host, port, path })', function () {
 
   });
 
-  describe('bacth mode: timeout', function () {
+  describe('batch mode: timeout', function () {
 
     beforeEach(function (done) {
       context = mockHttpServer(done, [dummyLog, dummyLog]);


### PR DESCRIPTION
This PR corrects a minor typo in the codebase. The word "bacth" has been corrected to "batch" in the description of a test suite.