### PR TITLE
chore(package): add homepage and bugs urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "type": "git",
     "url": "https://github.com/winstonjs/winston.git"
   },
+  "bugs": {
+    "url": "https://github.com/winstonjs/winston/issues"
+  },
+  "homepage": "https://github.com/winstonjs/winston#readme",
   "keywords": [
     "winston",
     "logger",


### PR DESCRIPTION
The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in VS Code when using a proxy registry like in Azure DevOps:

![image](https://github.com/user-attachments/assets/566b5bf2-d762-4d34-9b5b-b28e8342a1ae)

Compared to winston-transport, which [does have the homepage set](https://github.com/winstonjs/winston-transport/blob/eab6323e7081e84038b82144d01f0c353d226442/package.json#L29):

![image](https://github.com/user-attachments/assets/615d64df-967d-48a0-a1a3-1e72e69d4c30)


The [`bugs`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#bugs) property was also added to allow for `npm bugs` to work. 

