### PR TITLE
fix(logger): properly close transports on reconfigure to prevent 'write after end' (fixes #1573)

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -97,6 +97,12 @@ class Logger extends Transform {
   } = {}) {
     // Reset transports if we already have them
     if (this.transports.length) {
+      // Properly close all transports before clearing
+      this.transports.forEach(t => {
+        if (typeof t.close === 'function') {
+          t.close();
+        }
+      });
       this.clear();
     }
 

--- a/test/unit/winston/logger.test.js
+++ b/test/unit/winston/logger.test.js
@@ -22,6 +22,7 @@ const format = require('../../../lib/winston').format;
 const helpers = require('../../helpers');
 const mockTransport = require('../../helpers/mocks/mock-transport');
 const testLogFixturesPath = path.join(__dirname, '..', '..', 'fixtures', 'logs');
+const fs = require('fs');
 
 describe('Logger Instance', function () {
   describe('Configuration', function () {
@@ -630,8 +631,8 @@ describe('Logger Instance', function () {
 
       const expected = [
         'Now witness the power of the fully armed and operational logger',
-        'Consider the philosophical and metaphysical – BANANA BANANA BANANA',
-        'I was god once. I saw – you were doing well until everyone died.'
+        'Consider the philosophical and metaphysical – BANANA BANANA BANANA',
+        'I was god once. I saw – you were doing well until everyone died.'
       ];
 
       expected.forEach(msg => logger.info(msg));
@@ -1048,5 +1049,43 @@ describe('Logger Instance', function () {
         logger.log('info', err);
       });
     });
+  });
+});
+
+describe('Logger reconfiguration', function () {
+  it('should not throw write after end when reconfiguring file transport', function (done) {
+    this.timeout(10000); // Give plenty of time for file I/O
+  
+    const logFile1 = path.join(__dirname, '../../fixtures/logs/reconfig1.log');
+    const logFile2 = path.join(__dirname, '../../fixtures/logs/reconfig2.log');
+  
+    [logFile1, logFile2].forEach(f => { if (fs.existsSync(f)) fs.unlinkSync(f); });
+  
+    const logger = winston.createLogger({
+      transports: [
+        new winston.transports.File({ filename: logFile1 })
+      ]
+    });
+  
+    logger.on('error', (err) => {
+      console.error('Logger error:', err);
+      done(err);
+    });
+  
+    // Listen for finish event to ensure all logs are flushed
+    logger.on('finish', () => {
+      [logFile1, logFile2].forEach(f => { if (fs.existsSync(f)) fs.unlinkSync(f); });
+      done();
+    });
+  
+    logger.info('first log');
+    // Reconfigure with a new file transport
+    logger.configure({
+      transports: [
+        new winston.transports.File({ filename: logFile2 })
+      ]
+    });
+    logger.info('second log');
+    logger.end(); // This will flush and close all streams, triggering 'finish'
   });
 });


### PR DESCRIPTION
Issue: #1573 – Error: write after end when reconfiguring file transports with logger.configure().
Solution: Ensure all file transports are properly closed before being replaced.
Testing: Added a regression test to confirm no error is thrown after reconfiguration. All tests pass.

