### PR TITLE
feat(file): add mode and dirMode options for file/directory permissions

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -61,6 +61,7 @@ module.exports = class File extends TransportStream {
 
       this.dirname = options.dirname || path.dirname(options.filename);
       this.options = options.options || { flags: 'a' };
+      if (options.mode != null) this.options.mode = options.mode;
     } else if (options.stream) {
       // eslint-disable-next-line no-console
       console.warn('options.stream will be removed in winston@4. Use winston.transports.Stream');
@@ -80,6 +81,7 @@ module.exports = class File extends TransportStream {
     this.eol = (typeof options.eol === 'string') ? options.eol : os.EOL;
     this.tailable = options.tailable || false;
     this.lazy = options.lazy || false;
+    this.dirMode = options.dirMode || null;
 
     // Internal state variables representing the number of files this instance
     // has created and the current size (in bytes) of the current logfile.
@@ -788,7 +790,9 @@ module.exports = class File extends TransportStream {
   _createLogDirIfNotExist(dirPath) {
     /* eslint-disable no-sync */
     if (!fs.existsSync(dirPath)) {
-      fs.mkdirSync(dirPath, { recursive: true });
+      const mkdirOpts = { recursive: true };
+      if (this.dirMode != null) mkdirOpts.mode = this.dirMode;
+      fs.mkdirSync(dirPath, mkdirOpts);
     }
     /* eslint-enable no-sync */
   }

--- a/lib/winston/transports/index.d.ts
+++ b/lib/winston/transports/index.d.ts
@@ -36,6 +36,8 @@ declare namespace winston {
     eol?: string;
     tailable?: boolean;
     lazy?: boolean;
+    mode?: number;
+    dirMode?: number;
   }
 
   interface FileTransportInstance extends Transport {

--- a/test/unit/winston/transports/file.test.js
+++ b/test/unit/winston/transports/file.test.js
@@ -479,6 +479,48 @@ describe('File Transport', function () {
   });
 
 
+  describe('Mode option', function () {
+    it('should pass mode to the write stream options', function () {
+      const transport = new winston.transports.File({
+        filename: 'testmode.log',
+        dirname: testLogFixturesPath,
+        mode: 0o640
+      });
+
+      assert.strictEqual(transport.options.mode, 0o640);
+    });
+
+    it('should not set mode on stream options when mode is not provided', function () {
+      const transport = new winston.transports.File({
+        filename: 'testmode-default.log',
+        dirname: testLogFixturesPath
+      });
+
+      assert.strictEqual(transport.options.mode, undefined);
+    });
+  });
+
+  describe('DirMode option', function () {
+    it('should store dirMode when provided', function () {
+      const transport = new winston.transports.File({
+        filename: 'testdirmode.log',
+        dirname: testLogFixturesPath,
+        dirMode: 0o750
+      });
+
+      assert.strictEqual(transport.dirMode, 0o750);
+    });
+
+    it('should default dirMode to null when not provided', function () {
+      const transport = new winston.transports.File({
+        filename: 'testdirmode-default.log',
+        dirname: testLogFixturesPath
+      });
+
+      assert.strictEqual(transport.dirMode, null);
+    });
+  });
+
   // TODO: Reintroduce these tests
   //
   // "Error object in metadata #610": {


### PR DESCRIPTION
Adds support for configurable file and directory permissions in the File transport.

## Changes

- **`mode`** option: Sets the file permission mode (e.g. `0o640`) passed to `fs.createWriteStream`. Defaults to Node.js default (`0o666`) when not specified.
- **`dirMode`** option: Sets the directory permission mode (e.g. `0o750`) used when creating log directories with `fs.mkdirSync`. Defaults to Node.js default when not specified.
- Updated TypeScript definitions for both options.
- Added unit tests.

## Usage

```js
const logger = winston.createLogger({
  transports: [
    new winston.transports.File({
      filename: 'app.log',
      dirname: '/var/log/myapp',
      mode: 0o640,
      dirMode: 0o750
    })
  ]
});
```

Fixes #2026