### PR TITLE
fix(profiler): stop rejecting valid Loggers via instanceof across module copies

### DIFF
--- a/lib/winston/profiler.js
+++ b/lib/winston/profiler.js
@@ -20,8 +20,24 @@ class Profiler {
    * @private
    */
   constructor(logger) {
-    const Logger = require('./logger');
-    if (typeof logger !== 'object' || Array.isArray(logger) || !(logger instanceof Logger)) {
+    // Remark: We intentionally avoid an `instanceof Logger` check here.
+    // Loading `./logger` and comparing class identity breaks whenever more
+    // than one instance of the `winston` module ends up in memory (e.g. a
+    // duplicated nested install, or a test runner like Jest that resets its
+    // module registry between files/suites). In that situation a perfectly
+    // valid `DerivedLogger` fails `instanceof` against the "wrong" copy of
+    // the `Logger` class and profiling breaks for reasons unrelated to the
+    // caller's code. Instead we duck-type for the shape of a winston Logger
+    // (a writable stream with `.log()` and `.levels`), which still rejects
+    // arbitrary values and generic streams (see profiler.test.js).
+    if (
+      !logger ||
+      typeof logger !== 'object' ||
+      Array.isArray(logger) ||
+      typeof logger.write !== 'function' ||
+      typeof logger.log !== 'function' ||
+      typeof logger.levels !== 'object'
+    ) {
       throw new Error('Logger is required for profiling');
     } else {
       this.logger = logger;

--- a/test/unit/winston/profiler.test.js
+++ b/test/unit/winston/profiler.test.js
@@ -62,4 +62,31 @@ describe('Profiler', function () {
       new Profiler('1');
     }).throws('Logger is required for profiling');
   })
+
+  it('accepts a Logger created from a different copy of the `Logger` module (e.g. duplicated/hoisted install or test-runner module reset)', function () {
+    // Regression test for https://github.com/winstonjs/winston/issues/2432:
+    // `new Profiler(logger)` used to reject an otherwise valid winston
+    // Logger whenever it was constructed against a different in-memory
+    // copy of the `./logger` class (an `instanceof` check across two
+    // "copies" of the same module always fails, even though both copies
+    // define an identical class). This happens for reasons outside the
+    // caller's control, e.g. a duplicated nested `winston` install, or
+    // (as reported in the issue) a test runner such as Jest resetting its
+    // module registry between test files.
+    jest.resetModules();
+    const createLogger = require('../../../lib/winston/create-logger');
+    const logger = createLogger({});
+
+    // Force a fresh copy of `./logger` (and therefore `./profiler`, which
+    // requires it) to be loaded, simulating the module-duplication
+    // scenario from the issue.
+    jest.resetModules();
+    const FreshProfiler = require('../../../lib/winston/profiler');
+
+    let profiler;
+    assume(function () {
+      profiler = new FreshProfiler(logger);
+    }).not.throws();
+    assume(profiler.logger).equals(logger);
+  });
 });


### PR DESCRIPTION
Fixes #2432

## Problem

`Profiler`'s constructor validates its `logger` argument with:

```js
const Logger = require('./logger');
if (typeof logger !== 'object' || Array.isArray(logger) || !(logger instanceof Logger)) {
  throw new Error('Logger is required for profiling');
}
```

This `instanceof` check only holds when the `Logger` class used to build the
logger instance and the `Logger` class re-`require`d inside `Profiler` at
call time are the *exact same* in-memory class object. That's usually true,
but it stops being true the moment two copies of `winston` end up loaded in
the same process — e.g. a duplicated/hoisted nested install, or (as reported
in #2432) a test runner like Jest resetting its module registry between
test files/suites. In that situation a perfectly valid `DerivedLogger`
(built by `createLogger()`) fails `instanceof` against the "wrong" copy of
`Logger`, and `logger.startTimer()` throws `Logger is required for
profiling` for reasons that have nothing to do with the caller's code.

## Fix

Replace the class-identity check with duck-typing for the shape of a
winston Logger: a writable stream exposing `.log()` and `.levels`. This
still rejects everything the existing guardrail tests
(`test/unit/winston/profiler.test.js`, added in #2226 for #2091) require —
`undefined`, `Error` instances, plain objects, arrays, a bare
`PassThrough` stream, numbers, and strings — while no longer depending on
which copy of the `./logger` module defined the class.

## QA / verification

- Reproduced the bug directly against `lib/winston/create-logger.js` +
  `lib/winston/profiler.js` on the unfixed `master` by forcing a second,
  independent evaluation of `./logger` (mirroring both a genuinely
  duplicated nested install and `jest.resetModules()`) and confirming
  `logger.startTimer()` throws even though `logger` is a completely valid,
  freshly created `DerivedLogger`.
- Confirmed the fix resolves it: same repro, `startTimer()` now succeeds
  and returns a working `Profiler`.
- Added a regression test to `profiler.test.js` using `jest.resetModules()`
  (the direct, in-repo equivalent of the module-duplication scenario from
  the issue). Verified it **fails** against the unfixed constructor and
  **passes** with the fix.
- Ran the full existing `profiler.test.js` suite (including the pre-existing
  guardrail test that rejects `Error`/plain-object/array/`PassThrough`/
  number/string) — all pass with the new duck-typing check.
- Ran the full `npm test` (Jest) suite before and after the change. Aside
  from a handful of pre-existing, environment-sensitive failures unrelated
  to this change (timer/spawn-based tests in `log-exception.test.js` and
  `tail-file.test.js`, and file-rotation line-count assertions in
  `transports/file.test.js` — all reproduce identically on unmodified
  `master` on this machine, Windows), test results are unchanged by this
  PR.
- Linted `lib/winston/profiler.js`; no new issues introduced (the only
  lint output on this machine is pre-existing CRLF/LF noise from a
  Windows checkout with `core.autocrlf=true`, which also appears on
  unmodified files).

## Disclosure

This fix was investigated and written with AI assistance (Claude), with
the root cause reproduced locally before writing the fix, and the fix
verified against the repo's real test suite (including a written and
verified-red/verified-green regression test) rather than asserted. Happy
to adjust the approach if maintainers would prefer a different fix shape
(e.g. keeping `instanceof` but caching the `Logger` reference at module
load time instead of re-`require`-ing it per construction).
