### PR TITLE
docs: add missing Node.js stream link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,7 +1093,7 @@ by `winston` see the [`winston` Transports](docs/transports.md) document.
 ### Awaiting logs to be written in `winston`
 
 Often it is useful to wait for your logs to be written before exiting the
-process. Each instance of `winston.Logger` is also a [Node.js stream]. A
+process. Each instance of `winston.Logger` is also a [Node.js stream](https://nodejs.org/api/stream.html). A
 `finish` event will be raised when all logs have flushed to all transports
 after the stream has been ended.
 


### PR DESCRIPTION
## Summary
- Add the missing URL for the Node.js stream markdown link in the "Awaiting logs to be written in winston" section of the README.

Fixes #1870

## Test plan
- [x] Confirm the README link renders to https://nodejs.org/api/stream.html
- [x] Confirm no other files were changed