### PR TITLE
Update log level explanation on README.md to make slightly clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,10 @@ const logger = winston.createLogger({
     })
   ]
 });
+
+logger.debug('Will not be logged in either transport!');
+logger.info('Will be logged only in File!');
+logger.error('Will be logged by both transports!');
 ```
 
 You may also dynamically change the log level of a transport:


### PR DESCRIPTION
I was quite confused by the log level explanation on the README, and end up losing a good few minutes debugging my code because of it. 

I know that right on the start of the Logging Levels section it explains how winston follows RFC5424, but later the explanation for how the `level` filter defines the "maximum level" of messages logged can read quite oddly and potentially lead to confusion due to the unfamiliarity of having a filter that only lets through "X severity and higher [severity]" messages. 

It is especially confusing if you read where it says:

> using the `syslog` levels you could log only `error` messages to the console and everything `info` and below to a file (which includes `error` messages)

And miss the "which includes error messages" (as I did) -- double especially given that it says `syslog` levels there, but seems to actually mean "npm", given that it says "only error" (when in reality, if using syslog, it would log `error` and above). If you make that confusion (as I did), the two examples there seem to contradict each other.

I think it'd be ideal to write this part of the readme in a way that takes advantage of cognitive/processing fluency -- ie. in a way that reads familiar, basically avoiding this min/max severity/number thing. However, to remain completely technical and avoid subjectivity, my aim here is to just try and lessen the chance a bit of someone doing the same mistake as I.

So what I did was:
1. Put a couple more hints in the text to avoid confusion related to minimum/maximum severity
2. Put examples in the first code block as well (if someone is confused by the text, they'll notice their mistake in the code example)
3. Change the example to read `npm` instead of `syslog` as it didn't fully make sense before