### PR TITLE
Deep copy msg object (fix the issue: logger.info({message:...}) modifies original object)

### DIFF
--- a/lib/winston/create-logger.js
+++ b/lib/winston/create-logger.js
@@ -75,7 +75,7 @@ module.exports = function (opts = {}) {
       // Optimize the hot-path which is the single object.
       if (args.length === 1) {
         const [msg] = args;
-        const info = msg && msg.message && msg || { message: msg };
+        const info = msg && msg.message && JSON.parse(JSON.stringify(msg)) || { message: msg };
         info.level = info[LEVEL] = level;
         self._addDefaultMeta(info);
         self.write(info);


### PR DESCRIPTION
Fixing the belwo issue(#1775) by deep copy the message 
```js
const data = {'message':'hello'}
logger.log(data)
// now data contains "level":"info"
```