### PR TITLE
fix: replace deprecated fs.F_OK with fs.constants.F_OK

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -771,7 +771,7 @@ module.exports = class File extends TransportStream {
    * @private
    */
   _compressFile(src, dest, callback) {
-    fs.access(src, fs.F_OK, (err) => {
+    fs.access(src, fs.constants.F_OK, (err) => {
       if (err) {
         return callback();
       }


### PR DESCRIPTION
## Description

Replace deprecated `fs.F_OK` usage with `fs.constants.F_OK`.

Recent Node.js versions emit the following warning:

```text
[DEP0176] DeprecationWarning: fs.F_OK is deprecated, use fs.constants.F_OK instead
```

This change removes the deprecation warning while preserving existing behavior, since both values resolve to the same constant.

## Changes

- Replace `fs.F_OK` with `fs.constants.F_OK` in `lib/winston/transports/file.js`

## Testing

- Verified that `fs.F_OK` emits a deprecation warning on current Node.js versions.
- Existing file transport tests show the same failures on both `master` and this branch.