### PR TITLE
fix(file): use fs.constants.F_OK instead of deprecated fs.F_OK

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -771,7 +771,7 @@ module.exports = class File extends TransportStream {
    * @private
    */
   _compressFile(src, dest, callback) {
-    fs.access(src, fs.F_OK, (err) => {
+    fs.access(src, fs.constants.F_OK, (err) => {
       if (err) {
         return callback();
       }


### PR DESCRIPTION
Fixes #2610

Node.js v22 deprecated `fs.F_OK`, `fs.R_OK`, `fs.W_OK`, and `fs.X_OK` as direct properties on `fs` (see [DEP0176](https://nodejs.org/api/deprecations.html#dep0176-fsfok-fswok-fsrok-fsxok)). The correct replacement is `fs.constants.F_OK`.

The `_compressFile` method in the File transport was using `fs.F_OK` directly. Changed to `fs.constants.F_OK`.

All 234 tests pass.