### PR TITLE
feat: allow configurable file permissions in file transport

### DIFF
--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -609,9 +609,13 @@ module.exports = class File extends TransportStream {
   _createStream(source) {
     const fullpath = path.join(this.dirname, this.filename);
 
-    debug('create stream start', fullpath, this.options);
-    const dest = fs.createWriteStream(fullpath, this.options)
-      // TODO: What should we do with errors here?
+      debug('create stream start', fullpath, this.options);
+      const options = Object.assign({}, this.options);
+      if (this.options.mode) {
+      options.mode = this.options.mode;
+      }
+        const dest = fs.createWriteStream(fullpath, options)
+
       .on('error', err => debug(err))
       .on('close', () => debug('close', dest.path, dest.bytesWritten))
       .on('open', () => {


### PR DESCRIPTION
Closes #2026. This PR adds support for configurable file permissions (mode) in the file transport using fs.createWriteStream options.
