### PR TITLE
Save a reference to console methods in console transport

### DIFF
--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -18,6 +18,13 @@ const TransportStream = require('winston-transport');
  * @extends {TransportStream}
  */
 module.exports = class Console extends TransportStream {
+  // Keep a reference to the log, warn, and error console methods
+  // in case they get redirected to this transport after the logger is
+  // instantiated. This prevents a circular reference issue.
+  _consoleLog = console.log;
+  _consoleWarn = console.warn;
+  _consoleError = console.error;
+
   /**
    * Constructor function for the Console transport object responsible for
    * persisting log messages and metadata to a terminal or TTY.
@@ -30,7 +37,7 @@ module.exports = class Console extends TransportStream {
     this.name = options.name || 'console';
     this.stderrLevels = this._stringArrayToSet(options.stderrLevels);
     this.consoleWarnLevels = this._stringArrayToSet(options.consoleWarnLevels);
-    this.eol = (typeof options.eol === 'string') ? options.eol : os.EOL;
+    this.eol = typeof options.eol === 'string' ? options.eol : os.EOL;
     this.forceConsole = options.forceConsole || false;
 
     this.setMaxListeners(30);
@@ -52,7 +59,7 @@ module.exports = class Console extends TransportStream {
         console._stderr.write(`${info[MESSAGE]}${this.eol}`);
       } else {
         // console.error adds a newline
-        console.error(info[MESSAGE]);
+        this._consoleError(info[MESSAGE]);
       }
 
       if (callback) {
@@ -66,7 +73,7 @@ module.exports = class Console extends TransportStream {
         console._stderr.write(`${info[MESSAGE]}${this.eol}`);
       } else {
         // console.warn adds a newline
-        console.warn(info[MESSAGE]);
+        this._consoleWarn(info[MESSAGE]);
       }
 
       if (callback) {
@@ -80,7 +87,7 @@ module.exports = class Console extends TransportStream {
       console._stdout.write(`${info[MESSAGE]}${this.eol}`);
     } else {
       // console.log adds a newline.
-      console.log(info[MESSAGE]);
+      this._consoleLog(info[MESSAGE]);
     }
 
     if (callback) {
@@ -97,16 +104,16 @@ module.exports = class Console extends TransportStream {
    * @private
    */
   _stringArrayToSet(strArray, errMsg) {
-    if (!strArray)
-      return {};
+    if (!strArray) return {};
 
-    errMsg = errMsg || 'Cannot make set from type other than Array of string elements';
+    errMsg =
+      errMsg || 'Cannot make set from type other than Array of string elements';
 
     if (!Array.isArray(strArray)) {
       throw new Error(errMsg);
     }
 
-    return strArray.reduce((set, el) =>  {
+    return strArray.reduce((set, el) => {
       if (typeof el !== 'string') {
         throw new Error(errMsg);
       }

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -21,9 +21,9 @@ module.exports = class Console extends TransportStream {
   // Keep a reference to the log, warn, and error console methods
   // in case they get redirected to this transport after the logger is
   // instantiated. This prevents a circular reference issue.
-  _consoleLog = console.log;
-  _consoleWarn = console.warn;
-  _consoleError = console.error;
+  _consoleLog = console.log.bind(console);
+  _consoleWarn = console.warn.bind(console);
+  _consoleError = console.error.bind(console);
 
   /**
    * Constructor function for the Console transport object responsible for


### PR DESCRIPTION
Fixes #2497

* Save local references to `console.log`, `console.warn`, and `console.error`
* Use those references instead of the original methods when logging

@Jimbly could you please give this a try and see if it fixes your circular reference issue? I could never get a circular reference, but I did get other errors that no longer happen with this change and logging seems to work fine.