### PR TITLE
docs: fix exitOnError wording for unhandled exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ A logger accepts the following parameters:
 | `levels`      | `winston.config.npm.levels` | Levels (and colors) representing log priorities            |
 | `format`      | `winston.format.json`       | Formatting for `info` messages  (see: [Formats])           |
 | `transports`  | `[]` _(No transports)_      | Set of logging targets for `info` messages                 |
-| `exitOnError` | `true`                      | If false, handled exceptions will not cause `process.exit` |
+| `exitOnError` | `true`                      | If false, unhandled exceptions will not cause `process.exit` |
 | `silent`      | `false`                     | If true, all logs are suppressed |
 
 The levels provided to `createLogger` will be defined as convenience methods


### PR DESCRIPTION
## Summary
- Fixes the `exitOnError` row in the createLogger options table: it said "handled exceptions" but the option controls whether uncaught/unhandled exceptions call `process.exit`.
- Aligns that table row with the Handling Uncaught Exceptions section below it.

Fixes #1898

## Test plan
- [x] Confirmed the README table line matches the uncaughtException / exitOnError behavior described later in the same file
- [ ] Quick skim of the options table in the rendered README on GitHub