### PR TITLE
Add `forceConsole` to `ConsoleTransportOptions`

### DIFF
--- a/lib/winston/transports/index.d.ts
+++ b/lib/winston/transports/index.d.ts
@@ -3,16 +3,17 @@
 
 /// <reference types="node" />
 
-import {Agent} from "http";
+import { Agent } from 'http';
 
 import * as Transport from 'winston-transport';
 
 declare namespace winston {
   interface ConsoleTransportOptions extends Transport.TransportStreamOptions {
-    consoleWarnLevels?: string[],
+    consoleWarnLevels?: string[];
     stderrLevels?: string[];
     debugStdout?: boolean;
     eol?: string;
+    forceConsole?: boolean;
   }
 
   interface ConsoleTransportInstance extends Transport {
@@ -20,7 +21,7 @@ declare namespace winston {
     stderrLevels: string[];
     eol: string;
 
-    new(options?: ConsoleTransportOptions): ConsoleTransportInstance;
+    new (options?: ConsoleTransportOptions): ConsoleTransportInstance;
   }
 
   interface FileTransportOptions extends Transport.TransportStreamOptions {
@@ -50,14 +51,18 @@ declare namespace winston {
     tailable: boolean;
     lazy: boolean;
 
-    new(options?: FileTransportOptions): FileTransportInstance;
+    new (options?: FileTransportOptions): FileTransportInstance;
   }
 
   interface HttpTransportOptions extends Transport.TransportStreamOptions {
     ssl?: any;
     host?: string;
     port?: number;
-    auth?: { username?: string | undefined, password?: string | undefined, bearer?: string | undefined };
+    auth?: {
+      username?: string | undefined;
+      password?: string | undefined;
+      bearer?: string | undefined;
+    };
     path?: string;
     agent?: Agent;
     headers?: object;
@@ -74,11 +79,15 @@ declare namespace winston {
     host: string;
     maximumDepth: number;
     port: number;
-    auth?: { username?: string | undefined, password?: string | undefined, bearer?: string | undefined };
+    auth?: {
+      username?: string | undefined;
+      password?: string | undefined;
+      bearer?: string | undefined;
+    };
     path: string;
     agent?: Agent | null;
 
-    new(options?: HttpTransportOptions): HttpTransportInstance;
+    new (options?: HttpTransportOptions): HttpTransportInstance;
   }
 
   interface StreamTransportOptions extends Transport.TransportStreamOptions {
@@ -89,7 +98,7 @@ declare namespace winston {
   interface StreamTransportInstance extends Transport {
     eol: string;
 
-    new(options?: StreamTransportOptions): StreamTransportInstance;
+    new (options?: StreamTransportOptions): StreamTransportInstance;
   }
 
   interface Transports {


### PR DESCRIPTION
Fixes #2495

* Add the new property to the type

I've used this locally and confirmed it resolves the TypeScript error and I see the logs in VSCode debugger as the original fix intended.