### PR TITLE
File transport: Set _rotate false on emit 'rotate' false

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -439,9 +439,7 @@ module.exports = class File extends TransportStream {
       this._dest = this._createStream(this._stream);
       this._opening = false;
       this.once('open', () => {
-        if (this._stream.eventNames().includes('rotate')) {
-          this._stream.emit('rotate');
-        } else {
+        if (!this._stream.emit('rotate')) {
           this._rotate = false;
         }
       });


### PR DESCRIPTION
In some situations the event names includes events with no more listeners. Check the emit return code to see whether it was received instead of checking event names.

