### PR TITLE
fix(types): restore backward-compatible TransformableInfo for logform…fix(types): restore backward-compatible TransformableInfo for logform 2.7.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## UNRELEASED
+
+**TypeScript**
+- [#2528] Fix backward-compatible `TransformableInfo` type for logform 2.7.0+ breaking change
+
 ## [v3.9.0](https://github.com/winstonjs/winston/compare/v3.8.2...v3.9.0)
 ### Functionality changes
 * Handle undefined errors in getAllInfo in exception-handler in https://github.com/winstonjs/winston/pull/2208; thanks to new contributor @eivindrs

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,38 @@ import * as Transports from './lib/winston/transports/index';
 
 declare namespace winston {
   // Hoisted namespaces from other modules
-  export import format = logform.format;
+  // Backward-compatible TransformableInfo for logform 2.7.0+
+  // https://github.com/winstonjs/winston/issues/2528
+  interface TransformableInfo {
+    level: string;
+    message: any;
+    [key: string]: any;
+  }
+  type TransformFunction = (info: TransformableInfo, opts?: any) => TransformableInfo | boolean;
+  type FormatWrap = (opts?: any) => logform.Format;
+
+  function format(transform: TransformFunction): FormatWrap;
+  namespace format {
+    function align(): logform.Format;
+    function cli(opts?: logform.CliOptions): logform.Format;
+    function colorize(opts?: logform.ColorizeOptions): logform.Colorizer;
+    function combine(...formats: logform.Format[]): logform.Format;
+    function errors(opts?: object): logform.Format;
+    function json(opts?: logform.JsonOptions): logform.Format;
+    function label(opts?: logform.LabelOptions): logform.Format;
+    function logstash(): logform.Format;
+    function metadata(opts?: logform.MetadataOptions): logform.Format;
+    function ms(): logform.Format;
+    function padLevels(opts?: logform.PadLevelsOptions): logform.Format;
+    function prettyPrint(opts?: logform.PrettyPrintOptions): logform.Format;
+    function printf(templateFunction: (info: TransformableInfo) => string): logform.Format;
+    function simple(): logform.Format;
+    function splat(): logform.Format;
+    function timestamp(opts?: logform.TimestampOptions): logform.Format;
+    function uncolorize(opts?: logform.UncolorizeOptions): logform.Format;
+  }
+
+  // Re-export logform types for consumers who need them
   export import Logform = logform;
   export import config = Config;
   export import transports = Transports;


### PR DESCRIPTION
## Summary
Fixes #2528

This PR restores backward compatibility for TypeScript consumers after `logform@2.7.0` changed `TransformableInfo.message` from `any` to `unknown`.

## Changes
- Re-declare `TransformableInfo` interface with `message: any` and index signature `[key: string]: any`
- Re-declare `format` namespace functions to use the compatible `TransformableInfo` type
- Add `TransformFunction` and `FormatWrap` types for custom format functions

## Problem
Starting with Winston v3.17.0, valid TypeScript code like this stopped compiling:

```ts
const logger = winston.createLogger({
  format: winston.format.printf(info => {
    return `${info.level}: ${info.message}`; // Error: 'message' is 'unknown'
  })
});
```

## Solution
Winston now re-declares a backward-compatible `TransformableInfo` that preserves the original `any` typing, shielding consumers from the upstream breaking change.

## Testing
Verified TypeScript compilation with consumer-style usage patterns
All existing tests pass