### PR TITLE
fix: preserve string message passed to Profiler.done()

### DIFF
--- a/lib/winston/profiler.js
+++ b/lib/winston/profiler.js
@@ -43,6 +43,9 @@ class Profiler {
     }
 
     const info = typeof args[args.length - 1] === 'object' ? args.pop() : {};
+    if (typeof args[args.length - 1] === 'string') {
+      info.message = info.message || args.pop();
+    }
     info.level = info.level || 'info';
     info.durationMs = (Date.now()) - this.start;
 

--- a/test/unit/winston/profiler.test.js
+++ b/test/unit/winston/profiler.test.js
@@ -37,6 +37,21 @@ describe('Profiler', function () {
     }, 200);
   });
 
+  it('.done(message) uses the string as info.message', function (done) {
+    const logger = new Logger();
+    logger.write = function (info) {
+      assume(info).is.an('object');
+      assume(info.level).equals('info');
+      assume(info.durationMs).is.a('number');
+      assume(info.message).equals('testing1');
+      done();
+    };
+    var profiler = new Profiler(logger);
+    setTimeout(function () {
+      profiler.done('testing1');
+    }, 200);
+  });
+
   it('non logger object', function(){
     assume(function() {
       new Profiler(new Error('Unknown error'));


### PR DESCRIPTION
`logger.startTimer().done('some message')` silently drops the message: only an object arg is consumed, so a string is ignored and `info.message` stays `undefined`. This mirrors `logger.profile(id)` which does set `info.message`.

Fix: if the trailing arg is a string, use it as `info.message` (object form unchanged).

```js
const t = logger.startTimer();
t.done('Job complete');
// before: { durationMs: 0, level: 'info' }
// after:  { durationMs: 0, level: 'info', message: 'Job complete' }
```

Added a unit test in `test/unit/winston/profiler.test.js` (fails without the fix). Full unit suite green.