### PR TITLE
ci: upgrade test matrix to Node 22, 24, and 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 16
-          - 18
-          - 20
+          - 22
+          - 24
+          - 26
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -46,7 +46,7 @@ jobs:
         run: npm run test:integration
 
       - name: Report test coverage to Coveralls.io
-        if: matrix.node == '20'
+        if: matrix.node == '24'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,7 +8,6 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
-    "baseUrl": "./",
     "forceConsistentCasingInFileNames": true,
     "typeRoots": [
       "../node_modules",

--- a/test/unit/winston/transports/file.test.js
+++ b/test/unit/winston/transports/file.test.js
@@ -295,7 +295,7 @@ describe('File Transport', function () {
       assertFileDoesNotExist('testarchive.log'); // The oldest file should be deleted
       assertFileExists('testarchive1.log');
       assertFileExists('testarchive2.log');
-    });
+    }, 10000);
   });
 
   describe('Tailable option', function () {


### PR DESCRIPTION
Reminder: the winston support policy is only for non-EOL Node versions.  Any EOL'd Node versions are liable to not work with newer winston releases, even minor releases.

Upgrades the CI test matrix to test against currently-supported Node.js releases.

## Changes
- Replaces Node `16`, `18`, `20` with `22`, `24`, `26` in the test matrix.
- Updates the Coveralls reporting condition to run on Node `24` (the new middle version), replacing the old `20` check.

Node 16, 18, and 20 are all past end-of-life, so the matrix now exercises active and current releases instead.