### PR TITLE
Fixed the return type of method profile of class Logger

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -142,7 +142,7 @@ declare namespace winston {
     stream(options?: any): NodeJS.ReadableStream;
 
     startTimer(): Profiler;
-    profile(id: string | number, meta?: Record<string, any>): this;
+    profile(id: string | number, meta?: Record<string, any>): this | boolean;
 
     configure(options: LoggerOptions): void;
 


### PR DESCRIPTION
There is a possibility that the method profile of class Logger might return a boolean.