### PR TITLE
docs: explain colorize must be a format, not a Console option

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -94,6 +94,32 @@ The Console transport takes a few simple options:
 * __stderrLevels__ Array of strings containing the levels to log to stderr instead of stdout, for example `['error', 'debug', 'info']`. (default `[]`)
 * __consoleWarnLevels__ Array of strings containing the levels to log using console.warn or to stderr (in Node.js) instead of stdout, for example `['warn', 'debug']`. (default `[]`)
 
+#### Colorizing Console output
+
+`colorize` is **not** a Console transport option. It is a format, so it must be
+composed into the logger's `format` (or the transport's `format`) — not passed
+as a bare option like `colorize: true`:
+
+``` js
+const { createLogger, format, transports } = require('winston');
+const { colorize, combine, timestamp, printf } = format;
+
+const logger = createLogger({
+  format: combine(
+    colorize(),
+    timestamp(),
+    printf(({ level, message, timestamp }) => `${timestamp} ${level}: ${message}`)
+  ),
+  transports: [new transports.Console()]
+});
+```
+
+Putting `colorize()` **after** any `printf` (or other formatter that composes
+the final message string) has no visible effect, because the colors are applied
+to the already-final message. If you use a custom `printf` format, apply
+`colorize()` first in the `combine()` chain so the level text is colored before
+the final message is built.
+
 ### File Transport
 ``` js
 logger.add(new winston.transports.File(options));


### PR DESCRIPTION
## Summary

Per #1095: users try `colorize: true` as a Console transport option and see no colors. Documents that `colorize` is a format, not a transport option.

## Changes

- `docs/transports.md`: new "#### Colorizing Console output" subsection under the Console Transport section:
  - states plainly that `colorize` is a format and must be composed into `format` (logger or transport level)
  - shows a working `combine(colorize(), timestamp(), printf(...))` example
  - warns that `colorize()` placed **after** a `printf`/message-composing formatter has no visible effect, matching the root cause in the issue (colors applied to the already-final message)

## Verification

- Example matches the working resolution in the issue comments (colorize as format, first in the combine chain)