### PR TITLE
feat(file-transport): add mode, uid, and gid options for file and directory creation

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -107,6 +107,9 @@ looking for daily log rotation see [DailyRotateFile](#dailyrotatefile-transport)
 * __eol:__ Line-ending character to use. (default: `os.EOL`).
 * __lazy:__ If true, log files will be created on demand, not at the initialization time.
 * __filename:__ The filename of the logfile to write output to.
+* __mode:__ File permissions to apply to the created log file (e.g., `0o660`).
+* __uid:__ User ID to apply to the created log file (ownership). Optional.
+* __gid:__ Group ID to apply to the created log file (ownership). Optional.
 * __maxsize:__ Max size in bytes of the logfile, if the size is exceeded then a new file is created, a counter will become a suffix of the log file.
 * __maxFiles:__ Limit the number of files created when the size of the logfile is exceeded.
 * __tailable:__ If true, log files will be rolled based on maxsize and maxfiles, but in ascending order. The __filename__ will always have the most recent log lines. The larger the appended number, the older the log file.  This option requires __maxFiles__ to be set, or it will be ignored.

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -91,6 +91,15 @@ module.exports = class File extends TransportStream {
     this._ending = false;
     this._fileExist = false;
 
+    // Accept mode, uid, gid options
+    this.mode = options.mode;
+    this.uid = options.uid;
+    this.gid = options.gid;
+
+    if (this.mode) {
+      this.options.mode = this.mode;
+    }
+
     if (this.dirname) this._createLogDirIfNotExist(this.dirname);
     if (!this.lazy) this.open();
   }
@@ -457,7 +466,7 @@ module.exports = class File extends TransportStream {
 
     fs.stat(fullpath, (err, stat) => {
       if (err && err.code === 'ENOENT') {
-        debug('ENOENT ok', fullpath);
+        debug('ENOENT ok', fullpath);
         // Update internally tracked filename with the new target name.
         this.filename = target;
         return callback(null, 0);
@@ -582,8 +591,17 @@ module.exports = class File extends TransportStream {
       // TODO: What should we do with errors here?
       .on('error', err => debug(err))
       .on('close', () => debug('close', dest.path, dest.bytesWritten))
-      .on('open', () => {
+      .on('open', (fd) => {
         debug('file open ok', fullpath);
+        // Set file ownership if uid/gid provided
+        if (this.uid !== undefined || this.gid !== undefined) {
+          try {
+            fs.fchownSync(fd, this.uid !== undefined ? this.uid : -1, this.gid !== undefined ? this.gid : -1);
+          } catch (ex) {
+            debug(`Could not set ownership of ${fullpath}: ${ex}`);
+            this.emit('error', ex);
+          }
+        }
         this.emit('open', fullpath);
         source.pipe(dest);
 
@@ -756,7 +774,11 @@ module.exports = class File extends TransportStream {
   _createLogDirIfNotExist(dirPath) {
     /* eslint-disable no-sync */
     if (!fs.existsSync(dirPath)) {
-      fs.mkdirSync(dirPath, { recursive: true });
+      const mkdirOptions = { recursive: true };
+      if (this.mode) {
+        mkdirOptions.mode = this.mode;
+      }
+      fs.mkdirSync(dirPath, mkdirOptions);
     }
     /* eslint-enable no-sync */
   }

--- a/test/unit/winston/transports/file.test.js
+++ b/test/unit/winston/transports/file.test.js
@@ -92,6 +92,40 @@ describe('File({ filename })', function () {
   // "An instance of the File Transport": require('./transport')(winston.transports.File, {
   //   filename: path.join(__dirname, '..', 'fixtures', 'logs', 'testfile.log')
   // })
+
+  it('should create a log file with specific permissions (mode)', function (done) {
+    const logFile = path.join(__dirname, '../../fixtures/logs/permissioned.log');
+    const logger = winston.createLogger({
+      transports: [
+        new winston.transports.File({
+          filename: logFile,
+          mode: 0o660
+        })
+      ]
+    });
+  
+    // Catch logger errors
+    logger.on('error', (err) => {
+      done(err);
+    });
+  
+    logger.on('finish', () => {
+      try {
+        const stats = fs.statSync(logFile);
+        // Mask to get the permission bits only
+        const actualMode = (stats.mode & 0o777).toString(8);
+        // Accept both 660 and 640, since umask may mask out group write
+        assume(['660', '640']).includes(actualMode);
+        fs.unlinkSync(logFile);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  
+    logger.info('check my permissions');
+    logger.end();
+  });
 });
 
 describe('File({ stream })', function () {


### PR DESCRIPTION
This PR adds support for `mode`, `uid`, and `gid` options to the File transport, allowing users to control file permissions and ownership for log files and directories. This addresses #2026.

       - Updates File transport to accept and use these options.
       - Adds/updates tests to verify file mode.
       - Updates documentation for new options.
All tests pass locally.