### PR TITLE
test: make File transport coverage deterministic across environments

### DIFF
--- a/test/unit/winston/transports/file.test.js
+++ b/test/unit/winston/transports/file.test.js
@@ -139,6 +139,64 @@ describe('File Transport', function () {
 
       assertFileExists(expectedFilename);
     });
+
+    it('should reuse an existing file that is under maxsize on open', async function () {
+      // Pre-create a non-empty log file that is smaller than maxsize so that,
+      // when the transport opens, stat() deterministically takes the
+      // "existing file with room" path. Without this, whether that path runs
+      // depends on leftover filesystem state between tests, which made coverage
+      // flaky across runners and Node versions.
+      fs.writeFileSync(getFilePath('testarchive.log'), 'preexisting\n');
+
+      const transport = new winston.transports.File({
+        ...defaultTransportOptions
+      });
+
+      await logToTransport(transport);
+      await waitForFile('testarchive.log');
+
+      assertFileExists('testarchive.log');
+      // The pre-existing content must be retained (appended to, not truncated).
+      const contents = fs.readFileSync(getFilePath('testarchive.log'), 'utf8');
+      assert.ok(
+        contents.startsWith('preexisting\n'),
+        'Expected the existing file to be reused rather than overwritten'
+      );
+    });
+  });
+
+  describe('Backpressure', function () {
+    it('should wait for drain and requeue logs when the stream buffer fills', async function () {
+      // No maxsize: keep this focused on backpressure without triggering rotation.
+      const transport = new winston.transports.File({
+        timestamp: true,
+        json: false,
+        filename: 'testbackpressure.log',
+        dirname: testLogFixturesPath
+      });
+
+      // The internal PassThrough has a 16KB highWaterMark, so a single message
+      // larger than that makes stream.write() return false synchronously (this is
+      // governed by the in-memory buffer, not disk speed, so it is deterministic
+      // on every machine). This exercises the backpressure path that was
+      // previously only hit nondeterministically by the file stress tests, which
+      // made coverage flaky across runners and Node versions.
+      const oversized = 'a'.repeat(32 * 1024);
+      const written = transport.log({ level: 'info', [MESSAGE]: oversized }, () => {});
+
+      assert.strictEqual(written, false, 'Expected an oversized write to report backpressure');
+      assert.strictEqual(transport._drain, true, 'Expected the transport to be draining after an oversized write');
+
+      // A second log that arrives while draining must take the requeue path; its
+      // callback only fires once the drain event has flushed the buffer and the
+      // queued log has been written. Awaiting it (with no fixed timeout) keeps the
+      // assertion robust regardless of how long draining takes under load.
+      await new Promise((resolve, reject) => {
+        transport.log({ level: 'info', [MESSAGE]: 'after-drain' }, err => err ? reject(err) : resolve());
+      });
+
+      assert.strictEqual(transport._drain, false, 'Expected draining to finish once the queued log was flushed');
+    });
   });
 
   describe('Rotation Format option', function () {


### PR DESCRIPTION
## Problem

Unit-test line coverage for the **File transport** fluctuated run-to-run and across runners / Node versions. Because the Coveralls status fails a PR on *any* coverage decrease, and the project's baseline sits right at the top of this flaky band, roughly half of CI runs would report a spurious "coverage decreased (-0.2%)" and turn the Coveralls check red — even on PRs that change no source (e.g. the Node-matrix bump in #2612).

## Root cause

Isolated empirically (per-line coverage diffing over 100+ runs, with/without the stress tests, across Node 22/24/26, and under heavy CPU load). Two code paths in `lib/winston/transports/file.js` were only exercised *incidentally*, by timing-sensitive tests:

1. **Stream backpressure** — the `if (this._drain)` requeue and the `if (!written)` drain handler only run when `_stream.write()` returns `false`, i.e. when the OS write buffer fills. Whether that happens depends on I/O throughput, so the file **stress** tests covered these ~8 lines nondeterministically.

2. **`stat()` "existing file under maxsize" path** — covering an already-present log file on open. This was only hit depending on leftover filesystem state between tests, so it flickered in ~10% of runs.

## Fix

**Two focused tests — no production code changes.** Rather than hiding the lines from coverage, both paths are now exercised deterministically:

- **Backpressure** is forced with a single write larger than the internal `PassThrough`'s 16KB `highWaterMark`. That is governed by the in-memory buffer, not disk speed, so `write()` returns `false` identically on every machine; a second log issued while draining then covers the requeue path.

- **`stat()` existing-file path** is covered by pre-creating a small file before the transport opens.

## Verification

Coverage is now identical on every run — **784 covered lines** — verified over 70+ runs across Node 22 / 24 / 26, including under an artificial load average of ~280. Because both paths are now *always* covered (rather than ignored), this also raises coverage slightly versus master's flaky band, so the Coveralls baseline becomes stable going forward. `lint`, `test:unit` (233 passing), `test:integration`, and `test:typescript` all pass.