### PR TITLE
improve http transport error and message handling

### DIFF
--- a/lib/winston/transports/http.js
+++ b/lib/winston/transports/http.js
@@ -64,7 +64,7 @@ module.exports = class Http extends TransportStream {
       }
 
       if (err) {
-        this.emit('warn', err);
+        this.emit('warn', err, info);
       } else {
         this.emit('logged', info);
       }


### PR DESCRIPTION
Update http.js to emit the info message along with the error when the warn event is fired. The warn event is fired when there is an error sending the log to the http endpoint. This will help for someone who wants to write the logs to local storage and retry later.