### PR TITLE
Remove LogCallback in ts definition files

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,13 +63,6 @@ declare namespace winston {
     done(info?: any): boolean;
   }
 
-  type LogCallback = (
-    error?: any,
-    level?: string,
-    message?: string,
-    meta?: any
-  ) => void;
-
   interface LogEntry {
     level: string;
     message: string;
@@ -77,16 +70,12 @@ declare namespace winston {
   }
 
   interface LogMethod {
-    (level: string, message: string, callback: LogCallback): Logger;
-    (level: string, message: string, meta: any, callback: LogCallback): Logger;
     (level: string, message: string, ...meta: any[]): Logger;
     (entry: LogEntry): Logger;
     (level: string, message: any): Logger;
   }
 
   interface LeveledLogMethod {
-    (message: string, callback: LogCallback): Logger;
-    (message: string, meta: any, callback: LogCallback): Logger;
     (message: string, ...meta: any[]): Logger;
     (message: any): Logger;
     (infoObject: object): Logger;


### PR DESCRIPTION
## Background

LogCallback is not supported anymore as per version 3 and can cause confusion

https://github.com/winstonjs/winston/blob/HEAD/UPGRADE-3.0.md#winstonlogger
winston.Logger.log and level-specific methods (.info, .error, etc) no longer accepts a callback.

This PR removes the LogCallback types and its reference in LogLevelMethod and LogMethod interface

closes: https://github.com/winstonjs/winston/issues/1922