### PR TITLE
fix(type): replace hardcoded log method with generic ones from Logger.levels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,17 +75,17 @@ declare namespace winston {
     (level: string, message: any): Logger;
   }
 
-  interface LeveledLogMethod<Levels extends object = Config.NpmConfigSetLevels> {
+  interface LeveledLogMethod<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels> {
     (message: string, ...meta: any[]): Logger<Levels>;
     (message: any): Logger<Levels>;
     (infoObject: object): Logger<Levels>;
   }
 
-  type LeveledLogMethods<Levels extends object> = {
+  type LeveledLogMethods<Levels extends Config.AbstractConfigSetLevels<Levels>> = {
     [level in keyof Levels]: LeveledLogMethod<Levels>;
   };
 
-  interface LoggerOptions<Levels extends object = Config.NpmConfigSetLevels> {
+  interface LoggerOptions<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels> {
     levels?: Levels;
     silent?: boolean;
     format?: logform.Format;
@@ -99,7 +99,7 @@ declare namespace winston {
     rejectionHandlers?: any;
   }
 
-  class LoggerInstance<Levels extends object = Config.NpmConfigSetLevels> extends NodeJSStream.Transform {
+  class LoggerInstance<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels> extends NodeJSStream.Transform {
     constructor(options?: LoggerOptions<Levels>);
 
     silent: boolean;
@@ -141,7 +141,7 @@ declare namespace winston {
     isSillyEnabled(): boolean;
   }
 
-  type Logger<Levels extends object = Config.NpmConfigSetLevels> = LoggerInstance<Levels> & LeveledLogMethods<Levels>;
+  type Logger<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels> = LoggerInstance<Levels> & LeveledLogMethods<Levels>;
 
   const Logger: typeof LoggerInstance;
 
@@ -149,8 +149,8 @@ declare namespace winston {
     loggers: Map<string, Logger>;
     options: LoggerOptions;
 
-    add<Levels extends object = Config.NpmConfigSetLevels>(id: string, options?: LoggerOptions<Levels>): Logger<Levels>;
-    get<Levels extends object = Config.NpmConfigSetLevels>(id: string, options?: LoggerOptions<Levels>): Logger<Levels>;
+    add<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels>(id: string, options?: LoggerOptions<Levels>): Logger<Levels>;
+    get<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels>(id: string, options?: LoggerOptions<Levels>): Logger<Levels>;
     has(id: string): boolean;
     close(id?: string): void;
 
@@ -161,7 +161,7 @@ declare namespace winston {
   let loggers: Container;
 
   let addColors: (target: Config.AbstractConfigSetColors) => any;
-  let createLogger: <Levels extends object = Config.NpmConfigSetLevels>(options?: LoggerOptions<Levels>) => Logger<Levels>;
+  let createLogger: <Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels>(options?: LoggerOptions<Levels>) => Logger<Levels>;
 
   // Pass-through npm level methods routed to the default logger.
   let error: LeveledLogMethod;

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,16 +63,16 @@ declare namespace winston {
     done(info?: any): boolean;
   }
 
-  interface LogEntry {
-    level: string;
+  interface LogEntry<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels> {
+    level: keyof Levels,
     message: string;
     [optionName: string]: any;
   }
 
-  interface LogMethod {
-    (level: string, message: string, ...meta: any[]): Logger;
-    (entry: LogEntry): Logger;
-    (level: string, message: any): Logger;
+  interface LogMethod<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels> {
+    (level: keyof Levels, message: string, ...meta: any[]): Logger<Levels>;
+    (entry: LogEntry<Levels>): Logger<Levels>;
+    (level: keyof Levels, message: any): Logger<Levels>;
   }
 
   interface LeveledLogMethod<Levels extends Config.AbstractConfigSetLevels<Levels> = Config.NpmConfigSetLevels> {
@@ -113,7 +113,7 @@ declare namespace winston {
     exitOnError: Function | boolean;
     defaultMeta?: any;
 
-    log: LogMethod;
+    log: LogMethod<Levels>;
     add(transport: Transport): this;
     remove(transport: Transport): this;
     clear(): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,14 +75,18 @@ declare namespace winston {
     (level: string, message: any): Logger;
   }
 
-  interface LeveledLogMethod {
-    (message: string, ...meta: any[]): Logger;
-    (message: any): Logger;
-    (infoObject: object): Logger;
+  interface LeveledLogMethod<Levels extends object = Config.NpmConfigSetLevels> {
+    (message: string, ...meta: any[]): Logger<Levels>;
+    (message: any): Logger<Levels>;
+    (infoObject: object): Logger<Levels>;
   }
 
-  interface LoggerOptions {
-    levels?: Config.AbstractConfigSetLevels;
+  type LeveledLogMethods<Levels extends object> = {
+    [level in keyof Levels]: LeveledLogMethod<Levels>;
+  };
+
+  interface LoggerOptions<Levels extends object = Config.NpmConfigSetLevels> {
+    levels?: Levels;
     silent?: boolean;
     format?: logform.Format;
     level?: string;
@@ -95,12 +99,12 @@ declare namespace winston {
     rejectionHandlers?: any;
   }
 
-  class Logger extends NodeJSStream.Transform {
-    constructor(options?: LoggerOptions);
+  class LoggerInstance<Levels extends object = Config.NpmConfigSetLevels> extends NodeJSStream.Transform {
+    constructor(options?: LoggerOptions<Levels>);
 
     silent: boolean;
     format: logform.Format;
-    levels: Config.AbstractConfigSetLevels;
+    levels: Levels;
     level: string;
     transports: Transport[];
     exceptions: ExceptionHandler;
@@ -115,26 +119,6 @@ declare namespace winston {
     clear(): this;
     close(): this;
 
-    // for cli and npm levels
-    error: LeveledLogMethod;
-    warn: LeveledLogMethod;
-    help: LeveledLogMethod;
-    data: LeveledLogMethod;
-    info: LeveledLogMethod;
-    debug: LeveledLogMethod;
-    prompt: LeveledLogMethod;
-    http: LeveledLogMethod;
-    verbose: LeveledLogMethod;
-    input: LeveledLogMethod;
-    silly: LeveledLogMethod;
-
-    // for syslog levels only
-    emerg: LeveledLogMethod;
-    alert: LeveledLogMethod;
-    crit: LeveledLogMethod;
-    warning: LeveledLogMethod;
-    notice: LeveledLogMethod;
-
     query(
       options?: QueryOptions,
       callback?: (err: Error, results: any) => void
@@ -144,7 +128,7 @@ declare namespace winston {
     startTimer(): Profiler;
     profile(id: string | number, meta?: Record<string, any>): this;
 
-    configure(options: LoggerOptions): void;
+    configure(options: LoggerOptions<Levels>): void;
 
     child(options: Object): this;
 
@@ -157,12 +141,16 @@ declare namespace winston {
     isSillyEnabled(): boolean;
   }
 
+  type Logger<Levels extends object = Config.NpmConfigSetLevels> = LoggerInstance<Levels> & LeveledLogMethods<Levels>;
+
+  const Logger: typeof LoggerInstance;
+
   class Container {
     loggers: Map<string, Logger>;
     options: LoggerOptions;
 
-    add(id: string, options?: LoggerOptions): Logger;
-    get(id: string, options?: LoggerOptions): Logger;
+    add<Levels extends object = Config.NpmConfigSetLevels>(id: string, options?: LoggerOptions<Levels>): Logger<Levels>;
+    get<Levels extends object = Config.NpmConfigSetLevels>(id: string, options?: LoggerOptions<Levels>): Logger<Levels>;
     has(id: string): boolean;
     close(id?: string): void;
 
@@ -173,7 +161,7 @@ declare namespace winston {
   let loggers: Container;
 
   let addColors: (target: Config.AbstractConfigSetColors) => any;
-  let createLogger: (options?: LoggerOptions) => Logger;
+  let createLogger: <Levels extends object = Config.NpmConfigSetLevels>(options?: LoggerOptions<Levels>) => Logger<Levels>;
 
   // Pass-through npm level methods routed to the default logger.
   let error: LeveledLogMethod;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,8 @@ import * as Transport from 'winston-transport';
 import * as Config from './lib/winston/config/index';
 import * as Transports from './lib/winston/transports/index';
 
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
 declare namespace winston {
   // Hoisted namespaces from other modules
   export import format = logform.format;
@@ -89,7 +91,7 @@ declare namespace winston {
     levels?: Levels;
     silent?: boolean;
     format?: logform.Format;
-    level?: string;
+    level?: NoInfer<keyof Levels>;
     exitOnError?: Function | boolean;
     defaultMeta?: any;
     transports?: Transport[] | Transport;
@@ -105,7 +107,7 @@ declare namespace winston {
     silent: boolean;
     format: logform.Format;
     levels: Levels;
-    level: string;
+    level: keyof Levels;
     transports: Transport[];
     exceptions: ExceptionHandler;
     rejections: RejectionHandler;

--- a/lib/winston/config/index.d.ts
+++ b/lib/winston/config/index.d.ts
@@ -17,7 +17,7 @@ declare namespace winston {
     colors: AbstractConfigSetColors;
   }
 
-  interface CliConfigSetLevels extends AbstractConfigSetLevels {
+  interface CliConfigSetLevels {
     error: number;
     warn: number;
     help: number;
@@ -43,7 +43,7 @@ declare namespace winston {
     silly: string | string[];
   }
 
-  interface NpmConfigSetLevels extends AbstractConfigSetLevels {
+  interface NpmConfigSetLevels {
     error: number;
     warn: number;
     info: number;
@@ -63,7 +63,7 @@ declare namespace winston {
     silly: string | string[];
   }
 
-  interface SyslogConfigSetLevels extends AbstractConfigSetLevels {
+  interface SyslogConfigSetLevels {
     emerg: number;
     alert: number;
     crit: number;

--- a/lib/winston/config/index.d.ts
+++ b/lib/winston/config/index.d.ts
@@ -4,9 +4,9 @@
 /// <reference types="node" />
 
 declare namespace winston {
-  interface AbstractConfigSetLevels {
-    [key: string]: number;
-  }
+  type AbstractConfigSetLevels<Levels = any> = {
+    [level in keyof Levels]: number;
+  };
 
   interface AbstractConfigSetColors {
     [key: string]: string | string[];
@@ -17,7 +17,7 @@ declare namespace winston {
     colors: AbstractConfigSetColors;
   }
 
-  interface CliConfigSetLevels {
+  type CliConfigSetLevels = AbstractConfigSetLevels<{
     error: number;
     warn: number;
     help: number;
@@ -28,7 +28,7 @@ declare namespace winston {
     verbose: number;
     input: number;
     silly: number;
-  }
+  }>;
 
   interface CliConfigSetColors extends AbstractConfigSetColors {
     error: string | string[];
@@ -43,7 +43,7 @@ declare namespace winston {
     silly: string | string[];
   }
 
-  interface NpmConfigSetLevels {
+  type NpmConfigSetLevels = AbstractConfigSetLevels<{
     error: number;
     warn: number;
     info: number;
@@ -51,7 +51,7 @@ declare namespace winston {
     verbose: number;
     debug: number;
     silly: number;
-  }
+  }>;
 
   interface NpmConfigSetColors extends AbstractConfigSetColors {
     error: string | string[];
@@ -63,7 +63,7 @@ declare namespace winston {
     silly: string | string[];
   }
 
-  interface SyslogConfigSetLevels {
+  type SyslogConfigSetLevels = AbstractConfigSetLevels<{
     emerg: number;
     alert: number;
     crit: number;
@@ -72,7 +72,7 @@ declare namespace winston {
     notice: number;
     info: number;
     debug: number;
-  }
+  }>;
 
   interface SyslogConfigSetColors extends AbstractConfigSetColors {
     emerg: string | string[];

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -61,22 +61,29 @@ logger.isSillyEnabled();
 // Default (npm) levels, inferred without an explicit generic argument.
 const npmLogger = winston.createLogger({ });
 npmLogger.error('oops').warn('careful').info('fyi').http('req').verbose('v').debug('d').silly('s');
+npmLogger.log('error', 'oops').log('warn', 'careful').log('info', 'fyi').log('http', 'req').log('verbose', 'v').log('debug', 'd').log('silly', 's');
 
 // Syslog levels: only syslog-shaped methods should be available.
 const syslogLogger = winston.createLogger({
     levels: winston.config.syslog.levels,
 });
 syslogLogger.emerg('down').alert('page').crit('bad').warning('hmm').notice('fyi').debug('d');
+syslogLogger.log('emerg', 'down').log('alert', 'page').log('crit', 'bad').log('warning', 'hmm').log('notice', 'fyi').log('debug', 'd');
 // @ts-expect-error - the 'silly' method belongs to npm/cli levels, not syslog
 syslogLogger.silly('nope');
+// @ts-expect-error - the 'silly' method belongs to npm/cli levels, not syslog
+syslogLogger.log('silly', 'nope');
 
 // Fully custom levels: methods are inferred straight from the literal object.
 const customLogger = winston.createLogger({
     levels: { ok: 0, meh: 1, bad: 2 },
 });
 customLogger.ok('fine').meh('eh').bad('uh oh');
+customLogger.log('ok', 'fine').log('meh', 'eh').log('bad', 'uh oh');
 // @ts-expect-error - typo'd level name should not type-check
 customLogger.badd('typo');
+// @ts-expect-error - typo'd level name should not type-check
+customLogger.log('badd', 'typo');
 
 // @ts-expect-error - level values must be numbers
 winston.createLogger({ levels: { ok: 'not a number' } });

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -77,3 +77,6 @@ const customLogger = winston.createLogger({
 customLogger.ok('fine').meh('eh').bad('uh oh');
 // @ts-expect-error - typo'd level name should not type-check
 customLogger.badd('typo');
+
+// @ts-expect-error - level values must be numbers
+winston.createLogger({ levels: { ok: 'not a number' } });

--- a/test/typescript-definitions.ts
+++ b/test/typescript-definitions.ts
@@ -57,3 +57,23 @@ logger.isInfoEnabled();
 logger.isVerboseEnabled();
 logger.isDebugEnabled();
 logger.isSillyEnabled();
+
+// Default (npm) levels, inferred without an explicit generic argument.
+const npmLogger = winston.createLogger({ });
+npmLogger.error('oops').warn('careful').info('fyi').http('req').verbose('v').debug('d').silly('s');
+
+// Syslog levels: only syslog-shaped methods should be available.
+const syslogLogger = winston.createLogger({
+    levels: winston.config.syslog.levels,
+});
+syslogLogger.emerg('down').alert('page').crit('bad').warning('hmm').notice('fyi').debug('d');
+// @ts-expect-error - the 'silly' method belongs to npm/cli levels, not syslog
+syslogLogger.silly('nope');
+
+// Fully custom levels: methods are inferred straight from the literal object.
+const customLogger = winston.createLogger({
+    levels: { ok: 0, meh: 1, bad: 2 },
+});
+customLogger.ok('fine').meh('eh').bad('uh oh');
+// @ts-expect-error - typo'd level name should not type-check
+customLogger.badd('typo');


### PR DESCRIPTION
Replace the hardcoded LeveledLogMethod properties on Logger (`error`, `warn`, `help`, `data`, `info`, `debug`, `prompt`, `http`, `verbose`, `input`, `silly`, `emerg`, `alert`, `crit`, `warning`, `notice`) with a mapped type derived from the keys of the logger's levels object, mirroring what `lib/winston/create-logger.js` already does at runtime through `(Object.keys(opts.levels).forEach(...))`

_I normally don't use AI, but since this wasn't hard, just time consuming I did ask claude AI, to make it, then just reviewed and corrected what it did, if you want me to I can re-do it by hand (it would most likely have some differences as claude said to have seen things in the documentation that I didn't see)_