### PR TITLE
feat: adds helper function for highest log level

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -149,6 +149,28 @@ class Logger extends Transform {
     }
   }
 
+  /* eslint-disable valid-jsdoc */
+  /**
+   * Helper method to get the highest logging level associated with a logger
+   *
+   * @returns { number | null } - The highest configured logging level, null
+   * for invalid configuration
+   */
+  getHighestLogLevel() {
+    // This can be null, if this.level has an invalid value
+    const configuredLevelValue = getLevelValue(this.levels, this.level);
+
+    // If there are no transports, return the level configured at the logger level
+    if (!this.transports || this.transports.length === 0) {
+      return configuredLevelValue;
+    }
+
+    return this.transports.reduce((max, transport) => {
+      const levelValue = getLevelValue(this.levels, transport.level);
+      return levelValue !== null && levelValue > max ? levelValue : max;
+    }, configuredLevelValue);
+  }
+
   isLevelEnabled(level) {
     const givenLevelValue = getLevelValue(this.levels, level);
     if (givenLevelValue === null) {

--- a/test/unit/winston/logger.test.js
+++ b/test/unit/winston/logger.test.js
@@ -346,6 +346,9 @@ describe('Logger Instance', function () {
           transports: [new winston.transports.Console()]
         });
 
+        assume(logger.getHighestLogLevel).is.a('function');
+        assume(logger.getHighestLogLevel()).equals(4);
+
         assume(logger.isLevelEnabled).is.a('function');
 
         assume(logger.isErrorEnabled).is.a('function');
@@ -380,6 +383,9 @@ describe('Logger Instance', function () {
           transports: [transport]
         });
 
+        assume(logger.getHighestLogLevel).is.a('function');
+        assume(logger.getHighestLogLevel()).equals(5);
+
         assume(logger.isLevelEnabled).is.a('function');
 
         assume(logger.isErrorEnabled).is.a('function');
@@ -410,6 +416,9 @@ describe('Logger Instance', function () {
           levels: winston.config.npm.levels,
           transports: []
         });
+
+        assume(logger.getHighestLogLevel).is.a('function');
+        assume(logger.getHighestLogLevel()).equals(4);
 
         assume(logger.isLevelEnabled).is.a('function');
 
@@ -446,6 +455,9 @@ describe('Logger Instance', function () {
           transports: [new winston.transports.Console()]
         });
 
+        assume(logger.getHighestLogLevel).is.a('function');
+        assume(logger.getHighestLogLevel()).equals(1);
+
         assume(logger.isLevelEnabled).is.a('function');
 
         assume(logger.isBadEnabled).is.a('function');
@@ -471,6 +483,9 @@ describe('Logger Instance', function () {
           },
           transports: []
         });
+
+        assume(logger.getHighestLogLevel).is.a('function');
+        assume(logger.getHighestLogLevel()).equals(1);
 
         assume(logger.isLevelEnabled).is.a('function');
 
@@ -500,6 +515,9 @@ describe('Logger Instance', function () {
           },
           transports: [transport]
         });
+
+        assume(logger.getHighestLogLevel).is.a('function');
+        assume(logger.getHighestLogLevel()).equals(2);
 
         assume(logger.isLevelEnabled).is.a('function');
 


### PR DESCRIPTION
- Adds a helper function named `getHighestLogLevel` to get the highest log level (numeric value) associated with a helper.

ref: #837