### PR TITLE
fix: ensure File transport flushes all data before emitting finish

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -110,6 +110,38 @@ module.exports = class File extends TransportStream {
   }
 
   /**
+   * Called by Node.js Writable stream before emitting 'finish'.
+   * Ensures all buffered data is flushed to the underlying file stream
+   * before the transport signals completion.
+   * @param {Function} callback - Callback to signal completion.
+   * @private
+   */
+  _final(callback) {
+    // If still opening, wait for the file to be opened first
+    if (this._opening) {
+      this.once('open', () => this._final(callback));
+      return;
+    }
+
+    // End the PassThrough stream
+    this._stream.end();
+
+    // No destination stream, call callback immediately
+    if (!this._dest) {
+      return callback();
+    }
+
+    // Destination is already finished
+    if (this._dest.writableFinished) {
+      return callback();
+    }
+
+    // Wait for destination stream to finish writing
+    this._dest.once('finish', callback);
+    this._dest.once('error', callback);
+  }
+
+  /**
    * Core logging method exposed to Winston. Metadata is optional.
    * @param {Object} info - TODO: add param description.
    * @param {Function} callback - TODO: add param description.


### PR DESCRIPTION
Fixes #1504 and relates to https://github.com/promptfoo/promptfoo/pull/6511 

When you call `logger.end()` and then `process.exit()`, log messages get lost. This has been an open issue since 2018.

The problem is that the File transport's `finish` event fires when the internal PassThrough drains, not when the actual file write completes. So you think you're safe to exit, but the OS hasn't finished writing yet.

The fix adds a `_final()` method (the standard Node.js stream hook for this) that waits for the fs.WriteStream to finish before letting the transport emit `finish`.

---

**To verify the fix:**

```js
const fs = require('fs');
const winston = require('winston');

const transport = new winston.transports.File({ filename: 'test.log' });
const logger = winston.createLogger({ transports: [transport] });

(async () => {
  for (let i = 0; i < 1000; i++) logger.info(`message ${i}`);
  logger.info('THE LAST MESSAGE');

  await new Promise(resolve => {
    transport.on('finish', resolve);
    logger.end();
  });

  const lines = fs.readFileSync('test.log', 'utf8').split('\n').filter(Boolean);
  console.log(`Lines written: ${lines.length}`);  // should be 1001
})();
```

Before: ~1 line written. After: all 1001 lines written.

Also added regression tests under "Flushing on end (issue #1504)" in `file.test.js`.