### PR TITLE
fix: stop cli formatter from prepending undefined for syslog levels

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -35,6 +35,30 @@ exports.addColors = logform.levels;
  * @type {Object}
  */
 exports.format = logform.format;
+
+// format.cli() pads using its levels map. The default CLI set omits
+// syslog-only names (emerg, alert, crit, warning, notice), and logform
+// 2.7.0 stringifies the missing padding as "undefined".
+(function wrapCliFormat(format, config) {
+  const originalCli = format.cli;
+  function cli(opts) {
+    opts = opts || {};
+    const next = Object.assign({}, opts);
+    if (!next.levels) {
+      next.levels = Object.assign({}, config.cli.levels, config.npm.levels, config.syslog.levels);
+    }
+    if (!next.colors) {
+      next.colors = Object.assign({}, config.cli.colors, config.npm.colors, config.syslog.colors);
+    }
+    return originalCli(next);
+  }
+  cli.Format = originalCli.Format;
+  Object.defineProperty(format, 'cli', {
+    value: cli,
+    configurable: true
+  });
+}(exports.format, exports.config));
+
 /**
  * Expose core Logging-related prototypes.
  * @type {function}

--- a/test/unit/winston/formats/cli-syslog.test.js
+++ b/test/unit/winston/formats/cli-syslog.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assume = require('assume');
+const { Writable } = require('stream');
+const { MESSAGE } = require('triple-beam');
+const { config, createLogger, format, transports } = require('../../../../lib/winston');
+
+const SYSLOG_ONLY_LEVELS = ['emerg', 'alert', 'crit', 'warning', 'notice'];
+const SHARED_LEVELS = ['error', 'info'];
+
+function captureCliMessages(levels, levelNames) {
+  return new Promise((resolve) => {
+    const messages = [];
+    const transport = new transports.Stream({
+      format: format.cli(),
+      stream: new Writable({
+        objectMode: true,
+        write(info, encoding, callback) {
+          messages.push(info[MESSAGE]);
+          callback();
+        }
+      })
+    });
+
+    const logger = createLogger({
+      levels,
+      level: "debug",
+      transports: [transport]
+    });
+
+    transport.on("logged", () => {
+      if (messages.length === levelNames.length) {
+        resolve(messages);
+      }
+    });
+
+    levelNames.forEach((level) => {
+      logger[level]("Hello World!");
+    });
+  });
+}
+
+function assertHelloWithoutUndefined(message, level) {
+  assume(message).is.a("string");
+  assume(message).includes("Hello World!");
+  assume(message).includes(level);
+  assume(message.includes("undefined")).equals(false);
+}
+
+describe("format.cli() with syslog levels (#2477)", function () {
+  it("does not prepend undefined for emerg, alert, crit, warning, notice", async function () {
+    const messages = await captureCliMessages(
+      config.syslog.levels,
+      SYSLOG_ONLY_LEVELS
+    );
+
+    assume(messages).length(SYSLOG_ONLY_LEVELS.length);
+    messages.forEach((message, i) => {
+      assertHelloWithoutUndefined(message, SYSLOG_ONLY_LEVELS[i]);
+    });
+  });
+
+  it("still formats syslog error and info without undefined", async function () {
+    const messages = await captureCliMessages(
+      config.syslog.levels,
+      SHARED_LEVELS
+    );
+
+    assume(messages).length(SHARED_LEVELS.length);
+    messages.forEach((message, i) => {
+      assertHelloWithoutUndefined(message, SHARED_LEVELS[i]);
+    });
+  });
+
+  it("still formats default error and info", async function () {
+    const messages = await captureCliMessages(undefined, SHARED_LEVELS);
+    assume(messages).length(SHARED_LEVELS.length);
+    messages.forEach((message, i) => {
+      assertHelloWithoutUndefined(message, SHARED_LEVELS[i]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2477

format.cli() pads each message from a level-name map that defaults to the CLI set. Syslog-only names (emerg, alert, crit, warning, notice) are missing from that map. logform 2.7.0 then interpolates the missing padding, which becomes undefinedHello World!

Winston already registers syslog colors when config loads, so the level name itself colorizes correctly. This wraps format.cli() so its default levels and colors include the built-in cli, npm, and syslog sets. Callers can still pass their own maps.

Adds a Stream-transport unit test that logs those syslog levels and asserts the formatted line still contains Hello World! without the literal undefined.
