### PR TITLE
fix: add getOrCreate to Container and deprecate get (closes #2580)

### DIFF
--- a/lib/winston/container.js
+++ b/lib/winston/container.js
@@ -55,15 +55,42 @@ module.exports = class Container {
   }
 
   /**
-   * Retreives a `winston.Logger` instance for the specified `id`. If
-   * an instance does not exist, one is created.
-   * @param {!string} id - The id of the Logger to get.
-   * @param {?Object} [options] - Options for the Logger instance.
+ * @deprecated Use `loggers.getOrCreate(id, options)` or `loggers.add(id, options)`.
+ *
+ * Retrieves a `winston.Logger` instance for the specified `id`.
+ * If an instance does not exist, one is created.
+ * ⚠️ Passing `options` here will only be effective when creating,
+ * not when retrieving.
+ *
+ * @param {!string} id - The id of the Logger to get.
+ * @param {?Object} [options] - Options for the Logger instance.
+ * @returns {Logger} - A configured Logger instance with a specified id.
+ */
+  get(id, options) {
+    process.emitWarning(
+      'loggers.get(id, options) is deprecated — use loggers.getOrCreate(id, options) or loggers.add(id, options).',
+      'DeprecationWarning'
+    );
+    return this.getOrCreate(id, options);
+  }
+
+  /**
+   * Retrieves a `winston.Logger` instance for the specified `id`,
+   * or creates it with the given options if it does not exist.
+   *
+   * @param {!string} id - The id of the Logger to get or create.
+   * @param {?Object} [options] - Options for the Logger instance
+   *   (only used if creating).
    * @returns {Logger} - A configured Logger instance with a specified id.
    */
-  get(id, options) {
-    return this.add(id, options);
+  getOrCreate(id, options) {
+    if (this.has(id)) {
+      return this._getLoggerFromRegistry(id);
+    }
+    return this.add(id, options || {});
   }
+
+
 
   /**
    * Check if the container has a logger with the id.

--- a/test/unit/winston/container.test.js
+++ b/test/unit/winston/container.test.js
@@ -86,4 +86,36 @@ describe('Container', function () {
       assume(all.someOtherLogger._readableState.pipes).equals(all.someLogger._readableState.pipes);
     });
   });
+
+  describe('getOrCreate', function () {
+    var container;
+    var defaultTest;
+
+    beforeEach(function () {
+      container = new winston.Container();
+    });
+
+    it('creates a new logger if not exists', function () {
+      defaultTest = container.getOrCreate('test-logger', {
+        defaultMeta: { foo: 'bar' }
+      });
+
+      assume(defaultTest.defaultMeta).deep.equals({ foo: 'bar' });
+    });
+
+    it('returns existing logger if already created (ignores new options)', function () {
+      const logger1 = container.getOrCreate('test-logger', {
+        defaultMeta: { foo: 'bar' }
+      });
+
+      const logger2 = container.getOrCreate('test-logger', {
+        defaultMeta: { baz: 'qux' }
+      });
+
+      assume(logger1).equals(logger2);
+
+      assume(logger2.defaultMeta).deep.equals({ foo: 'bar' });
+    });
+  });
+
 });


### PR DESCRIPTION
fix: add getOrCreate to Container and deprecate get (closes #2580)

Fixes issue #2580 by clarifying logger creation behavior.

 Added loggers.getOrCreate(id, options) to create a logger only if it does not exist.
 Deprecated loggers.get(id, options); passing options to `get` now only works when creating a new logger.
 Ensures options like defaultMeta are applied consistently when creating loggers.
 Added tests to verify correct creation and retrieval behavior.

This makes logger retrieval predictable and avoids confusion when extending existing loggers.
