### PR TITLE
Addition of Logger.getAll() method as discussed in #970 

### DIFF
--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -66,6 +66,19 @@ module.exports = class Container {
   }
 
   /**
+   * Retreives all `winston.Logger` instances for the specified `regex`.
+   * @param {!string} id - The regrex to match the Loggers to get.
+   * @returns {Map<Logger>} - A Map of Logger instances matching the regex.
+   */
+  getAll(regex) {
+    if(regex) {
+      return new Map([...this.loggers].filter(([key]) => key.match(regex)));
+    }
+
+    return this.loggers;
+  }
+
+  /**
    * Check if the container has a logger with the id.
    * @param {?string} id - The id of the Logger instance to find.
    * @returns {boolean} - Boolean value indicating if this instance has a


### PR DESCRIPTION
**Related Issue** : #970 

As discussed in issue #970, this PR introduces a new method that returns a Map<Logger>. This enhancement allows users to retrieve all loggers that match a given regex pattern, providing a convenient way to manage and configure multiple loggers at once.

With this new functionality, users can now establish mass control over their loggers by iterating over the returned Map, making bulk configuration and modifications simpler and more efficient. This change is aimed at improving flexibility and easing the management of logger configurations in large-scale applications.

@DABH PR for the changes I thought about, let me know if you are looking for a different approach for this feature.