### PR TITLE
fix: correct engines.node floor and document Node.js compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,20 @@ npm install winston
 yarn add winston
 ```
 
+### Node.js compatibility
+
+`winston` requires **Node.js 16.9.0 or later**. This floor is set by the
+dependency tree rather than by `winston`'s own source: `@dabh/diagnostics`
+pulls in `@so-ric/colorspace`, which uses the logical-OR assignment operator
+(`||=`, Node 15+) and `Object.hasOwn` (Node 16.9+).
+
+As a matter of policy, `winston` does not support Node.js versions that have
+reached end-of-life, and only currently-maintained releases are exercised in
+CI. If you are pinned to an older runtime, install a `winston` release from
+before the offending dependency was published, or pin the transitive
+dependency yourself — for example, `@dabh/diagnostics@2.0.3` predates the
+`@so-ric/colorspace` switch. Neither workaround is supported or tested.
+
 ## Run Tests
 
 ``` bash

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"prepublishOnly": "npm run build"
 	},
 	"engines": {
-		"node": ">= 12.0.0"
+		"node": ">= 16.9.0"
 	},
 	"license": "MIT"
 }


### PR DESCRIPTION
Fixes #2586.

## Problem

`winston` declares `engines.node: ">= 12.0.0"`, but the runtime dependency tree has not actually been Node 12 compatible for some time. The single offender is transitive:

```
winston@3.19.0
└─┬ @dabh/diagnostics@2.0.8
  └── @so-ric/colorspace@1.1.6
```

`@so-ric/colorspace`'s published CJS bundle uses:

- `||=` — logical OR assignment, ES2021, Node 15+ (`dist/index.cjs.js:1976`)
- `Object.hasOwn` — Node 16.9+ (`dist/index.cjs.js:158`, `:260`)

Because the `engines` field claims Node 12 support, npm emits no `EBADENGINE` warning at install time. The first signal a user gets is a `SyntaxError: Unexpected token '='` thrown at `require('winston')`, which is what #2586 reports.

I verified that `@so-ric/colorspace` is the *only* package in the production tree that exceeds ES2019, by parsing every `.js` file in a `--omit=dev` install with `acorn` at successively higher `ecmaVersion` levels:

```
=== runtime tree files needing > ES2019 ===
ES2021 @so-ric/colorspace node_modules/@so-ric/colorspace/dist/index.cjs.js
(total pkgs scanned) 21
```

`winston`'s own `lib/` is ES2019-clean, so nothing here is self-inflicted.

## What this PR does

Deliberately the **minimal, non-behavioural** option:

1. `engines.node` → `">= 16.9.0"`, the honest floor implied by the dependency tree. Users on older runtimes now get an install-time warning instead of a load-time crash.
2. A short **Node.js compatibility** section in the README, per @DABH's suggestion in the issue thread, documenting the constraint and noting the (unsupported) `@dabh/diagnostics@2.0.3` pin that several commenters are already using.

## What this PR deliberately does *not* do

It does **not** pin or downgrade `@dabh/diagnostics`. That would be a policy call about supporting an EOL runtime, and @DABH already stated in the thread that winston does not support EOL Node versions — so making the metadata honest seemed like the right scope rather than reshaping the dependency tree. Happy to change direction if you'd prefer otherwise.

Two things worth your judgement, since they're policy rather than mechanics:

- **`>= 16.9.0` is the *technical* floor, not necessarily the *supported* one.** CI currently exercises Node 22, 24, and 26. If you'd rather have `engines` reflect what you actually support and test, say `">= 20"` or `">= 22"`, I'm glad to change it — I picked the technically-derived number because it's the one I could prove, and because it's the least disruptive to existing users.
- Raising `engines` is arguably a breaking change for anyone currently installing on Node 12–16, though in practice those installs are already broken at runtime. Retarget the base branch if you'd like this to land in a major.

## Verification

All commands run at `dd41581` on Node 26.5.0.

<details>
<summary><code>npm run lint</code> — 0 errors (10 pre-existing warnings, unchanged from master)</summary>

```
lib/winston/tail-file.js
  63:72  warning  Arrow function has too many statements (30). Maximum allowed is 15  max-statements
  63:72  warning  Arrow function has a complexity of 13. Maximum allowed is 11        complexity

lib/winston/transports/console.js
  52:3  warning  Method 'log' has too many statements (19). Maximum allowed is 15  max-statements
  52:3  warning  Method 'log' has a complexity of 12. Maximum allowed is 11        complexity

lib/winston/transports/file.js
  341:18  warning  'buff' is already declared in the upper scope on line 295 column 9     no-shadow
  402:29  warning  'options' is already declared in the upper scope on line 287 column 9  no-shadow

✖ 10 problems (0 errors, 10 warnings)
```
</details>

<details>
<summary><code>npm test</code> — all green</summary>

```
Test Suites: 22 passed, 22 total
Tests:       3 todo, 237 passed, 240 total
Snapshots:   0 total
Time:        42.718 s
```
</details>

<details>
<summary><code>npm run test:typescript</code> — clean</summary>

```
> npx --package typescript tsc --project test
(no output)
```
</details>

---

*Courtesy disclosure: I used AI assistance (Claude) while investigating and drafting this change. The dependency analysis, the ES-version scan, and the lint/test/tsc runs above were all executed and checked by me locally. `CONTRIBUTING.md` doesn't currently state an AI policy — mentioning it in case you'd like one, and happy to follow whatever you prefer.*
