### PR TITLE
docs: fix how to specify all in the colorize argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ To colorize the full log line with the json formatter you can apply the followin
 ```js
 winston.format.combine(
   winston.format.json(),
-  winston.format.colorize({ all })
+  winston.format.colorize({ all: true })
 );
 ```
 


### PR DESCRIPTION
Corrected the sample code in README to properly specify the 'all' option in winston.format.colorize.